### PR TITLE
Temporal clone damage fix

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3087,6 +3087,12 @@ void CDbRoom::KillMonstersOnHazard(CCueEvents &CueEvents)
 				pConstruct->KillIfOnOremites(CueEvents);
 			}
 			break;
+			case M_TEMPORALCLONE:
+			{
+				CTemporalClone *pTemporalClone = DYN_CAST(CTemporalClone*, CMonster*, pMonster);
+				pTemporalClone->KillIfOnDeadlyTile(CueEvents);
+			}
+			break;
 		}
 		pMonster = pNext;
 	}

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -134,6 +134,29 @@ bool CTemporalClone::IsTarget() const
 }
 
 //*****************************************************************************
+bool CTemporalClone::KillIfOnDeadlyTile(CCueEvents & CueEvents)
+//Kill the Temporal Clone if it is on a tile that would kill its role.
+{
+	if (!(this->wIdentity == M_CONSTRUCT || this->wIdentity == M_FLUFFBABY)) {
+		// Only Constructs and Puffs die from being on a specific tile.
+		return false;
+	}
+
+	CCurrentGame *pGame = const_cast<CCurrentGame*>(this->pCurrentGame);
+	const UINT dwTileNo = pGame->pRoom->GetOSquare(this->wX, this->wY);
+
+	if ((this->wIdentity == M_CONSTRUCT && dwTileNo == T_GOO) ||
+		(this->wIdentity == M_FLUFFBABY && dwTileNo == T_HOT) ) {
+		pGame->pRoom->KillMonster(this, CueEvents);
+		SetKillInfo(NO_ORIENTATION); //center stab effect
+		CueEvents.Add(CID_MonsterDiedFromStab, this);
+		return true;
+	}
+
+	return false;
+}
+
+//*****************************************************************************
 bool CTemporalClone::OnStabbed(
 // Override for Temporal Clone, as some player roles can survive stabs.
 	CCueEvents & CueEvents,
@@ -169,6 +192,9 @@ void CTemporalClone::Process(const int /*nLastCommand*/, CCueEvents &CueEvents)
 		pGame->pRoom->RemoveMonsterDuringPlayWithoutEffect(this);
 		return;
 	}
+
+	if (KillIfOnDeadlyTile(CueEvents))
+		return;
 
 	CDbRoom& room = *(this->pCurrentGame->pRoom);
 

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -133,7 +133,14 @@ bool CTemporalClone::IsTarget() const
 	return this->bIsTarget;
 }
 
