### PR TITLE
Character processing seq buffer overflow

### DIFF
--- a/BackEndLib/Wchar.cpp
+++ b/BackEndLib/Wchar.cpp
@@ -560,7 +560,7 @@ int _Wtoi(const WCHAR* wsz)
 }
 
 //*****************************************************************************
-WCHAR* _itoW(int value, WCHAR* wcz, int radix)
+WCHAR* _itoW(int value, WCHAR* wcz, int radix, int bufferLength)
 {
 	int i = 0;
 	bool bNegative = false;
@@ -568,12 +568,17 @@ WCHAR* _itoW(int value, WCHAR* wcz, int radix)
 	{
 		value = -value;
 		bNegative = true;
+		bufferLength--; // We have one character fewers for numbers because we need negative sign
 	}
+	bufferLength--; // Make space for null termination char
 	do {
 		int val = value % radix;
 		if (val < 10)
 			buffer[i++] = (value % radix) + '0';
 		else buffer[i++] = (value % radix) - 10 + 'A';
+
+		if (i >= bufferLength) // Ran out of space in the buffer
+			break;
 	} while ((value /= radix) > 0);
 	if (bNegative)
 		buffer[i++] = '-';

--- a/BackEndLib/Wchar.cpp
+++ b/BackEndLib/Wchar.cpp
@@ -86,7 +86,7 @@ const WCHAR wszITag[] = { We('<'),We('i'),We('>'), We(0) };
 const WCHAR wszEndITag[] = { We('<'),We('/'),We('i'),We('>'), We(0) };
 const WCHAR wszPTag[] = { We('<'),We('p'),We('>'), We(0) };
 
-static char buffer[512];
+static char buffer[WCHAR_INTERNAL_BUFFER];
 
 //*****************************************************************************
 void AsciiToUnicode(const char *psz, WSTRING &wstr)
@@ -562,6 +562,9 @@ int _Wtoi(const WCHAR* wsz)
 //*****************************************************************************
 WCHAR* _itoW(int value, WCHAR* wcz, int radix, int bufferLength)
 {
+	// Internal buffer's max length should never ever be exceeded
+	bufferLength = min(WCHAR_INTERNAL_BUFFER, bufferLength);
+
 	int i = 0;
 	bool bNegative = false;
 	if (value < 0) //negative?
@@ -572,13 +575,16 @@ WCHAR* _itoW(int value, WCHAR* wcz, int radix, int bufferLength)
 	}
 	bufferLength--; // Make space for null termination char
 	do {
+		if (i >= bufferLength) {
+			ASSERT(!"_itoW: ran out of space in the provided buffer - it will be trimmed.");
+			break;
+		}
+
 		int val = value % radix;
 		if (val < 10)
 			buffer[i++] = (value % radix) + '0';
 		else buffer[i++] = (value % radix) - 10 + 'A';
 
-		if (i >= bufferLength) // Ran out of space in the buffer
-			break;
 	} while ((value /= radix) > 0);
 	if (bNegative)
 		buffer[i++] = '-';

--- a/BackEndLib/Wchar.h
+++ b/BackEndLib/Wchar.h
@@ -129,7 +129,7 @@ bool isWInteger(const WCHAR* wcz);
 bool isInteger(const char* pcz);
 
 int      _Wtoi(const WCHAR* wsz);
-WCHAR*   _itoW(int value, WCHAR* wcz, int radix);
+WCHAR*   _itoW(int value, WCHAR* wcz, int radix, int bufferLength = INT_MAX);
 
 UINT     WCSlen(const WCHAR* wsz)  FUNCATTR_PURE;
 int      WCScmp(const WCHAR* pwcz1, const WCHAR* pwcz2)  FUNCATTR_PURE;

--- a/BackEndLib/Wchar.h
+++ b/BackEndLib/Wchar.h
@@ -38,6 +38,8 @@
 #define STRFY(x) #x
 #define STRFY_EXPAND(x) STRFY(x)
 
+#define WCHAR_INTERNAL_BUFFER 512
+
 // C++11 has native 16-bit string support, so use that if we can
 #if !defined(USE_CXX11) && (defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__))
 
@@ -129,7 +131,7 @@ bool isWInteger(const WCHAR* wcz);
 bool isInteger(const char* pcz);
 
 int      _Wtoi(const WCHAR* wsz);
-WCHAR*   _itoW(int value, WCHAR* wcz, int radix, int bufferLength = INT_MAX);
+WCHAR*   _itoW(int value, WCHAR* wcz, int radix, int bufferLength = WCHAR_INTERNAL_BUFFER);
 
 UINT     WCSlen(const WCHAR* wsz)  FUNCATTR_PURE;
 int      WCScmp(const WCHAR* pwcz1, const WCHAR* pwcz2)  FUNCATTR_PURE;

--- a/DROD/CharacterOptionsWidget.cpp
+++ b/DROD/CharacterOptionsWidget.cpp
@@ -56,7 +56,7 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 		CX_SEQUENCEHELP, CY_SEQUENCEHELP, F_Small, g_pTheDB->GetMessageText(MID_SetProcessingSequenceDescription)));
 
 	this->pSequenceTextBox = new CTextBoxWidget(0L, X_SEQUENCETEXT, Y_SEQUENCETEXT,
-		CX_SEQUENCETEXT, CY_SEQUENCETEXT, 9, TAG_OK);
+		CX_SEQUENCETEXT, CY_SEQUENCETEXT, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);
 
 	this->pSequenceTextBox->SetDigitsOnly(true);
 	this->pSequenceTextBox->SetAllowNegative(false);
