### PR TITLE
Fix ExtraVars overriding non-character monster stats in SetMonstersFromExploredRoomData().

### DIFF
--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -131,8 +131,8 @@ public:
 	static bool    IsValidFactor(const WCHAR *pwStr, UINT& index, CDbHold *pHold);
 	virtual bool   IsVisible() const {return this->bVisible;}
 	virtual bool   IsVulnerable() const {return this->bVulnerable;}
-	static void    LoadCommands(CDbPackedVars& ExtraVars, COMMAND_VECTOR& commands);
-	static void    LoadCommands(CDbPackedVars& ExtraVars, COMMANDPTR_VECTOR& commands);
+	static void    LoadCommands(const CDbPackedVars& ExtraVars, COMMAND_VECTOR& commands);
+	static void    LoadCommands(const CDbPackedVars& ExtraVars, COMMANDPTR_VECTOR& commands);
 	virtual bool   OnAnswer(int nCommand, CCueEvents &CueEvents);
 	virtual bool   OnStabbed(CCueEvents &CueEvents, const UINT /*wX*/=-1, const UINT /*wY*/=-1);
 	static int     parseExpression(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC=NULL, const bool bExpectCloseParen=false);
@@ -157,9 +157,8 @@ public:
 	static void    SaveSpeech(const COMMAND_VECTOR& commands);
 	static void    SaveSpeech(const COMMANDPTR_VECTOR& commands);
 	virtual void   SetCurrentGame(const CCurrentGame *pSetCurrentGame);
-	virtual void   SetExtraVarsFromMembers();
-	void           SetExtraVarsFromMembersWithoutScript();
-	virtual void   SetMembersFromExtraVars();
+	void           SetExtraVarsFromMembersWithoutScript(CDbPackedVars& vars) const;
+	virtual void   SetMembers(const CDbPackedVars& vars);
 	virtual void   Delete();
 
 	//Behavior patterns.
@@ -210,7 +209,7 @@ private:
 	static void  SerializeCommands(string& buffer, const COMMANDPTR_VECTOR& commands);
 	static void  writeBpUINT(string& buffer, UINT n);
 
-	void  setBaseMembersFromExtraVars();
+	void  setBaseMembers(const CDbPackedVars& vars);
 
 	UINT wCurrentCommandIndex; //command to play next
 	UINT wTurnDelay;        //turns before next command

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -6374,7 +6374,7 @@ void CCurrentGame::SaveExploredRoomData(CDbRoom& room)
 
 			//Save current state of NPC, but the NPCs script itself doesn't need to be saved,
 			//and should not be included to save space.
-			pCharacter->SetExtraVarsFromMembersWithoutScript();
+			pCharacter->SetExtraVarsFromMembersWithoutScript(pCharacter->ExtraVars);
 		}
 
 		//Make copy of monster in its current state.

--- a/drodrpg/DRODLib/DbPackedVars.h
+++ b/drodrpg/DRODLib/DbPackedVars.h
@@ -93,14 +93,18 @@ class CDbPackedVars
 public:
 	CDbPackedVars() {Clear();}
 	CDbPackedVars(const CDbPackedVars& Src);
-	CDbPackedVars(const BYTE *pBuf);
+	CDbPackedVars(const BYTE* pBuf);
+	CDbPackedVars(const c4_BytesRef& Buf) {
+		c4_Bytes Bytes = (c4_Bytes)Buf;
+		UnpackBuffer(Bytes.Contents(), Bytes.Size());
+	}
 	~CDbPackedVars();
 
 	CDbPackedVars& operator=(const CDbPackedVars &Src) {SetMembers(Src); return *this;}
 	const BYTE* operator = (const BYTE *pBuf) {UnpackBuffer(pBuf, 1); return pBuf;}
 	CDbPackedVars& operator = (const c4_BytesRef &Buf)
 	{
-      c4_Bytes Bytes = (c4_Bytes) Buf;
+		c4_Bytes Bytes = (c4_Bytes) Buf;
 		UnpackBuffer(Bytes.Contents(), Bytes.Size());
 		return *this;
 	}
@@ -116,6 +120,8 @@ public:
 	{
 		return FindVarByName(pszVarName)!=NULL;
 	}
+	bool        Empty() const { return vars.empty(); }
+
 	UNPACKEDVAR*   GetFirst();
 	UNPACKEDVAR*   GetNext();
 	BYTE *         GetPackedBuffer(UINT &dwBufferSize) const;

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -645,7 +645,7 @@ public:
 	void           SetHoldForMonsters(CDbHold* pHold); //back door
 	void           SetMembersFromExploredRoomData(ExploredRoom *pExpRoom);
 	void           SetMonstersFromExploredRoomData(ExploredRoom* pExpRoom,
-			const bool bLoadNPCScripts=true);
+			const bool bLoadNPCScripts);
 
 //	void           SetHalphSlayerEntrance();
 	void           SetMonsterSquare(CMonster *pMonster);