-bool CTemporalClone::OnStabbed(CCueEvents & CueEvents, const UINT wX, const UINT wY, WeaponType weaponType)
+//*****************************************************************************
+bool CTemporalClone::OnStabbed(
+// Override for Temporal Clone, as some player roles can survive stabs.
+	CCueEvents & CueEvents,
+	const UINT wX,
+	const UINT wY,
+	WeaponType weaponType
+)
 {
 	if (this->wIdentity == M_WUBBA && weaponType != WeaponType::WT_Firetrap) {
 		// Wubbas can only be killed by Firetrap stabs.

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -142,8 +142,9 @@ bool CTemporalClone::OnStabbed(
 	WeaponType weaponType
 )
 {
-	if (this->wIdentity == M_WUBBA && weaponType != WeaponType::WT_Firetrap) {
-		// Wubbas can only be killed by Firetrap stabs.
+	if ((this->wIdentity == M_WUBBA || this->wIdentity == M_FLUFFBABY)
+		 && weaponType != WeaponType::WT_Firetrap) {
+		// Wubbas and Puffs can only be killed by Firetrap stabs.
 		return false;
 	}
 

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -133,6 +133,23 @@ bool CTemporalClone::IsTarget() const
 	return this->bIsTarget;
 }
 
+bool CTemporalClone::OnStabbed(CCueEvents & CueEvents, const UINT wX, const UINT wY, WeaponType weaponType)
+{
+	if (this->wIdentity == M_WUBBA && weaponType != WeaponType::WT_Firetrap) {
+		// Wubbas can only be killed by Firetrap stabs.
+		return false;
+	}
+
+	if (this->wIdentity == M_FEGUNDO) {
+		// Fegundoes are immune to all weapon types.
+		return false;
+	}
+
+	//Monster dies.
+	CueEvents.Add(CID_MonsterDiedFromStab, this);
+	return true;
+}
+
 //*****************************************************************************
 void CTemporalClone::Process(const int /*nLastCommand*/, CCueEvents &CueEvents)
 {

--- a/DRODLib/TemporalClone.h
+++ b/DRODLib/TemporalClone.h
@@ -43,6 +43,8 @@ public:
 	virtual bool IsHiding() const;
 	virtual bool IsMonsterTarget() const;
 	virtual bool IsTarget() const;
+	virtual bool OnStabbed(CCueEvents &CueEvents, const UINT wX = (UINT)-1, const UINT wY = (UINT)-1,
+		WeaponType weaponType = WT_Sword);
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 	virtual void PushInDirection(int dx, int dy, bool bStun, CCueEvents &CueEvents);
 	virtual bool SetWeaponSheathed();

--- a/DRODLib/TemporalClone.h
+++ b/DRODLib/TemporalClone.h
@@ -43,6 +43,7 @@ public:
 	virtual bool IsHiding() const;
 	virtual bool IsMonsterTarget() const;
 	virtual bool IsTarget() const;
+	bool         KillIfOnDeadlyTile(CCueEvents &CueEvents);
 	virtual bool OnStabbed(CCueEvents &CueEvents, const UINT wX = (UINT)-1, const UINT wY = (UINT)-1,
 		WeaponType weaponType = WT_Sword);
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);

--- a/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
@@ -28,6 +28,17 @@ TEST_CASE("Construct player role", "[game]") {
 		REQUIRE(game->GetDyingEntity() == &(game->swordsman));
 	}
 
+	SECTION("Time clone construct stepping onto oremites should be killed") {
+		RoomBuilder::Plot(T_GOO, 10, 12);
+
+		CTemporalClone* time_clone = DYN_CAST(
+			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
+		);
+		time_clone->wIdentity = M_CONSTRUCT;
+		std::vector<int> time_moves = { 7, 7, 12, 12 };
+		time_clone->InputCommands(time_moves);
+	}
+
 	SECTION("Player-construct should be vulnerable to body attack"){
 		RoomBuilder::PlotToken(RoomTokenType::PowerTarget, 11, 11);
 		RoomBuilder::AddMonster(M_ROACH, 10, 11, N);

--- a/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
@@ -28,26 +28,6 @@ TEST_CASE("Construct player role", "[game][construct][player][player role]") {
 		REQUIRE(game->GetDyingEntity() == &(game->swordsman));
 	}
 
-	SECTION("Time clone construct stepping onto oremites should be killed") {
-		RoomBuilder::Plot(T_GOO, 10, 9);
-
-		CTemporalClone* time_clone = DYN_CAST(
-			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
-		);
-		time_clone->wIdentity = M_CONSTRUCT;
-		std::vector<int> time_moves = { CMD_N, CMD_WAIT };
-		time_clone->InputCommands(time_moves);
-
-		CCurrentGame* game = Runner::StartGame(5, 5, N);
-		time_clone->eMovement = GROUND_AND_SHALLOW_WATER;
-
-		Runner::ExecuteCommand(CMD_WAIT);
-
-		INFO("(" << time_clone->wX << ", " << time_clone->wY << ")");
-
-		REQUIRE(game->GetDyingEntity() == time_clone);
-	}
-
 	SECTION("Player-construct should be vulnerable to body attack"){
 		RoomBuilder::PlotToken(RoomTokenType::PowerTarget, 11, 11);
 		RoomBuilder::AddMonster(M_ROACH, 10, 11, N);

--- a/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
@@ -1,6 +1,6 @@
 #include "../../test-include.hpp"
 
-TEST_CASE("Construct player role", "[game]") {
+TEST_CASE("Construct player role", "[game][construct][player][player role]") {
 	RoomBuilder::ClearRoom();
 
 	CCharacter* character = RoomBuilder::AddVisibleCharacter(1, 1);
@@ -29,14 +29,23 @@ TEST_CASE("Construct player role", "[game]") {
 	}
 
 	SECTION("Time clone construct stepping onto oremites should be killed") {
-		RoomBuilder::Plot(T_GOO, 10, 12);
+		RoomBuilder::Plot(T_GOO, 10, 9);
 
 		CTemporalClone* time_clone = DYN_CAST(
 			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
 		);
 		time_clone->wIdentity = M_CONSTRUCT;
-		std::vector<int> time_moves = { 7, 7, 12, 12 };
+		std::vector<int> time_moves = { CMD_N, CMD_WAIT };
 		time_clone->InputCommands(time_moves);
+
+		CCurrentGame* game = Runner::StartGame(5, 5, N);
+		time_clone->eMovement = GROUND_AND_SHALLOW_WATER;
+
+		Runner::ExecuteCommand(CMD_WAIT);
+
+		INFO("(" << time_clone->wX << ", " << time_clone->wY << ")");
+
+		REQUIRE(game->GetDyingEntity() == time_clone);
 	}
 
 	SECTION("Player-construct should be vulnerable to body attack"){

--- a/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
@@ -49,19 +49,13 @@ TEST_CASE("Fegundo player role", "[game]") {
 
 	SECTION("Fegundo time clone should not be killed by fire trap") {
 		RoomBuilder::Plot(T_FIRETRAP_ON, 10, 12);
+		RoomBuilder::PlotToken(TemporalSplit, 10, 11);
 
-		CTemporalClone* time_clone = DYN_CAST(
-			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
-		);
-		time_clone->wIdentity = M_FEGUNDO;
-		std::vector<int> time_moves = { CMD_S, CMD_S, CMD_WAIT, CMD_WAIT };
-		time_clone->InputCommands(time_moves);
-
-		CCurrentGame* game = Runner::StartGame(5, 5, N);
-		time_clone->eMovement = AIR;
-
-		CCueEvents CueEvents;
-		Runner::ExecuteCommand(CMD_WAIT, 2);
+		CCurrentGame* game = Runner::StartGame(10, 10, N);
+		
+		Runner::ExecuteCommand(CMD_S, 2);
+		Runner::ExecuteCommand(CMD_CLONE);
+		Runner::ExecuteCommand(CMD_N);
 
 		REQUIRE(game->GetDyingEntity() == NULL);
 	}

--- a/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
@@ -46,4 +46,22 @@ TEST_CASE("Fegundo player role", "[game]") {
 
 		REQUIRE(game->GetDyingEntity() == NULL);
 	}
+
+	SECTION("Fegundo time clone should not be killed by fire trap") {
+		RoomBuilder::Plot(T_FIRETRAP_ON, 10, 12);
+
+		CTemporalClone* time_clone = DYN_CAST(
+			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
+		);
+		time_clone->wIdentity = M_FEGUNDO;
+		std::vector<int> time_moves = { 7, 7, 12, 12 };
+		time_clone->InputCommands(time_moves);
+
+		CCurrentGame* game = Runner::StartGame(5, 5, N);
+
+		CCueEvents CueEvents;
+		Runner::ExecuteCommand(CMD_WAIT, 2);
+
+		REQUIRE(game->GetDyingEntity() == NULL);
+	}
 }

--- a/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
@@ -54,10 +54,11 @@ TEST_CASE("Fegundo player role", "[game]") {
 			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
 		);
 		time_clone->wIdentity = M_FEGUNDO;
-		std::vector<int> time_moves = { 7, 7, 12, 12 };
+		std::vector<int> time_moves = { CMD_S, CMD_S, CMD_WAIT, CMD_WAIT };
 		time_clone->InputCommands(time_moves);
 
 		CCurrentGame* game = Runner::StartGame(5, 5, N);
+		time_clone->eMovement = AIR;
 
 		CCueEvents CueEvents;
 		Runner::ExecuteCommand(CMD_WAIT, 2);

--- a/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
@@ -43,12 +43,13 @@ TEST_CASE("Puff player role", "[game]") {
 			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
 		);
 		time_clone->wIdentity = M_FLUFFBABY;
-		std::vector<int> time_moves = { 7, 7 };
+		std::vector<int> time_moves = { CMD_S, CMD_S };
 		std::vector<int> wait_ten = { 12, 12, 12, 12, 12, 12, 12, 12, 12, 12 };
 		time_clone->InputCommands(time_moves);
 		time_clone->InputCommands(wait_ten);
 
 		CCurrentGame* game = Runner::StartGame(5, 5, N);
+		time_clone->eMovement = AIR;
 
 		CCueEvents CueEvents;
 		Runner::ExecuteCommand(CMD_WAIT, 10);

--- a/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
@@ -39,20 +39,15 @@ TEST_CASE("Puff player role", "[game]") {
 
 	SECTION("Puff time clone should be safe from spike traps") {
 		RoomBuilder::Plot(T_FLOOR_SPIKES, 10, 12);
-		CTemporalClone* time_clone = DYN_CAST(
-			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
-		);
-		time_clone->wIdentity = M_FLUFFBABY;
-		std::vector<int> time_moves = { CMD_S, CMD_S };
-		std::vector<int> wait_ten = { 12, 12, 12, 12, 12, 12, 12, 12, 12, 12 };
-		time_clone->InputCommands(time_moves);
-		time_clone->InputCommands(wait_ten);
+		RoomBuilder::PlotToken(TemporalSplit, 10, 11);
 
-		CCurrentGame* game = Runner::StartGame(5, 5, N);
-		time_clone->eMovement = AIR;
+		CCurrentGame* game = Runner::StartGame(10, 10, N);
 
-		CCueEvents CueEvents;
+		Runner::ExecuteCommand(CMD_S, 2);
 		Runner::ExecuteCommand(CMD_WAIT, 10);
+		Runner::ExecuteCommand(CMD_CLONE);
+		Runner::ExecuteCommand(CMD_N);
+		Runner::ExecuteCommand(CMD_WAIT, 8);
 
 		REQUIRE(game->GetDyingEntity() == NULL);
 	}

--- a/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
@@ -37,6 +37,25 @@ TEST_CASE("Puff player role", "[game]") {
 		REQUIRE(game->GetDyingEntity() == NULL);
 	}
 
+	SECTION("Puff time clone should be safe from spike traps") {
+		RoomBuilder::Plot(T_FLOOR_SPIKES, 10, 12);
+		CTemporalClone* time_clone = DYN_CAST(
+			CTemporalClone*, CMonster*, RoomBuilder::AddMonster(M_TEMPORALCLONE, 10, 10)
+		);
+		time_clone->wIdentity = M_FLUFFBABY;
+		std::vector<int> time_moves = { 7, 7 };
+		std::vector<int> wait_ten = { 12, 12, 12, 12, 12, 12, 12, 12, 12, 12 };
+		time_clone->InputCommands(time_moves);
+		time_clone->InputCommands(wait_ten);
+
+		CCurrentGame* game = Runner::StartGame(5, 5, N);
+
+		CCueEvents CueEvents;
+		Runner::ExecuteCommand(CMD_WAIT, 10);
+
+		REQUIRE(game->GetDyingEntity() == NULL);
+	}
+
 	SECTION("Should be killed by fire trap"){
 		RoomBuilder::Plot(T_FIRETRAP_ON, 10, 10);
 		CCurrentGame* game = Runner::StartGame(10, 10, N);


### PR DESCRIPTION
Fix for issues reported in http://forum.caravelgames.com/viewtopic.php?TopicID=42819

There is no test to see if Construct timeclones die on oremites. This is due to the test system failing in some unknown way to fully simulate DROD. The beheviour has been tested in game, and works there.