### PR TITLE
Armed monsters that are drawn with transparency automatically mark th…

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -6293,6 +6293,10 @@ bool CRoomWidget::NeedsSwordRedrawing(const CMonster *pMonster) const
 	if (pMonster->wType == M_TEMPORALCLONE)
 		return !IsTemporalCloneAnimated();
 
+	// Hiding clones are redrawn every turn
+	if (pMonster->wType == M_CLONE)
+		return !pMonster->IsHiding();
+
 	return true;
 }
 
@@ -7660,6 +7664,10 @@ void CRoomWidget::DrawArmedMonster(
 		TileImageBlitParams::setDisplayArea(0, y_bottom, CX_TILE, CY_TILE - y_bottom);
 	}
 
+	// Transparent armed monsters must dirty their tiles to ensure RedrawMonsters doesn't cause flickering
+	if (blit.nOpacity < 255)
+		this->pTileImages[this->pRoom->ARRAYINDEX(pArmedMonster->wX, pArmedMonster->wY)].dirty = 1;
+
 	DrawTileImage(blit, pDestSurface);
 
 	if (bHasSword) {
@@ -7669,6 +7677,10 @@ void CRoomWidget::DrawArmedMonster(
 		weaponBlit.nAddColor = -1;
 		weaponBlit.wTileImageNo = wSwordTI;
 		DrawSwordFor(pArmedMonster, weaponBlit, pDestSurface);
+
+		// The same for the sword, want to avoid flickering
+		if (blit.nOpacity < 255 && IS_COLROW_IN_DISP(weaponBlit.wCol, weaponBlit.wRow))
+			this->pTileImages[this->pRoom->ARRAYINDEX(weaponBlit.wCol, weaponBlit.wRow)].dirty = 1;
 	}
 
 	TileImageBlitParams::resetDisplayArea();


### PR DESCRIPTION
…eir tiles as dirty to prevent multiple delta-draws from stacking and causing flickering + ditto for their swords + damaged sword tiles are no longer redrawn if they belong to a hiding clone

I hope you can make sense of it Mike.

[Relevant thread](http://forum.caravelgames.com/message.php?Action=NewReplyMessage&BoardID=7&TopicID=38214)