### PR TITLE
Fix Tarstuff construction destroy mother-supported Tarstuff

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -9216,17 +9216,20 @@ void CDbRoom::BreakUnstableTar(CCueEvents &CueEvents)
 			const bool bFluff = wTarType == T_FLUFF;
 			if (bIsTarOrFluff(wTarType) && !IsTarStableAt(wX, wY, wTarType))
 			{
-				bStable = false;
 				//Get rid of the unstable tar
 				if (bFluff){
 					RemoveStabbedTar(wX, wY, CueEvents, true);
 					CueEvents.Add(CID_FluffDestroyed, new CMoveCoordEx(wX, wY, NO_ORIENTATION, T_FLUFF), true);
 
 				} else {
+					CMonster* pMonster = GetMonsterAtSquare(wX, wY);
+					if (pMonster && bIsMother(pMonster->wType))
+						continue; //allow unstable tarstuff to remain under a mother
 					CueEvents.Add(CID_TarstuffDestroyed, new CMoveCoordEx(wX, wY, NO_ORIENTATION, wTarType), true);
 					DestroyTar(wX, wY, CueEvents);
 				}
 
+				bStable = false;
 				CMonster *pMonster = GetMonsterAtSquare(wX, wY);
 
 				//Don't spawn tar babies under living monsters

--- a/DRODLibTests/src/tests/Scripting/Build/BuildingTarstuff.cpp
+++ b/DRODLibTests/src/tests/Scripting/Build/BuildingTarstuff.cpp
@@ -43,6 +43,18 @@ static void TestShouldBreakIntoBabiesWhenUnstable(const UINT tarType, const UINT
 	REQUIRE(game->pRoom->GetMonsterAtSquare(11, 10)->wType == babyType);
 }
 
+static void TestShouldNotBreakMotherSupportedTarStuff(const UINT tarType, const UINT motherType) {
+	CCharacter* character = RoomBuilder::AddVisibleCharacter(1, 1);
+	RoomBuilder::AddCommand(character, CCharacterCommand::CC_Build, 12, 12, 1, 1, tarType);
+
+	RoomBuilder::AddMonster(motherType, 10, 10);
+	RoomBuilder::Plot(tarType, 10, 10);
+
+	CCurrentGame* game = Runner::StartGame(15, 15, N);
+
+	REQUIRE(game->pRoom->GetTSquare(10, 10) == tarType);
+}
+
 TEST_CASE("Scripting: Build tarstuff over monsters", "[game]") {
 	RoomBuilder::ClearRoom();
 
@@ -86,6 +98,16 @@ TEST_CASE("Scripting: Build tarstuff over monsters", "[game]") {
 	}
 	SECTION("Break Fluff when unstable on build"){
 		TestShouldBreakIntoBabiesWhenUnstable(T_FLUFF, M_FLUFFBABY);
+	}
+
+	SECTION("Don't break mother supported Tar on build") {
+		TestShouldNotBreakMotherSupportedTarStuff(T_TAR, M_TARMOTHER);
+	}
+	SECTION("Don't break mother supported Mud on build") {
+		TestShouldNotBreakMotherSupportedTarStuff(T_MUD, M_MUDMOTHER);
+	}
+	SECTION("Don't break mother supported Gel on build") {
+		TestShouldNotBreakMotherSupportedTarStuff(T_GEL, M_GELMOTHER);
 	}
 }
 


### PR DESCRIPTION
Fix for this report: http://forum.caravelgames.com/viewtopic.php?TopicID=44634

When tarstuff is constructed in a room by a Citizen, Engineer or script command, the game will later clean up any built tarstuff that's not stable. The function did not check if unstable tarstuff was no a mother, and would also remove that tarstuff.

A test has also been added for this situation.