### PR TITLE
Prevent Time Token activation on the same turn a player double is placed.

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -4142,7 +4142,9 @@ void CDbRoom::ActivateToken(
 		case TemporalSplit:
 			//Touching a temporal split point for the first time.
 			if (!bOn && this->pCurrentGame->swordsman.wX == wX &&
-					this->pCurrentGame->swordsman.wY == wY && this->pCurrentGame->StartTemporalSplit()) {
+					this->pCurrentGame->swordsman.wY == wY && 
+					this->pCurrentGame->swordsman.wPlacingDoubleType == 0 &&
+					this->pCurrentGame->StartTemporalSplit()) {
 				SetTParam(wX, wY, tParam + TOKEN_ACTIVE);  //toggle on-off
 				CueEvents.Add(CID_TemporalSplitStart);
 				this->PlotsMade.insert(wX,wY);

--- a/DRODLibTests/DRODLibTest.2013.vcxproj
+++ b/DRODLibTests/DRODLibTest.2013.vcxproj
@@ -212,6 +212,7 @@
     <ClCompile Include="src\tests\Scripting\WaitForItem\WaitForToken.cpp" />
     <ClCompile Include="src\tests\Scripting\WaitForSomeoneToPushMe\WaitForSomeoneToPushMe.cpp" />
     <ClCompile Include="src\tests\Scripting\WaitForWeapon\WaitForWeapon.cpp" />
+    <ClCompile Include="src\tests\TemporalToken\DoublePlacementPreventsRecording.cpp" />
     <ClCompile Include="src\tests\TemporalToken\TemporalProjectionVsFluff.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/DRODLibTests/src/tests/TemporalToken/DoublePlacementPreventsRecording.cpp
+++ b/DRODLibTests/src/tests/TemporalToken/DoublePlacementPreventsRecording.cpp
@@ -1,0 +1,16 @@
+#include "../../test-include.hpp"
+
+TEST_CASE("Time Token Double Potion Pushing weirdness", "[game][potion][time token][pushing]") {
+	RoomBuilder::ClearRoom();
+
+	SECTION("Pushed from Potion to Time Token") {
+		RoomBuilder::PlotRect(T_WALL, 0, 8, 20, 8);
+		RoomBuilder::AddMonsterWithWeapon(M_MIMIC, WT_Staff, 9, 9, E);
+		RoomBuilder::PlotToken(RoomTokenType::TemporalSplit, 11, 9);
+
+		CCueEvents CueEvents;
+		CCurrentGame* game = Runner::StartGame(10, 10, E);
+		Runner::ExecuteCommand(CMD_NE, CueEvents);
+		REQUIRE(!CueEvents.HasOccurred(CID_TemporalSplitStart));
+	}
+}


### PR DESCRIPTION
This PR fixes the strange behavior described here: http://forum.caravelgames.com/viewtopic.php?TopicID=42966

Time Tokens will no longer activate if CSwordsman::wPlacingDoubleType isn't zero. This is probably preferable to the current behavior, which allows double placement to be repeated upon rewinding, and allows recording from arbitrary locations using clone potions.