### PR TITLE
Prevent Illegal NPC Pushing moves

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -5898,7 +5898,12 @@ CheckMonsterLayer:
 						const UINT wDestX = pCharacter->wX + dx;
 						const UINT wDestY = pCharacter->wY + dy;
 
-						if (this->pRoom->IsValidColRow(wDestX, wDestY) &&
+						//Prevent pushes that would allow an otherwise illegal move.
+						bool bPlayerCanMoveTo = this->pRoom->CanPlayerMoveOnThisElement(
+							this->swordsman.wAppearance, this->pRoom->GetOSquare(destX, destY)
+						) && ! (bIsTar(wNewTTile) || wNewTTile == T_OBSTACLE || wNewTTile == T_BOMB || wNewTTile == T_STATION || wNewTTile == T_LIGHT);
+
+						if (this->pRoom->IsValidColRow(wDestX, wDestY) && bPlayerCanMoveTo &&
 								this->pRoom->CanPushMonster(pMonster, pMonster->wX, pMonster->wY, wDestX, wDestY)){
 							pCharacter->PushInDirection(dx, dy, false, CueEvents);
 							bPushedCharacter = true;

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -5901,7 +5901,7 @@ CheckMonsterLayer:
 						//Prevent pushes that would allow an otherwise illegal move.
 						bool bPlayerCanMoveTo = this->pRoom->CanPlayerMoveOnThisElement(
 							this->swordsman.wAppearance, this->pRoom->GetOSquare(destX, destY)
-						) && ! (bIsTar(wNewTTile) || wNewTTile == T_OBSTACLE || wNewTTile == T_BOMB || wNewTTile == T_STATION || wNewTTile == T_LIGHT);
+						) && !bIsTLayerObstacle(wNewTTile);
 
 						if (this->pRoom->IsValidColRow(wDestX, wDestY) && bPlayerCanMoveTo &&
 								this->pRoom->CanPushMonster(pMonster, pMonster->wX, pMonster->wY, wDestX, wDestY)){

--- a/DRODLib/TileConstants.h
+++ b/DRODLib/TileConstants.h
@@ -377,6 +377,7 @@ static inline bool bIsTLayerCoverableItem(const UINT t) {
 		default: return false;
 	}
 }
+static inline bool bIsTLayerObstacle(const UINT t) { return bIsTarOrFluff(t) || t==T_OBSTACLE || t==T_BOMB || t==T_STATION || t==T_LIGHT; }
 
 static inline bool bIsFuseConnected(const UINT t) { return t==T_FUSE || t==T_BOMB; }
 static inline bool bIsCombustibleItem(const UINT t) { return t==T_FUSE || t==T_BOMB || t==T_POWDER_KEG; }

--- a/DRODLibTests/DRODLibTest.2013.vcxproj
+++ b/DRODLibTests/DRODLibTest.2013.vcxproj
@@ -198,6 +198,7 @@
     <ClCompile Include="src\tests\Player\Basic\MoveBeethroInEmptyRoom.cpp" />
     <ClCompile Include="src\tests\Player\Bugs\PushedPlayerKilledByHotTiles.cpp" />
     <ClCompile Include="src\tests\Player\Bugs\PushingMonstersOnHotTiles.cpp" />
+    <ClCompile Include="src\tests\Player\Bugs\PushNPCOnBlockingTile.cpp" />
     <ClCompile Include="src\tests\Player\Bugs\PushPlayerAgainstChain.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildingBombs.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildingOrbs.cpp" />

--- a/DRODLibTests/src/tests/Player/Bugs/PushNPCOnBlockingTile.cpp
+++ b/DRODLibTests/src/tests/Player/Bugs/PushNPCOnBlockingTile.cpp
@@ -1,0 +1,41 @@
+#include "../../../test-include.hpp"
+
+static void AddPushableCharacter(UINT x, UINT y) {
+	CCharacter *character = RoomBuilder::AddVisibleCharacter(x, y);
+	RoomBuilder::AddCommand(character, CCharacterCommand::CC_Imperative, ScriptFlag::PushableByBody);
+}
+
+TEST_CASE("Player should push NPC on blocking tile", "[game][scripting][player][player moves][push][bug]") {
+	SECTION("Player should not move") {
+		//WBL.
+		//S*TT
+		//.OTT
+		//....
+		RoomBuilder::Plot(T_THINICE, 10, 10);
+		RoomBuilder::Plot(T_WALL, 9, 9);
+		RoomBuilder::Plot(T_BOMB, 10, 9);
+		RoomBuilder::Plot(T_LIGHT, 11, 9);
+		RoomBuilder::Plot(T_STATION, 9, 10);
+		RoomBuilder::Plot(T_OBSTACLE, 10, 11);
+		RoomBuilder::PlotRect(T_TAR, 11, 10, 12, 11);
+
+		AddPushableCharacter(9, 9);
+		AddPushableCharacter(10, 9);
+		AddPushableCharacter(11, 9);
+		AddPushableCharacter(9, 10);
+		AddPushableCharacter(10, 11);
+		AddPushableCharacter(9, 9);
+		AddPushableCharacter(11, 11);
+
+		CCurrentGame* game = Runner::StartGame(10, 10, S);
+
+		Runner::ExecuteCommand(CMD_NW);
+		Runner::ExecuteCommand(CMD_N);
+		Runner::ExecuteCommand(CMD_NE);
+		Runner::ExecuteCommand(CMD_E);
+		Runner::ExecuteCommand(CMD_S);
+		Runner::ExecuteCommand(CMD_SW);
+
+		REQUIRE(game->pRoom->GetOSquare(10, 10) == T_THINICE_SH);
+	}
+}


### PR DESCRIPTION
Pushing an NPC located on a generically impassable tile allowed the player to move onto the tile.

See: http://forum.caravelgames.com/viewtopic.php?TopicID=41547