### PR TITLE
Fixed a bug where multiple speeches + temporal projections would cras…

### DIFF
--- a/DROD/DemoScreen.cpp
+++ b/DROD/DemoScreen.cpp
@@ -371,6 +371,9 @@ void CDemoScreen::OnBetweenEvents()
 				//so here we need to re-sync it
 				this->currentCommandIter = CGameScreen::pCurrentGame->Commands.Get(CGameScreen::pCurrentGame->wTurnNo);
 
+				//call this to unlink characters deleted during room reset caused by temporal split, will crash game randomly otherwise
+				CGameScreen::ClearSpeech(false, true);
+
 				if (this->sCueEvents.HasOccurred(CID_ActivatedTemporalSplit))
 					DrawCurrentTurn();
 			} else {


### PR DESCRIPTION
…h the game during demo playback caused by accessing memory of deleted objects

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44162&page=0#435737)