### PR TITLE
When level complete event was triggered game would redraw the current…

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -4611,7 +4611,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsAfterRoomDraw(
 
 	if (CueEvents.HasOccurred(CID_CompleteLevel))
 	{
-		this->pMapWidget->UpdateFromCurrentGame();
+		this->pMapWidget->DrawMapSurfaceFromRoom(this->pCurrentGame->pRoom);
 		this->pMapWidget->RequestPaint();
 		if (bLevelComplete)
 		{


### PR DESCRIPTION
… room in the minimap on turn 0 from the original room data rather than current state, ignoring turn 0 changes

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44788&page=0)