### PR TITLE
DROD RPG: Make monster weakness behaviours function on accessories

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1810,6 +1810,8 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 					def = (int)pCharacter->getDEF();
 					bMetal = pCharacter->IsMetal();
 					bBeamBlock = pCharacter->HasRayGun();
+					bGoblinWeakness = pCharacter->HasGoblinWeakness();
+					bSerpentWeakness = pCharacter->HasSerpentWeakness();
 				}
 			}
 			bLuckyGR = this->pCurrentGame->IsLuckyGRItem(ScriptFlag::Accessory);

--- a/drodrpg/DRODLib/Combat.cpp
+++ b/drodrpg/DRODLib/Combat.cpp
@@ -428,6 +428,9 @@ bool CCombat::PlayerDoesStrongHit(CMonster* pMonster) const
 		if (this->pGame->IsSwordStrongAgainst(pMonster))
 			return true;
 	}
+	if (this->pGame->IsEquipmentStrongAgainst(pMonster, ScriptFlag::Accessory)) {
+		return true;
+	}
 
 	return false;
 }

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3284,23 +3284,9 @@ bool CCurrentGame::IsSwordStrongAgainst(CMonster* pMonster) const
 			return pMonster->HasSerpentWeakness();
 		default:
 		{
-			CCharacter* pCharacter = getCustomEquipment(ScriptFlag::Weapon);
-			if (pCharacter)
-			{
-				if (pMonster->HasGoblinWeakness() && pCharacter->HasGoblinWeakness())
-					return true;
-				if (pMonster->HasSerpentWeakness() && pCharacter->HasSerpentWeakness())
-					return true;
-			}
-
-			pCharacter = getCustomEquipment(ScriptFlag::Accessory);
-			if (pCharacter)
-			{
-				if (pMonster->HasGoblinWeakness() && pCharacter->HasGoblinWeakness())
-					return true;
-				if (pMonster->HasSerpentWeakness() && pCharacter->HasSerpentWeakness())
-					return true;
-			}
+			if (IsEquipmentStrongAgainst(pMonster, ScriptFlag::Weapon) ||
+				IsEquipmentStrongAgainst(pMonster, ScriptFlag::Accessory))
+				return true;
 		}
 		return false;
 	}

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3292,9 +3292,33 @@ bool CCurrentGame::IsSwordStrongAgainst(CMonster* pMonster) const
 				if (pMonster->HasSerpentWeakness() && pCharacter->HasSerpentWeakness())
 					return true;
 			}
+
+			pCharacter = getCustomEquipment(ScriptFlag::Accessory);
+			if (pCharacter)
+			{
+				if (pMonster->HasGoblinWeakness() && pCharacter->HasGoblinWeakness())
+					return true;
+				if (pMonster->HasSerpentWeakness() && pCharacter->HasSerpentWeakness())
+					return true;
+			}
 		}
 		return false;
 	}
+}
+
+bool CCurrentGame::IsEquipmentStrongAgainst(CMonster* pMonster, const UINT type) const
+//Returns: whether the player has an item that is strong against this monster
+{
+	CCharacter* pCharacter = getCustomEquipment(type);
+	if (pCharacter)
+	{
+		if (pMonster->HasGoblinWeakness() && pCharacter->HasGoblinWeakness())
+			return true;
+		if (pMonster->HasSerpentWeakness() && pCharacter->HasSerpentWeakness())
+			return true;
+	}
+
+	return false;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3284,14 +3284,14 @@ bool CCurrentGame::IsSwordStrongAgainst(CMonster* pMonster) const
 			return pMonster->HasSerpentWeakness();
 		default:
 		{
-			if (IsEquipmentStrongAgainst(pMonster, ScriptFlag::Weapon) ||
-				IsEquipmentStrongAgainst(pMonster, ScriptFlag::Accessory))
+			if (IsEquipmentStrongAgainst(pMonster, ScriptFlag::Weapon))
 				return true;
 		}
 		return false;
 	}
 }
 
+//*****************************************************************************
 bool CCurrentGame::IsEquipmentStrongAgainst(CMonster* pMonster, const UINT type) const
 //Returns: whether the player has an item that is strong against this monster
 {

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -278,6 +278,7 @@ public:
 	bool     IsSwordMetal(const UINT type) const;
 	bool     IsShieldMetal(const UINT type) const;
 	bool     IsSwordStrongAgainst(CMonster* pMonster) const;
+	bool     IsEquipmentStrongAgainst(CMonster* pMonster, const UINT type) const;
 	bool     IsValidatingPlayback() const {return this->bValidatingPlayback;}
 	bool     LoadFromHold(const UINT dwHoldID, CCueEvents &CueEvents);
 	bool     LoadFromLevelEntrance(const UINT dwHoldID, const UINT dwEntranceID,


### PR DESCRIPTION
Based on this request, I suppose: http://forum.caravelgames.com/viewtopic.php?TopicID=41033

A little refactoring and a change so that adding Goblin Weakness or Wyrm Weakness to custom accessories works. This can be extended to support shields, but there's precedent for shields using behaviours in different ways, so I haven't added them for the moment.