@@ -68,23 +68,29 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 void CCharacterOptionsDialog::SetCharacter(
 	const CCharacter *pCharacter
 ){
-	WCHAR temp[8];
+	const UINT bufferLength = PROCESSING_SEQUENCE_MAX_LENGTH + 1; // Added space for null-termination
+	WCHAR temp[bufferLength];
 
-	this->pSequenceTextBox->SetText(_itoW(pCharacter->wProcessSequence, temp, 10));
+	_itoW(pCharacter->wProcessSequence, temp, 10, bufferLength);
+
+	this->pSequenceTextBox->SetText(temp);
 }
 
 //*****************************************************************************
 void CCharacterOptionsDialog::SetCharacter(
 	HoldCharacter *pCharacter
 ){
-	WCHAR temp[8];
-	
-	this->pSequenceTextBox->SetText(_itoW(pCharacter->ExtraVars.GetVar(ParamProcessSequenceStr, SPD_CHARACTER), temp, 10));
+	const UINT bufferLength = PROCESSING_SEQUENCE_MAX_LENGTH + 1; // Added space for null-termination
+	WCHAR temp[bufferLength];
+
+	_itoW(pCharacter->ExtraVars.GetVar(ParamProcessSequenceStr, SPD_CHARACTER), temp, 10, bufferLength);
+
+	this->pSequenceTextBox->SetText(temp);
 }
 
 //*****************************************************************************
 UINT CCharacterOptionsDialog::GetProcessSequence(){
-	return (UINT) _Wtoi(this->pSequenceTextBox->GetText());
+	return (UINT) this->pSequenceTextBox->GetNumber();
 }
 
 //*****************************************************************************

--- a/DROD/CharacterOptionsWidget.h
+++ b/DROD/CharacterOptionsWidget.h
@@ -90,6 +90,8 @@ private:
 	static const int CY_CANCEL = CY_STANDARD_BUTTON;
 	static const int X_CANCEL = CX_DIALOG / 2 + CX_SPACE / 2;
 	static const int Y_CANCEL = CY_DIALOG - CY_SAVE - CY_SPACE;
+
+	static const int PROCESSING_SEQUENCE_MAX_LENGTH = 9;
 };
 
 #endif


### PR DESCRIPTION
I've tested that the changes to `_itoW` work correctly but please double check it. If you're worried about speed I'll gladly create another function that's safe.

[Relevant thread](http://forumskell.caravelgames.com/viewtopic.php?TopicID=44139).