### PR TITLE
Modified GetEffectListForLayer() to always return a sensible default …

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -559,8 +559,8 @@ CRoomEffectList* CRoomWidget::GetEffectListForLayer(const int layer) const
 		case 0: return this->pOLayerEffects;
 		case 1: return this->pTLayerEffects;
 		case 2: return this->pMLayerEffects;
-		case 3: return this->pLastLayerEffects;
-		default: return NULL;
+		case 3: 
+		default: return this->pLastLayerEffects;
 	}
 }
 


### PR DESCRIPTION
…because the callers don't check the return and it's a user-provided value so best to treat it as unsafe

[Related thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44770)