### PR TITLE
When placing gentryii head, if you try to place the chain in front of…

### DIFF
--- a/DROD/EditRoomScreen.cpp
+++ b/DROD/EditRoomScreen.cpp
@@ -4925,7 +4925,7 @@ PlotType CEditRoomScreen::PlotGentryiiSegment()
 			{
 				//Head already here.  Update head's direction.
 				ASSERT(pMonster->IsLongMonster());
-				pMonster->wO = wDirection;
+				pMonster->wO = nGetReverseO(wDirection);
 			} else {
 				PlotObjectAt(wX, wY, T_GENTRYII, wDirection);
 			}


### PR DESCRIPTION
… its head (through its head) it will no longer result in Gentryii facing the wrong direction

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=38767)