### PR TITLE
Image Overlay - made is so that when DisplayTurns command finishes it…

### DIFF
--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -459,6 +459,11 @@ void CImageOverlayEffect::FinishCommand(const ImageOverlayCommand& command, cons
 			this->angle = clipAngle(ce.startAngle + command.val[0]);
 			this->bPrepareAlteredImage = true;
 			break;
+		case ImageOverlayCommand::TurnDuration:
+			// This is required for any time-based command that runs afterwards to correctly
+			// calculate the start time
+			this->startOfNextEffect = SDL_GetTicks();
+			break;
 		default: break;
 	}
 }


### PR DESCRIPTION
… sets the start time for the next command to be current time, so that it can correctly calculate its end time and display correctly rather than finish super quickly

----

[Related thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44753&page=0)