### PR TITLE
Room preview from clicking on minimap now will have access to the current game's state variables (in a safe way).

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -5989,7 +5989,7 @@ void CGameScreen::ShowRoomTemporarily(const UINT roomID)
 	pTempGame->bSwordsmanOutsideRoom = true;
 	pTempGame->CompletedScripts = this->pCurrentGame->CompletedScripts;
 	pTempGame->ConqueredRooms = this->pCurrentGame->ConqueredRooms;
-	pTempGame->stats = this->pCurrentGame->stats;
+	pTempGame->statsAtRoomStart = this->pCurrentGame->statsAtRoomStart;
 	pRoom->SetCurrentGame(pTempGame);
 	pTempGame->SetTurn(0, CueEvents);
 

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -5989,7 +5989,7 @@ void CGameScreen::ShowRoomTemporarily(const UINT roomID)
 	pTempGame->bSwordsmanOutsideRoom = true;
 	pTempGame->CompletedScripts = this->pCurrentGame->CompletedScripts;
 	pTempGame->ConqueredRooms = this->pCurrentGame->ConqueredRooms;
-	pTempGame->statsAtRoomStart = this->pCurrentGame->statsAtRoomStart;
+	pTempGame->statsAtRoomStart = this->pCurrentGame->stats;
 	pRoom->SetCurrentGame(pTempGame);
 	pTempGame->SetTurn(0, CueEvents);
 


### PR DESCRIPTION
The original code would only set `stats` field of the temporary current game, which is immediattely overwrrited by the left-empty `statsAtRoomStart`. Happened in a call to `CCurrentGame::SetTurn(0)`, followed by `CCurrentGame::SetPlayerToRoomStart()` followed by `this->stats = this->statsAtRoomStart`.

The new solution will instead set `statsAtRoomStart` to the current game's `statsAtRoomStart` effectively exposing the variables in the previews.