### PR TITLE
DROD RPG: Fix DRODUtil linking

### DIFF
--- a/drodrpg/DRODUtil/DRODUtil.2019.vcxproj
+++ b/drodrpg/DRODUtil/DRODUtil.2019.vcxproj
@@ -256,7 +256,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libtheora_static.lib;libvorbisfile_static.lib;libvorbis_static.lib;libogg_static.lib;libcurl_imp.lib;mk4vc70s.lib;libjpeg.lib;libpng.lib;fmodvc.lib;sdl.lib;sdlmain.lib;SDL_ttf.lib;zlib.lib;libexpat.lib;ws2_32.lib;json_vc71_libmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libtheora_static.lib;libvorbisfile_static.lib;libvorbis_static.lib;libogg_static.lib;libcurl_imp.lib;mk4vc70s.lib;jpeglib.lib;libpng.lib;fmodvc.lib;sdl2.lib;sdl2main.lib;SDL2_ttf.lib;zlib.lib;libexpat.lib;ws2_32.lib;json_vc71_libmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(Configuration)/DRODUtil.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ProgramDatabaseFile>$(Configuration)/DRODUtil.pdb</ProgramDatabaseFile>

--- a/drodrpg/DRODUtil/DRODUtil.2019.vcxproj
+++ b/drodrpg/DRODUtil/DRODUtil.2019.vcxproj
@@ -180,6 +180,7 @@
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateMapFile>true</GenerateMapFile>
       <MapFileName>$(Configuration)/drodutil.map</MapFileName>
+      <IgnoreSpecificDefaultLibraries>libcmtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='SteamDebug|Win32'">
@@ -264,6 +265,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Steam|Win32'">

--- a/drodrpg/DRODUtil/GameScreenDummy.h
+++ b/drodrpg/DRODUtil/GameScreenDummy.h
@@ -9,5 +9,6 @@
 
 SCREENTYPE CGameScreen::ProcessCommand(const int nCommand, const UINT wX, const UINT wY) {return (SCREENTYPE)0;}
 void CGameScreen::ShowStatsForMonsterAt(const UINT wX, const UINT wY) {}
+void CGameScreen::ShowStatsForMonster(CMonster*) {}
 
 #endif


### PR DESCRIPTION
Even though I look at it every day at my job, appearently I can't read Visual Studio's build output. So I missed that DRODUtil wasn't actually linking for VS2019.

The problems:

- A stub function was missing from GameScreenDummy.h, which has been added
- Some of the release libraries were incorrect
- There is some kind of default library conflict occuring for the DROD RPG version of DRODUtil. For now, I've set it to ignore libcmt, which allows DRODUtil to link.