### PR TITLE
Modified temporal projection roles. Wubba temporal projection is now …

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -4088,6 +4088,7 @@ void CDbRoom::ActivateToken(
 					{
 						CTemporalClone *pClone = DYN_CAST(CTemporalClone*, CMonster*, pMonster);
 						pClone->bIsTarget = true;
+						pClone->SetMovementType();
 					}
 					break;
 					default: break;

--- a/DRODLib/MonsterType.h
+++ b/DRODLib/MonsterType.h
@@ -283,6 +283,20 @@ static inline bool bCanFluffTrack(const UINT mt) {
 			return true;
 	}	
 }
+static inline bool bIsVulnerableToBodyAttack(const UINT mt) {
+	switch (mt){
+		case M_WUBBA:
+		case M_FLUFFBABY:
+		case M_FEGUNDO:
+		case M_NONE:
+			//case M_ROCKGOLEM: // For backwards compatibility rock golems are not resistant to body attack. 
+			return false;
+		default:
+			//All other (monster) roles are vulnerable.
+			return true;
+		}
+}
+
 static inline bool bCanFluffKill(const UINT mt) {
 	switch(mt) {
 		case M_ROCKGOLEM: case M_ROCKGIANT: case M_CONSTRUCT:

--- a/DRODLib/Slayer.h
+++ b/DRODLib/Slayer.h
@@ -73,6 +73,7 @@ private:
 	void MoveToOpenDoor(CCueEvents &CueEvents);
 	void StopOpeningDoor();
 	void StopStrikingOrb(CCueEvents &CueEvents);
+	bool CanBodyKillTarget(const UINT wTX, const UINT wTY) const;
 	CCoord openingDoorAt; //door being opened
 	CCoordSet orbsToHit, platesToDepress;  //set of possible destination orbs/plates
 

--- a/DRODLib/Swordsman.cpp
+++ b/DRODLib/Swordsman.cpp
@@ -215,25 +215,6 @@ bool CSwordsman::IsVulnerableToWeapon(const WeaponType weaponType) const
 }
 
 //*****************************************************************************
-bool CSwordsman::IsVulnerableToBodyAttack() const
-//Returns: true if player in current role is vulnerable to attacks made by monster body moving onto the player
-{
-	//Human roles can't step on monsters.
-	//Exception: Slayer
-	switch (this->wAppearance)
-	{
-		case M_WUBBA:
-		case M_FLUFFBABY:
-		case M_FEGUNDO:
-		case M_NONE:
-			//case M_ROCKGOLEM: // For backwards compatibility rock golems are not resistant to body attack. 
-			return false;
-		default:
-			//All other (monster) roles are vulnerable.
-			return true;
-	}
-}
-//*****************************************************************************
 bool CSwordsman::IsTarget() const
 //Returns: whether player is a target to monsters
 {

--- a/DRODLib/Swordsman.h
+++ b/DRODLib/Swordsman.h
@@ -75,7 +75,7 @@ public:
 	bool IsInRoom() const;
 	bool IsStabbable() const;
 	bool IsVulnerableToWeapon(const WeaponType weaponType) const;
-	bool IsVulnerableToBodyAttack() const;
+	bool IsVulnerableToBodyAttack() const { return bIsVulnerableToBodyAttack(this->wAppearance); }
 	bool IsTarget() const;
 	bool IsWeaponAt(UINT wX, UINT wY) const;
 	bool IsVisible() const { return !(this->bIsInvisible || this->bIsHiding); }

--- a/DRODLib/TemporalClone.h
+++ b/DRODLib/TemporalClone.h
@@ -52,6 +52,7 @@ public:
 	void SetMovementType();
 	virtual void Stun(CCueEvents &CueEvents, UINT val=1);
 	virtual bool CanMoveOntoTunnelAt(UINT /*col*/, UINT /*row*/) const { return true; }
+	bool IsVulnerableToBodyAttack() const { return bIsVulnerableToBodyAttack(this->wAppearance); }
 
 	int getNextCommand() const;
 	void InputCommands(const vector<int>& commands);


### PR DESCRIPTION
…resistant to body attacks + Power token now gives abilities to temporal projections that are already active (there was a bug with stalwart role, which would inherit shallow water traversal from player IF player touched power token before recording, but would not do so if the token was activated during playback)

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=40546)