### PR TITLE
gitignore additions for VS2019 + compiler warning fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,14 @@ Deps/
 DepsSrc/
 
 # Build Folders
-Master/Linux/build.*
-Master/Linux/builds/
-Master/Linux/drod-sdl2.sublime-*
-DRODLibTests/debug/
-DRODLibTests/DebugVS2008/
-DRODLibTests\DRODLibTest.log
-DRODLibTests/Release/
+BackEndLib/Debug-Temp/
+BackEndLib/Release-Temp/
+CaravelNet/Debug/
+CaravelNet/Debug-Temp/
+CaravelNet/Release/
+CaravelNet/Release-Temp/
+DROD/Debug/
+DROD/Debug-Temp/
 DROD/DebugVS2008/
 DROD/DebugVS2013/
 DROD/DebugVS2013-Temp/
@@ -17,12 +18,22 @@ DROD/Steam/
 DROD/SteamBuildDats/
 DROD/Release/
 DROD/Release-Temp/
+DRODLib/Debug-Temp/
 DRODLib/DebugVS2008/
 DRODLib/DebugVS2013/
 DRODLib/Release/
+DRODLib/Release-Temp/
 DRODLib/Steam/
 DRODLib/BuildDats/
 DRODLib/SteamBuildDats/
+DRODLibTests/Debug/
+DRODLibTests/Debug-Temp/
+DRODLibTests/DebugVS2008/
+DRODLibTests/DRODLibTest.log
+DRODLibTests/Release/
+DRODLibTests/Release-Temp/
+DRODUtil/Debug/
+DRODUtil/Debug-Temp/
 DRODUtil/DebugVS2008/
 DRODUtil/DebugVS2013/
 DRODUtil/DebugVS2013-Temp/
@@ -30,8 +41,14 @@ DRODUtil/Release/
 DRODUtil/Release-Temp/
 DRODUtil/Steam/
 DRODUtil/Steam-Temp/
+FrontEndLib/Debug-Temp/
+FrontEndLib/Release-Temp/
+Master/Linux/build.*
+Master/Linux/builds/
+Master/Linux/drod-sdl2.sublime-*
 
 # Various things we don't want.
+Master/.vs/
 **/*.obj
 **/*.log
 **/*.dll

--- a/CompilingDrod_Win.md
+++ b/CompilingDrod_Win.md
@@ -56,6 +56,8 @@ Known build issues:
  - Expat has an incompatible compiler flag when upgrading the project to MSVS 2019.  Workaround: I manually made the top change proposed on this StackOverflow topic:
    https://stackoverflow.com/questions/43141401/visual-studio-error-d8016-zi-and-gy-command-line-options-are-incompatible/43141537
    (If tweaks like this are required, to speed up repeat re-runs of the build script, note that you can set the `DepsToBuild` variable to skip re-building libraries that have already built successfully.)
+   
+   Open DepsSrc/expat-2.1.0/expat-2.1.0.expat.sln, and for each project file, right-click it --> Properties --> Configuration Properties --> C/C++ --> Code Generation --> Enable Function-level Linking. Change this to `Yes (/Gy)`
 
 ##### Update include and library paths in the project files
 

--- a/DRODUtil/DRODUtil.cpp
+++ b/DRODUtil/DRODUtil.cpp
@@ -135,7 +135,7 @@ int wmain(int argc, WCHAR* argv[])
 {
 #ifdef _DEBUG
 #  ifdef WIN32
-#     define DEBUGPAUSE getch()
+#     define DEBUGPAUSE _getch()
 #  else
 #     define DEBUGPAUSE getchar()
 #  endif


### PR DESCRIPTION
- Rearrange gitignore folders into alphabetical order
- Add new folders to gitignore
- Add more clarity to troubleshooting issue for expat in build readme
- Fix compiler warning in DRODUtil regarding getch()