### PR TITLE
In editor, when show errors is checked, tarstuff gates will now conti…

### DIFF
--- a/DROD/EditRoomScreen.cpp
+++ b/DROD/EditRoomScreen.cpp
@@ -7501,7 +7501,10 @@ void CEditRoomScreen::ShowErrors()
 					if (!pMonster || wTileNo[1] == T_FLUFF || !bIsMother(pMonster->wType))
 						AddShadeToTile(LightRed);
 				}
-				bTar = true;
+
+				if (wTileNo[1] != T_FLUFF)
+					bTar = true;
+
 				break;
 			}
 


### PR DESCRIPTION
…nue reporting error when there is fluff in the room but not other tarstuff

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=38771)