### PR TITLE
Made it so that pressing escape during death animation returns to the…

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -2952,6 +2952,10 @@ int CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 						break;
 						default: break;
 					}
+					if (keysym.sym == SDLK_ESCAPE) {
+						cmd_response = CMD_ESCAPE;
+						dwStart = 0;
+					}
 				}
 				break;
 				default: break;
@@ -4432,7 +4436,15 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		}
 		PaintClock();
 		const int cmd_response = HandleEventsForPlayerDeath(CueEvents);
-		const bool bUndoDeath = cmd_response == CMD_UNDO;
+
+		if (cmd_response == CMD_ESCAPE) {
+			eNextScreen = SCR_Return;
+		}
+
+		const bool bUndoDeath = (
+			cmd_response == CMD_UNDO 
+			|| cmd_response == CMD_ESCAPE // Undo the death move when exiting from death so that state is saved
+		);
 		if (bUndoDeath) {
 			if (this->pCurrentGame && !this->pCurrentGame->dwCutScene)
 				this->undo.advanceTurnThreshold(this->pCurrentGame->wTurnNo);

--- a/DRODLib/GameConstants.h
+++ b/DRODLib/GameConstants.h
@@ -85,6 +85,7 @@ extern const WCHAR wszVersionReleaseNumber[];
 #define CMD_BUMP_S (COMMAND_COUNT+8)
 #define CMD_BUMP_SE (COMMAND_COUNT+9)
 #define CMD_BUMP_NW (COMMAND_COUNT+10)
+#define CMD_ESCAPE (COMMAND_COUNT+11) // Used only in front end for tracking wish to exit game
 
 //Sword orientation.
 //TODO make an enum?


### PR DESCRIPTION
… title screen, allowing to avoid death-loops stemming from cutscenes. The progress is saved up to the move before the one that kills the player, or 0th turn when no move was made yet.

[Relevant thread]|(http://forum.caravelgames.com/viewtopic.php?TopicID=44765)