### PR TITLE
SwordsInRoom cache in Character was not cleared at the start of the t…

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -1109,6 +1109,10 @@ void CCharacter::Process(
 	if (this->wCurrentCommandIndex >= this->commands.size())
 		goto Finish;
 
+	//Sword cache must be cleared to avoid using state of the room from some other entity's
+	//turn and/or being blocked by this character's own weapon
+	this->swordsInRoom.Clear();
+
 	//Only character monsters taking up a single tile are implemented.
 	ASSERT(!bIsSerpentOrGentryii(GetResolvedIdentity()));
 
@@ -3043,7 +3047,6 @@ bool CCharacter::GetMovement(
 	const bool bAllowTurning)
 {
 	bPathmapping = false;
-	this->swordsInRoom.Clear();
 
 	bool bStopTurn = false;
 	switch (this->movementIQ)


### PR DESCRIPTION
…urn meaning that command IsOpenMove could use sword coords generated by, for example, Citizen. Which could cause 2 problems:

Sword state of the room could've changed meaning it would query outdated data

The sword cache would include the character's own sword meaning it would return false when asking if it can move into its own sword

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=41319)