### PR TITLE
Temporal projection attempted-move effect now draws the sword when th…

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -2808,8 +2808,9 @@ int CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 			if (wSwordTI != TI_UNSPECIFIED) {
 				const CCoord sword(player.wSwordX, player.wSwordY);
 				const vector<UINT> swordTile(1, wSwordTI);
-				this->pRoomWidget->AddMLayerEffect(
-						new CTrapdoorFallEffect(this->pRoomWidget, sword, swordTile, fallTime));
+				if (this->pRoomWidget->pRoom->IsValidColRow(sword.wX, sword.wY))
+					this->pRoomWidget->AddMLayerEffect(
+							new CTrapdoorFallEffect(this->pRoomWidget, sword, swordTile, fallTime));
 			}
 		}
 	}
@@ -3958,8 +3959,10 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 
 				if (pCoord->wValue2 != WT_Off) {
 					const UINT swordTile = this->pRoomWidget->GetSwordTileFor(pCoord->wValue - M_OFFSET, pCoord->wO, pCoord->wValue2);
-					if (swordTile)
-						fallingTiles[ROOMCOORD(pCoord->wX + nGetOX(pCoord->wO), pCoord->wY + nGetOY(pCoord->wO))].push_back(swordTile);
+					const INT wSwordX = pCoord->wX + nGetOX(pCoord->wO);
+					const INT wSwordY = pCoord->wY + nGetOY(pCoord->wO);
+					if (swordTile && this->pRoomWidget->pRoom->IsValidColRow(wSwordX, wSwordY))
+						fallingTiles[ROOMCOORD(wSwordX, wSwordY)].push_back(swordTile);
 				}
 			}
 			else if (bIsSerpentTile(pCoord->wValue))

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -7736,12 +7736,10 @@ void CRoomWidget::AddTemporalCloneNextMoveEffect(const CTemporalClone *pTC, cons
 	if (pTC->HasSword()) {
 		coord.wX += nGetOX(newO);
 		coord.wY += nGetOY(newO);
-		if (this->pRoom->IsValidColRow(coord.wX + dx, coord.wY + dy)) {
-			const UINT wSwordTI = GetSwordTileFor(pTC, newO, logicalIdentity);
-			pTME = new CTemporalMoveEffect(this, coord, wSwordTI,
-					EFFECTLIB::EGENERIC); //don't prevent another similar effect from originating here
-			AddMLayerEffect(pTME);
-		}
+		const UINT wSwordTI = GetSwordTileFor(pTC, newO, logicalIdentity);
+		pTME = new CTemporalMoveEffect(this, coord, wSwordTI,
+				EFFECTLIB::EGENERIC); //don't prevent another similar effect from originating here
+		AddMLayerEffect(pTME);
 	}
 }
 

--- a/DROD/TemporalMoveEffect.cpp
+++ b/DROD/TemporalMoveEffect.cpp
@@ -29,6 +29,7 @@
 #include "../DRODLib/CurrentGame.h"
 #include "../DRODLib/GameConstants.h"
 #include <FrontEndLib/BitmapManager.h>
+#include <FrontEndLib/Colors.h>
 
 const Uint32 START_DELAY = 500;
 const Uint32 DISPLAY_DURATION = 750;
@@ -89,12 +90,21 @@ bool CTemporalMoveEffect::Draw(SDL_Surface* pDestSurface)
 
 	const UINT wThisX = this->startX + int(deltaX * percent);
 	const UINT wThisY = this->startY + int(deltaY * percent);
+	
+	SDL_Rect BlitRect = MAKE_SDL_RECT(wThisX, wThisY, CBitmapManager::CX_TILE, CBitmapManager::CY_TILE);
+	SDL_Rect WidgetRect = MAKE_SDL_RECT(0, 0, 0, 0);
+	this->pRoomWidget->GetRect(WidgetRect);
+	if (!CWidget::ClipRectToRect(BlitRect, WidgetRect))
+		return true;
 
-	g_pTheBM->BlitTileImage(this->wTileNo, wThisX, wThisY,
-			pDestSurface, this->bUseLightLevel, opacity);
+	g_pTheBM->BlitTileImagePart(
+		this->wTileNo, 
+		BlitRect.x, BlitRect.y,
+		BlitRect.x - wThisX, BlitRect.y - wThisY, BlitRect.w, BlitRect.h,
+		pDestSurface, this->bUseLightLevel, opacity);
 
-	SDL_Rect clipRect = MAKE_SDL_RECT(wThisX, wThisY,
-			CBitmapManager::CX_TILE, CBitmapManager::CY_TILE);
+	SDL_Rect clipRect = MAKE_SDL_RECT(BlitRect.x, BlitRect.y,
+		BlitRect.w, BlitRect.h);
 	this->dirtyRects[0] = clipRect;
 
 	//Continue effect.


### PR DESCRIPTION
…e move will put the sword outside the edge + no longer  draws over UI when moving sword from outside the room + fixed assertion when an armed entity falls to its death but their sword is outside the room edges

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=41878&page=0#435874)