### PR TITLE
Retain sword state of custom player roles with temporal clones

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -2336,6 +2336,7 @@ void CCurrentGame::ActivateTemporalSplit(CCueEvents& CueEvents)
 	pClone->bIsTarget = this->swordsman.IsTarget();
 	pClone->weaponType = this->swordsman.GetActiveWeapon();
 	pClone->wIdentity = this->swordsman.wIdentity;
+	pClone->wAppearance = this->swordsman.wAppearance;
 	pClone->SetWeaponSheathed();
 	pClone->SetMovementType();
 	pClone->InputCommands(player_commands);

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -33,6 +33,7 @@ CTemporalClone::CTemporalClone(
 	CCurrentGame *pSetCurrentGame)
 	: CMimic(M_TEMPORALCLONE, pSetCurrentGame, SPD_TEMPORALCLONE)
 	, wIdentity(M_TEMPORALCLONE)
+	, wAppearance(M_TEMPORALCLONE)
 	, bInvisible(false)
 	, bIsTarget(false)
 { }

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -296,7 +296,7 @@ bool CTemporalClone::SetWeaponSheathed()
 		return true;
 	//If player or player's identity type is marked to not have a sword, then clones do not either.
 	const CSwordsman& player = this->pCurrentGame->swordsman;
-	if (!bEntityHasSword(GetIdentity()) || player.bWeaponOff || player.bNoWeapon)
+	if (!bEntityHasSword(this->wAppearance) || player.bWeaponOff || player.bNoWeapon)
 	{
 		this->bWeaponSheathed = true;
 		return true;

--- a/DRODLib/TemporalClone.h
+++ b/DRODLib/TemporalClone.h
@@ -58,6 +58,7 @@ public:
 
 	//player stats on creation
 	UINT wIdentity;
+	UINT wAppearance;
 	bool bInvisible;
 	bool bIsTarget;
 


### PR DESCRIPTION
Fix for this report: http://forum.caravelgames.com/viewtopic.php?TopicID=44202

Temporal clones determine if their weapon should be active based on their identity. If this is set to a customer character, the identity will never be one that can weild a sword. This is inconsistent with the Swordsman, which uses "appearance" to determine if it can be armed. Appearance is based on the character type the custom character is based on.

By allowing temporal clones to have "appearance", this inconsistency can be fixed, allowing temporal clones of custom roles to use swords.