### PR TITLE
THere was a visual bug with Beethro's face during death animation whe…

### DIFF
--- a/DROD/FaceWidget.cpp
+++ b/DROD/FaceWidget.cpp
@@ -135,7 +135,7 @@ CFaceWidget::CFaceWidget(
 	, eMood(Mood_Normal), ePrevMood(Mood_Normal)
 	, dwDelayMood(0), dwStartDelayMood(0)
 	, bMoodDrawn(false), bIsReading(false), bIsBlinking(false), bIsSleeping(false)
-	, bDoBlink(false)
+	, bDoBlink(false), bIsDeathAnimation(false)
 	, eMoodSEID(SEID_NONE)
 	, bMoodLocked(false)
 	, nPupilX(0), nPupilY(0), nPupilTargetX(0), nPupilTargetY(0)
@@ -284,6 +284,12 @@ void CFaceWidget::SetMoodDelay(
 {
 	this->dwDelayMood = dwDelay;
 	this->dwStartDelayMood = SDL_GetTicks();
+}
+
+//****************************************************************************
+void CFaceWidget::SetIsDeathAnimation(const bool bIsDeathAnimation)
+{
+	this->bIsDeathAnimation = bIsDeathAnimation;
 }
 
 //****************************************************************************
@@ -767,7 +773,7 @@ void CFaceWidget::Paint(
 	const bool bWasBlinking = this->bIsBlinking;
 	if (!this->bIsSleeping)
 	{
-		if (this->bIsBlinking)
+		if (this->bIsBlinking || this->bIsDeathAnimation)
 			this->bIsBlinking = false;
 		else
 		{

--- a/DROD/FaceWidget.h
+++ b/DROD/FaceWidget.h
@@ -173,6 +173,7 @@ public:
 		const bool bOverrideLock=false);
 	void           SetMoodToSoundEffect(MOOD eSetMood, SEID eUntilSEID);
 	void           SetReading(const bool bReading);
+	void           SetIsDeathAnimation(const bool bIsDeathAnimation);
 	void           SetSleeping();
 
 struct POINT
@@ -205,6 +206,7 @@ private:
 	bool           bDoBlink;      //when set, do a blink at next possible time
 	SEID           eMoodSEID;
 	bool           bMoodLocked;   //can't change mood w/o explicit flag
+	bool           bIsDeathAnimation; // Whether death animation is playing
 
 	//Eye movement.
 	int               nPupilX, nPupilY;

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -2830,6 +2830,7 @@ int CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 	this->pRoomWidget->DrawOverheadLayer(this->pRoomWidget->pRoomSnapshotSurface);
 	this->pRoomWidget->DrawGhostOverheadCharacters(this->pRoomWidget->pRoomSnapshotSurface, false);
 	this->pRoomWidget->RenderEnvironment(this->pRoomWidget->pRoomSnapshotSurface);
+	this->pFaceWidget->SetIsDeathAnimation(true);
 
 	const bool bFade = g_pTheBM->bAlpha;
 	CFade *pFade = bFade ? new CFade(this->pRoomWidget->pRoomSnapshotSurface,NULL) : NULL;
@@ -3057,6 +3058,8 @@ int CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 		ClearSpeech();
 		this->pFaceWidget->SetMood(Mood_Normal);
 	}
+
+	this->pFaceWidget->SetIsDeathAnimation(false);
 
 	return cmd_response;
 }


### PR DESCRIPTION
…n critical her was killing. Turned out to be blinking, made it so that a flag is set on the face widget for the whole duratin of death animation, which is used to prevent blinking.

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=38466)