### PR TITLE
fix: set default black color in different manner to ensure it is always set correctly

### DIFF
--- a/DROD/Chat.h
+++ b/DROD/Chat.h
@@ -67,9 +67,8 @@ namespace CNetChat
 
 	struct Data
 	{
-		Data() : chatID(0), opType(0), timestamp(0), bAdminMessage(false), bAFK(false)
+		Data() : chatID(0), opType(0), timestamp(0), bAdminMessage(false), bAFK(false), color({0, 0, 0, 0})
 		{
-			color.r = color.g = color.b = 0;
 		}
 
 		UINT chatID;      //unique ID

--- a/FrontEndLib/ListBoxWidget.h
+++ b/FrontEndLib/ListBoxWidget.h
@@ -40,9 +40,9 @@ struct LBOX_ITEM
 	LBOX_ITEM()
 		: bGrayed(false)
 		, rearrangeable(true)
-	{
-		color.r = color.g = color.b = 0; //[default=black]
-	}
+		, color({0, 0, 0, 0})
+    {
+    }
 
 	union {
 		UINT dwKey;

--- a/FrontEndLib/SubtitleEffect.h
+++ b/FrontEndLib/SubtitleEffect.h
@@ -40,8 +40,8 @@ class CSubtitleEffect;
 typedef std::map<CMoveCoord*, CSubtitleEffect*> SUBTITLES;
 
 struct TEXTLINE {
-	TEXTLINE() {color.r = color.g = color.b = 0;} //black
-	TEXTLINE(const WCHAR* pText) : text(pText) {color.r = color.g = color.b = 0;}
+	TEXTLINE() : color({0, 0, 0, 0}) {} //black
+	TEXTLINE(const WCHAR* pText) : text(pText), color({0, 0, 0, 0}) {}
 	WSTRING text;
 	SDL_Color color;
 };

--- a/drodrpg/DROD/Chat.h
+++ b/drodrpg/DROD/Chat.h
@@ -83,9 +83,8 @@ namespace CNetChat
 
 	struct Data
 	{
-		Data() : chatID(0), opType(0), timestamp(0), bAdminMessage(false), bAFK(false)
+		Data() : chatID(0), opType(0), timestamp(0), bAdminMessage(false), bAFK(false), color({0, 0, 0, 0})
 		{
-			color.r = color.g = color.b = 0;
 		}
 
 		UINT chatID;      //unique ID


### PR DESCRIPTION
The way the default black color was set in some instances caused issues on OS X, where the color would not always be set correctly, resulting in text not being visible in list boxes. I've changed the constructors using this logic to fix the issue.