--- a/drodrpg/DRODLib/DbSavedGames.cpp
+++ b/drodrpg/DRODLib/DbSavedGames.cpp
@@ -416,8 +416,8 @@ CMonster* CDbSavedGame::LoadMonster(const c4_RowRef& row)
 	pNew->wY = pNew->wPrevY = wY;
 	pNew->wO = pNew->wPrevO = p_O(row);
 
-	pNew->ExtraVars = p_ExtraVars(row);
-	pNew->SetMembersFromExtraVars();
+	const CDbPackedVars vars = p_ExtraVars(row);
+	pNew->SetMembers(vars);
 
 	//Pieces.
 	c4_View PiecesView = p_Pieces(row);
@@ -1035,7 +1035,7 @@ MESSAGE_ID CDbSavedGame::SetProperty(
 					delete[] data;
 /*
 //Monsters in saved games are saved without script info, so they don't need speech import.
-//If this step is performed, having an empty script will cause their attributes,
+//If this step is performed, having an empty script would cause their attributes,
 //saved in ExtraVars, to be cleared inside ImportSpeech.
 					if (pImportERMonster->wType == M_CHARACTER)
 					{

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1897,9 +1897,9 @@ void CMonster::Save(
 	const c4_RowRef &MonsterRowRef,     //(in/out) Open row ref to fill.
 	const bool /*bSaveScript*/) //currently for NPCs only [default=true]
 {
-	//Don't clear this->ExtraVars here, or CCharacter::Save won't work properly.
+	//Don't clear this->ExtraVars here, as CCharacter::Save, which is called above this, won't work properly because its compiled data will be wiped.
 
-	//Prepare monster data.
+	//Pack monster stats.
 	if (this->HP)
 		this->ExtraVars.SetVar(HPStr, this->HP);
 	if (this->ATK)
@@ -1945,14 +1945,14 @@ void CMonster::Save(
 }
 
 //*****************************************************************************
-void CMonster::SetMembersFromExtraVars()
+void CMonster::SetMembers(const CDbPackedVars& vars)
 //Reads vars from ExtraVars to reconstruct the monster's stats.
 {
-	this->HP = this->ExtraVars.GetVar(HPStr, this->HP);
-	this->ATK = this->ExtraVars.GetVar(ATKStr, this->ATK);
-	this->DEF = this->ExtraVars.GetVar(DEFStr, this->DEF);
-	this->GOLD = this->ExtraVars.GetVar(GOLDStr, this->GOLD);
-	this->XP = this->ExtraVars.GetVar(XPStr, this->XP);
+	this->HP = vars.GetVar(HPStr, this->HP);
+	this->ATK = vars.GetVar(ATKStr, this->ATK);
+	this->DEF = vars.GetVar(DEFStr, this->DEF);
+	this->GOLD = vars.GetVar(GOLDStr, this->GOLD);
+	this->XP = vars.GetVar(XPStr, this->XP);
 }
 
 //

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -252,10 +252,9 @@ public:
 	virtual void  Save(const c4_RowRef &MonsterRowRef, const bool bSaveScript=true);
 	void          Say(MESSAGE_ID eMessageID, CCueEvents &CueEvents) const;
 	virtual void  SetCurrentGame(const CCurrentGame *pSetCurrentGame);
-	virtual void  SetExtraVarsFromMembers() { }
 	void          SetHP();
 	void          SetKillInfo(const UINT wKillDirection);
-	virtual void  SetMembersFromExtraVars();
+	virtual void  SetMembers(const CDbPackedVars& vars);
 	void          SetOrientation(const int dxFirst, const int dyFirst);
 	virtual bool  TurnToFacePlayerWhenFighting() const {return false;}
 	void          UpdateGaze(CCueEvents &CueEvents);
@@ -268,7 +267,7 @@ public:
 
 	UINT HP, ATK, DEF, GOLD, XP; //combat stats
 
-	CDbPackedVars ExtraVars;
+	CDbPackedVars ExtraVars; //used only for saving stats during play and for storing CCharacter properties and scripting
 	MonsterPieces Pieces;  //when monster fills more than one square
 
 	CMonster *    pNext; //should be updated by caller when copying a monster


### PR DESCRIPTION
As per forum bug topic: http://forum.caravelgames.com/viewtopic.php?TopicID=43560

Also some related code hygiene:

LoadMonster now doesn't populate ExtraVars, as this isn't necessary.
Assert empty ExtraVars for non-character monsters on room import.
Refactor references to monster ExtraVars.
Refactor and remove SetExtraVarsFromMembers.
Rename SetMembersFromExtraVars -> SetMembers.