### PR TITLE
There was a bug where operations that shouldn't take a turn (like swi…

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3360,7 +3360,7 @@ SCREENTYPE CGameScreen::ProcessCommand(
 	}
 
 	if (this->pCurrentGame && !bWasCutScene)
-		this->undo.advanceTurnThreshold(this->pCurrentGame->wTurnNo);
+		this->undo.advanceTurnThreshold(this->pCurrentGame->wPlayerTurn);
 
 	return eNextScreen;
 }
@@ -4450,7 +4450,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		);
 		if (bUndoDeath) {
 			if (this->pCurrentGame && !this->pCurrentGame->dwCutScene)
-				this->undo.advanceTurnThreshold(this->pCurrentGame->wTurnNo);
+				this->undo.advanceTurnThreshold(this->pCurrentGame->wPlayerTurn);
 			UndoMove();
 		}
 		CueEvents.Clear();	//clear after death sequence (whether move is undone or not)
@@ -6204,7 +6204,7 @@ void CGameScreen::UndoMove()
 		return; //nothing to undo
 
 	if (!this->bPlayTesting && //unlimited undo always allowed during playtesting
-			!this->undo.canUndoBefore(this->pCurrentGame->wTurnNo))
+			!this->undo.canUndoBefore(this->pCurrentGame->wPlayerTurn))
 		return;
 
 	g_pTheSound->PlaySoundEffect(SEID_UNDO);


### PR DESCRIPTION
…tching clones) consumed undo slots. It was fixed by replacing all uses of wTurnNo (which is the turn number from the perspective of running ProcessCommand()) to wPlayerTurn (which is the number of turns as displayed using F7).

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=38253&page=0#435610)
[Relevant thread #2](http://forum.caravelgames.com/viewtopic.php?TopicID=40529&page=0#435616)