### PR TITLE
Temporal Projection will no longer do a wait move when pushed, since …

### DIFF
--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -243,7 +243,8 @@ void CTemporalClone::Process(const int /*nLastCommand*/, CCueEvents &CueEvents)
 		}
 	}
 
-	ApplyMimicMove(dx, dy, command, nGetO(dx,dy), CueEvents, bEnteredTunnel);
+	if (!this->bPushedThisTurn)
+		ApplyMimicMove(dx, dy, command, nGetO(dx,dy), CueEvents, bEnteredTunnel);
 
 	//Light any fuse stood on.
 	if (CanLightFuses())


### PR DESCRIPTION
…it makes no sense to do that (all interactions done by the move should've been handled by the push already) and it caused prevX/Y vars to be reset and instakill them when pushed onto hot tiles

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=38450&page=0#406292)