### PR TITLE
Fix issues stemming from end-of-turn cue events and checks not being processed anytime the current room is initialized.

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -296,6 +296,7 @@ public:
 			const bool bTruncateInvalidCommands=false);
 	void     ProcessCommand(int nCommand, CCueEvents &CueEvents,
 			const UINT wX=(UINT)-1, const UINT wY=(UINT)-1);
+	void     ProcessCommand_EndOfTurnEventHandling(CCueEvents& CueEvents);
 	void     ProcessCommandSetVar(CCueEvents& CueEvents,
 			const UINT itemID, UINT newVal);
 	void     ProcessMonsterDefeat(CCueEvents& CueEvents,


### PR DESCRIPTION
See an example of this issue described here: http://forum.caravelgames.com/viewtopic.php?TopicID=41889
In addition to tokens not activating, I understand the issue could skip other events as well, such as queuing a question for processing or NPC scripts checking for an event occurring on room entrance.