### PR TITLE
RPG gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 Deps/
 DepsSrc/
 
-# Build Folders
+# DROD Build Folders
 BackEndLib/Debug-Temp/
 BackEndLib/Release-Temp/
 CaravelNet/Debug/
@@ -47,8 +47,27 @@ Master/Linux/build.*
 Master/Linux/builds/
 Master/Linux/drod-sdl2.sublime-*
 
+# DROD RPG Build Folders
+drodrpg/CaravelNet/Debug/
+drodrpg/CaravelNet/Debug-Temp/
+drodrpg/CaravelNet/Release/
+drodrpg/CaravelNet/Release-Temp/
+drodrpg/DROD/Debug/
+drodrpg/DROD/Debug-Temp/
+drodrpg/DROD/Steam/
+drodrpg/DROD/SteamBuildDats/
+drodrpg/DROD/Release/
+drodrpg/DROD/Release-Temp/
+drodrpg/DRODLib/Debug/
+drodrpg/DRODLib/Debug-Temp/
+drodrpg/DRODLib/Release/
+drodrpg/DRODLib/Release-Temp/
+drodrpg/DRODLib/Steam/
+drodrpg/DRODLib/BuildDats/
+drodrpg/DRODLib/SteamBuildDats/
+
 # Various things we don't want.
-Master/.vs/
+**/.vs/
 **/*.obj
 **/*.log
 **/*.dll

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ drodrpg/DRODLib/Release-Temp/
 drodrpg/DRODLib/Steam/
 drodrpg/DRODLib/BuildDats/
 drodrpg/DRODLib/SteamBuildDats/
+drodrpg/DRODUtil/Debug/
+drodrpg/DRODUtil/Debug-Temp/
+drodrpg/DRODUtil/Release/
+drodrpg/DRODUtil/Release-Temp/
 
 # Various things we don't want.
 **/.vs/

--- a/drodrpg/DRODUtil/DRODUtil.cpp
+++ b/drodrpg/DRODUtil/DRODUtil.cpp
@@ -132,7 +132,7 @@ int wmain(int argc, WCHAR* argv[])
 {
 #ifdef _DEBUG
 #  ifdef WIN32
-#     define DEBUGPAUSE getch()
+#     define DEBUGPAUSE _getch()
 #  else
 #     define DEBUGPAUSE getchar()
 #  endif


### PR DESCRIPTION
More additions to gitignore when building the 2019 sln for RPG from a fairly new VS 2019 Community install.

Also fixes a minor compiler warning.