### PR TITLE
fix: don't draw wading tiles for Young Halph

### DIFF
--- a/DROD/TileImageCalcs.cpp
+++ b/DROD/TileImageCalcs.cpp
@@ -1709,7 +1709,6 @@ UINT GetWadingEntityTile(
 		case M_MIMIC: return MIMIC_WATER_TI[wO];
 		case M_CITIZEN: return CITIZEN_WATER_TI[wO];
 		case M_ARCHITECT: return ARCHITECT_WATER_TI[wO];
-		case M_HALPH:
 		case M_HALPH2: return HALPH_WATER_TI[wO];
 		case M_SLAYER:
 		case M_SLAYER2: return SLAYER_WATER_TI[wO];
@@ -1739,7 +1738,6 @@ UINT GetWadingUnarmedEntityTile(
 		case M_MIMIC: return MIMIC_WATER_UTI[wO];
 		case M_CITIZEN: return CITIZEN_WATER_TI[wO];
 		case M_ARCHITECT: return ARCHITECT_WATER_TI[wO];
-		case M_HALPH:
 		case M_HALPH2: return HALPH_WATER_TI[wO];
 		case M_SLAYER:
 		case M_SLAYER2: return SLAYER_WATER_UTI[wO];

--- a/DROD/TileImageCalcs.h
+++ b/DROD/TileImageCalcs.h
@@ -125,7 +125,7 @@ static inline bool bIsWadingMonsterType(const UINT mt) {
 		case M_MIMIC:
 		case M_DECOY:
 		case M_CITIZEN: case M_ARCHITECT:
-		case M_HALPH: case M_HALPH2:
+		case M_HALPH2:
 		case M_SLAYER: case M_SLAYER2:
 		case M_GOBLIN:
 		case M_ROCKGOLEM:


### PR DESCRIPTION
This PR fixes http://forum.caravelgames.com/viewtopic.php?TopicID=39612.

As Halph and Young Halph share graphics they were both marked as having wading graphics. However, Young Halph cannot wade, but wading graphics were still being drawn when Young Halph is killed by being pushed into shallow water.