### PR TITLE
Moved when ResetForPaint() happens so that creating effects for CueEv…

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3238,7 +3238,6 @@ SCREENTYPE CGameScreen::ProcessCommand(
 				}
 				if (bPlayerDied)
 					this->pRoomWidget->RenderRoomLighting();
-				this->pRoomWidget->ResetForPaint();
 
 				if (!bPlayerDied)
 					this->bRoomClearedOnce = false;
@@ -3270,6 +3269,13 @@ SCREENTYPE CGameScreen::ProcessCommand(
 	bPlayerDied = this->sCueEvents.HasAnyOccurred(IDCOUNT(CIDA_PlayerDied), CIDA_PlayerDied);
 	const bool bPlayingVideo = this->sCueEvents.HasOccurred(CID_PlayVideo);
  	SCREENTYPE eNextScreen = ProcessCueEventsBeforeRoomDraw(this->sCueEvents);
+
+	// ResetForPaint() must happen after ProcessCueEventsBeforeRoomDraw so that it can inspect the state of the rendered
+	// room from the previous turn, otherwise things can get weird, like briar getting disconnected if it falls on the
+	// turn the player dies/leaves the room
+	if (bLeftRoom)
+		this->pRoomWidget->ResetForPaint();
+
 	if (eNextScreen == SCR_Game)
 	{
 		//Redraw the room.


### PR DESCRIPTION
…ents can still inspect room's previous state

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=39404)

@mrimer  I am not 100% confident this change won't break anything but I think it makes sense to do it like that.