### PR TITLE
Remove unstable tarstuff after pushing fluff onto tarstuff mother

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -3159,8 +3159,13 @@ void CCurrentGame::WeaponPushback(
 					pNewFluff->PushInDirection(dx, dy, true, CueEvents);
 			} else {
 				this->pRoom->KillMonster(pNewFluff,CueEvents);
-				if (bValidDestinationTile)
+				if (bValidDestinationTile) {
+					const CMonster* pMonsterAtDest = this->pRoom->GetMonsterAtSquare(wDestX, wDestY);
+					const bool bKillingTarstuffMother = pMonsterAtDest && bIsMother(pMonsterAtDest->wType);
 					this->pRoom->ProcessPuffAttack(CueEvents, wDestX, wDestY);
+					if (bKillingTarstuffMother)
+						this->pRoom->FixUnstableTar(CueEvents);
+				}
 				else
 					CueEvents.Add(CID_FluffPuffDestroyed, new CCoord(wFromX, wFromY), true);
 			}

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="src\tests\Monsters\Aumtlich\CrackedOrbs.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PuffPushingArrowsOrthosquares.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PuffTargetsVisibleClone.cpp" />
+    <ClCompile Include="src\tests\Monsters\Puff\PushFluffOntoTarstuffMother.cpp" />
     <ClCompile Include="src\tests\Monsters\Rattlesnake\RattlesnakeVsFiretrap.cpp" />
     <ClCompile Include="src\tests\Monsters\RoachQueen\StunnedRoachQueen.cpp" />
     <ClCompile Include="src\tests\Monsters\Seep\SeepVsPit.cpp" />

--- a/DRODLibTests/src/tests/Monsters/Puff/PushFluffOntoTarstuffMother.cpp
+++ b/DRODLibTests/src/tests/Monsters/Puff/PushFluffOntoTarstuffMother.cpp
@@ -1,0 +1,89 @@
+#include "../../../catch.hpp"
+#include "../../../CTestDb.h"
+#include "../../../Runner.h"
+#include "../../../RoomBuilder.h"
+#include "../../../../../DRODLib/CurrentGame.h"
+#include "../../../../../DRODLib/Character.h"
+#include "../../../../../DRODLib/CharacterCommand.h"
+
+#include <vector>
+using namespace std;
+
+TEST_CASE("Pushing Puffs and Fluff onto Tarstuff Mothers", "[game][fluff][puff][tarstuff]") {
+	RoomBuilder::ClearRoom();
+
+	CCharacter* character = RoomBuilder::AddCharacter(1, 1, SW, M_CLONE);
+	RoomBuilder::AddCommand(character, CCharacterCommand::CC_SetPlayerWeapon, WT_Staff);
+
+	SECTION("Push Puff onto stable mother") {
+		// Puffs can kill mothers when pused, but not the unlying tarstuff
+		// Therefore, if the underlying tarstuff is stable, it will not be removed
+
+		RoomBuilder::AddMonster(M_FLUFFBABY, 12, 10);
+		RoomBuilder::AddMonster(M_TARMOTHER, 13, 10);
+		RoomBuilder::PlotRect(T_TAR, 13, 10, 14, 11);
+
+		CCurrentGame* pGame = Runner::StartGame(10, 10, E);
+
+		// Player steps east, pushing puff on to tar mother
+		Runner::ExecuteCommand(CMD_E);
+
+		// Mother should be removed, but not the tar
+		REQUIRE(!pGame->pRoom->GetMonsterAtSquare(13, 10));
+		REQUIRE(pGame->pRoom->GetTSquare(13, 10) == T_TAR);
+	}
+
+	SECTION("Push Puff onto unstable mother") {
+		// Tarstuff mothers can support otherwise unstable tarstuff
+		// When killed by a puff push, that tarstuff should be removed
+
+		RoomBuilder::AddMonster(M_FLUFFBABY, 12, 10);
+		RoomBuilder::AddMonster(M_TARMOTHER, 13, 10);
+		RoomBuilder::Plot(T_TAR, 13, 10);
+
+		CCurrentGame* pGame = Runner::StartGame(10, 10, E);
+
+		// Player steps east, pushing puff on to tar mother
+		Runner::ExecuteCommand(CMD_E);
+
+		// Mother and tar should be removed
+		REQUIRE(!pGame->pRoom->GetMonsterAtSquare(13, 10));
+		REQUIRE(pGame->pRoom->GetTSquare(13, 10) == T_EMPTY);
+	}
+
+	SECTION("Push Fluff onto stable mother") {
+		// Fluff can kill mothers when pushed, but not the unlying tarstuff
+		// Therefore, if the underlying tarstuff is stable, it will not be removed
+
+		RoomBuilder::AddMonster(M_TARMOTHER, 10, 8);
+		RoomBuilder::PlotRect(T_TAR, 10, 8, 11, 9);
+		RoomBuilder::PlotRect(T_FLUFF, 8, 8, 9, 9);
+
+		CCurrentGame* pGame = Runner::StartGame(10, 10, W);
+
+		// Player rotates clockwise, pushing fluff onto tar mother
+		Runner::ExecuteCommand(CMD_C);
+
+		// Mother should be removed, but not the tar
+		REQUIRE(!pGame->pRoom->GetMonsterAtSquare(10, 8));
+		REQUIRE(pGame->pRoom->GetTSquare(10, 8) == T_TAR);
+	}
+
+	SECTION("Push Fluff onto unstable mother") {
+		// Tarstuff mothers can support otherwise unstable tarstuff
+		// When killed by a fluff push, that tarstuff should be removed
+
+		RoomBuilder::AddMonster(M_TARMOTHER, 10, 8);
+		RoomBuilder::Plot(T_TAR, 10, 8);
+		RoomBuilder::PlotRect(T_FLUFF, 8, 8, 9, 9);
+
+		CCurrentGame* pGame = Runner::StartGame(10, 10, W);
+
+		// Player rotates clockwise, pushing fluff onto tar mother
+		Runner::ExecuteCommand(CMD_C);
+
+		// Mother and tar should be removed
+		REQUIRE(!pGame->pRoom->GetMonsterAtSquare(10, 8));
+		REQUIRE(pGame->pRoom->GetTSquare(10, 8) == T_EMPTY);
+	}
+}


### PR DESCRIPTION
Fix for: http://forum.caravelgames.com/viewtopic.php?TopicID=40928

The fix for unstable tarstuff not being removed after a puff was pushed onto mother-supported tarstuff was not applied to fluff. This meant bad tarstuff formations could be created.

Some tests have also been added to check situations where fluff and puffs are pushed onto tarstuff mothers.