### PR TITLE
fix: check if monster in square where stun effect is being applied is actually stunned

### DIFF
--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -620,7 +620,7 @@ void CDrodScreen::AddVisualCues(CCueEvents& CueEvents, CRoomWidget* pRoomWidget,
 		const CMoveCoord *pCoord = DYN_CAST(const CMoveCoord*, const CAttachableObject*, pObj);
 		const CMonster *pMonster = pGame->pRoom->GetMonsterAtSquare(pCoord->wX,pCoord->wY);
 		const bool bPlayer = pGame->swordsman.wX == pCoord->wX && pGame->swordsman.wY == pCoord->wY;
-		if (bPlayer || (pMonster && pMonster->IsAlive()))
+		if (bPlayer || (pMonster && pMonster->IsAlive() && pMonster->IsStunned()))
 			pRoomWidget->AddMLayerEffect(new CStunEffect(pRoomWidget, *pCoord));
 	}
 	for (pObj = CueEvents.GetFirstPrivateData(CID_MonsterPieceStabbed);

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3845,7 +3845,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		const CMoveCoord *pCoord = DYN_CAST(const CMoveCoord*, const CAttachableObject*, pObj);
 		const CMonster *pMonster = this->pCurrentGame->pRoom->GetMonsterAtSquare(pCoord->wX,pCoord->wY);
 		const bool bPlayer = this->pCurrentGame->swordsman.wX == pCoord->wX && this->pCurrentGame->swordsman.wY == pCoord->wY;
-		if (bPlayer || (pMonster && pMonster->IsAlive()))
+		if (bPlayer || (pMonster && pMonster->IsAlive() && pMonster->IsStunned()))
 			this->pRoomWidget->AddMLayerEffect(new CStunEffect(this->pRoomWidget, *pCoord));
 	}
 	for (pObj = CueEvents.GetFirstPrivateData(CID_TrapDoorRemoved);


### PR DESCRIPTION
Turns out the methods that add stun effects didn't actually check if the monster at that location is stunned, it just checks if it's alive. If a character is pushed to a square and then immediately killed, `pMonster` is actually the killing monster and a stun effect should not be drawn. The explicit `isStunned` check remedies this.