### PR TITLE
A big rewrite of FaceWidget.

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5499,9 +5499,8 @@ void CCharacterDialogWidget::SetCharacterWidgetStates()
 		static const UINT CY_TILES = 6 * CDrodBitmapManager::CY_TILE;
 
 		pCharGraphicList->SelectItem(pChar->wType);
-		pFace->SetCharacter(getSpeakerType(MONSTERTYPE(pChar->wType)), false);
+		pFace->SetCharacter(FaceWidgetLayer::PlayerRole, getSpeakerType(MONSTERTYPE(pChar->wType)), pChar);
 		pDefaultAvatar->Enable(pChar->dwDataID_Avatar != 0);
-		pFace->SetImage(pChar->dwDataID_Avatar);
 
 		const bool bHasTiles = pChar->dwDataID_Tiles != 0;
 		pDefaultTiles->Enable(bHasTiles);
@@ -5527,8 +5526,8 @@ void CCharacterDialogWidget::SetCharacterWidgetStates()
 		IDtext += _itoW(pChar->dwCharID, temp, 10);
 		pIDLabel->SetText(IDtext.c_str());
 	} else {
-		pFace->SetCharacter(getSpeakerType(
-				MONSTERTYPE(pCharGraphicList->GetSelectedItem())), false);
+		pFace->SetCharacter(FaceWidgetLayer::PlayerRole, getSpeakerType(
+				MONSTERTYPE(pCharGraphicList->GetSelectedItem())), NULL);
 		pDefaultAvatar->Disable();
 		pDefaultTiles->Disable();
 		pAnimateSpeed->SetText(wszEmpty);

--- a/DROD/CreditsScreen.cpp
+++ b/DROD/CreditsScreen.cpp
@@ -155,7 +155,7 @@ void CCreditsScreen::SetForActivateStart()
 #	define A_FACEIMAGE(eSpeaker) { \
 	SDL_Surface *pFaceSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, CX_FACE, CY_FACE, g_pTheBM->BITS_PER_PIXEL, 0, 0, 0, 0); \
 	this->pFaceWidget->SetDestSurface(pFaceSurface); \
-	this->pFaceWidget->SetCharacter(eSpeaker, false); \
+	this->pFaceWidget->SetCharacter(FaceWidgetLayer::PlayerRole, eSpeaker, NULL); \
 	this->pFaceWidget->Paint(); \
 	CImageWidget *pImage = new CImageWidget(0, (this->pScrollingText->GetW()-CX_FACE)/2, 0, pFaceSurface); \
 	this->pScrollingText->Add(pImage); }

--- a/DROD/FaceWidget.cpp
+++ b/DROD/FaceWidget.cpp
@@ -131,18 +131,16 @@ CFaceWidget::CFaceWidget(
 	const int nSetX, const int nSetY,               //    constructor.
 	const UINT wSetW, const UINT wSetH)             //
 	: CWidget((WIDGETTYPE)WT_Face, dwSetTagNo, nSetX, nSetY, wSetW, wSetH)
-	, eSpeaker(Speaker_Beethro)
-	, eMood(Mood_Normal), ePrevMood(Mood_Normal)
-	, dwDelayMood(0), dwStartDelayMood(0)
-	, bMoodDrawn(false), bIsReading(false), bIsBlinking(false), bIsSleeping(false)
-	, bDoBlink(false), bIsDeathAnimation(false)
-	, eMoodSEID(SEID_NONE)
-	, bMoodLocked(false)
 	, nPupilX(0), nPupilY(0), nPupilTargetX(0), nPupilTargetY(0)
 	, dwLastFrame(0), bAlwaysPaintFull(false)
-	, pImage(NULL), dwImageID(0)
+	, pImage(NULL)
+	, facePlayer(Face(PlayerRole))
+	, faceSpeaker(Face(Speaker))
+	, faceDying(Face(Death))
 {
 	this->imageFilenames.push_back(string("Faces"));
+
+	this->facePlayer.bIsActive = true;
 }
 
 //****************************************************************************
@@ -154,19 +152,22 @@ CFaceWidget::~CFaceWidget()
 }
 
 //****************************************************************************
-SDL_Rect* CFaceWidget::getEyeMask() const {
-	return GetCharacter() == Speaker_Gunthro ? m_GunthroEyeMaskRectArray + this->eMood : m_EyeMaskRectArray + this->eMood;
+SDL_Rect* CFaceWidget::getEyeMask() {
+	const Face* face = GetActiveFace();
+	return face->eCharacter == Speaker_Gunthro ? m_GunthroEyeMaskRectArray + face->eMood : m_EyeMaskRectArray + face->eMood;
 }
 
-const CFaceWidget::POINT* CFaceWidget::getEyeMaskOffset() const {
-	return GetCharacter() == Speaker_Gunthro ? m_GunthroEyeMaskOffsetArray + this->eMood : m_EyeMaskOffsetArray + this->eMood;
+const CFaceWidget::POINT* CFaceWidget::getEyeMaskOffset() {
+	const Face* face = GetActiveFace();
+	return face->eCharacter == Speaker_Gunthro ? m_GunthroEyeMaskOffsetArray + face->eMood : m_EyeMaskOffsetArray + face->eMood;
 }
 
-UINT CFaceWidget::getBetweenPupils() const {
-	if (GetCharacter() != Speaker_Gunthro)
+UINT CFaceWidget::getBetweenPupils() {
+	const Face* face = GetActiveFace();
+	if (face->eCharacter != Speaker_Gunthro)
 		return CX_BETWEEN_PUPILS;
 
-	switch (this->eMood) {
+	switch (face->eMood) {
 		case Mood_Aggressive:
 		case Mood_Strike:
 			return CX_BETWEEN_PUPILS_GUNTHRO_AGG;
@@ -174,13 +175,37 @@ UINT CFaceWidget::getBetweenPupils() const {
 	}
 }
 
+Face* CFaceWidget::GetFace(const FaceWidgetLayer layer) {
+	switch (layer) {
+		case Speaker: return &faceSpeaker;
+		case Death: return &faceDying;
+		case PlayerRole:
+		default:
+			return &facePlayer;
+	}
+}
+
+const FaceWidgetLayer CFaceWidget::GetActiveLayer() const{
+	if (faceSpeaker.bIsActive)
+		return faceSpeaker.eLayer;
+
+	if (faceDying.bIsActive)
+		return faceDying.eLayer;
+	
+	return facePlayer.eLayer;
+}
+
+Face* CFaceWidget::GetActiveFace() {
+	return GetFace(GetActiveLayer());
+}
+
 //****************************************************************************
-bool CFaceWidget::IsSpeakerAnimated() const
+bool CFaceWidget::IsSpeakerAnimated(const Face* face) const
 //Returns: whether current character face is animated
 {
-	const SPEAKER speaker = GetCharacter();
-	return (speaker == Speaker_Beethro || speaker == Speaker_Gunthro ||
-			speaker == Speaker_Clone ||	speaker == Speaker_BeethroInDisguise) && !this->dwImageID;
+	const SPEAKER eSpeaker = face->eCharacter;
+	return (eSpeaker == Speaker_Beethro || eSpeaker == Speaker_Gunthro ||
+			eSpeaker == Speaker_Clone || eSpeaker == Speaker_BeethroInDisguise) && !face->dwImageID;
 }
 
 //****************************************************************************
@@ -188,46 +213,34 @@ void CFaceWidget::SetCharacter(
 //Sets the character face shown.
 //
 //Params:
+    const FaceWidgetLayer eLayer, //(in) layer on which the character is set
 	const SPEAKER eSpeaker,    //(in) speaker to display
-	const bool bLockMood)      //(in) whether to disallow changing mood
+	const HoldCharacter* pHoldCharacter) //(in) hold character if speaker is a custom character
 {
 	ASSERT(eSpeaker < Speaker_Count);
-	this->eSpeaker = eSpeaker;
-	this->bMoodLocked = bLockMood;
-	this->bMoodDrawn = false;
+	Face* face = GetFace(eLayer);
+	ASSERT(face);
+	face->eCharacter = eSpeaker;
+	face->pHoldCharacter = pHoldCharacter;
+	face->dwImageID = pHoldCharacter
+		? pHoldCharacter->dwDataID_Avatar
+		: 0;
+	face->bIsDrawn = false;
 
-	this->pImage = NULL; //stop showing custom image
-	this->dwImageID = 0;
-}
-
-//****************************************************************************
-void CFaceWidget::SetImage(const UINT dwDataID)
-//Sets the face widget to indicated image in DB.
-{
-	if (!dwDataID)
-		return;
-
-	if (dwDataID == this->dwImageID)
-		return; //image is already being displayed
-
-	//Is image already loaded into face widget?
-	SDL_Surface *pSurface;
-	SurfaceMap::iterator id = this->faceImages.find(dwDataID);
-	if (id != this->faceImages.end())
-		pSurface = id->second;
-	else
-	{
-		//No -- load image into face widget.
-		pSurface = g_pTheDBM->LoadImageSurface(dwDataID);
-		if (pSurface)
-			this->faceImages[dwDataID] = pSurface;
+	if (face->dwImageID) {
+		const UINT dwDataID = face->dwImageID;
+		SDL_Surface* pSurface;
+		SurfaceMap::iterator id = this->faceImages.find(dwDataID);
+		if (id != this->faceImages.end())
+			pSurface = id->second;
+		else
+		{
+			//No -- load image into face widget.
+			pSurface = g_pTheDBM->LoadImageSurface(dwDataID);
+			if (pSurface)
+				this->faceImages[dwDataID] = pSurface;
+		}
 	}
-
-	//Show image.
-	this->pImage = pSurface;
-	this->dwImageID = dwDataID;
-	this->bMoodLocked = true;
-	this->bMoodDrawn = false;
 }
 
 //****************************************************************************
@@ -235,24 +248,31 @@ void CFaceWidget::SetMood(
 //Sets the mood state of the face.
 //
 //Params:
+	const FaceWidgetLayer eLayer, //(in) Layer to modify
 	const MOOD eSetMood,       //(in) Mood to show
-	const Uint32 lDelay,       //(in) Amount of time in msecs to pass before mood reverts to previous. [default=0 ms]
-	const bool bOverrideLock)  //(in) [default=false]
+	const Uint32 lDelay)       //(in) Amount of time in msecs to pass before mood reverts to previous. [default=0 ms]
 {
-	if (this->bMoodLocked && !bOverrideLock) return;
+	Face* face = GetFace(eLayer);
 
-	if ((this->ePrevMood != eSetMood) && !this->dwDelayMood) //keep track of previous mood for temporary changes in expression
-		this->ePrevMood = this->eMood;   //only keep track of previous mood if it isn't a temporary one
+	const bool bHasTemporaryMood = face->eMoodSEID != SEID_NONE || face->dwMoodUntil > 0;
 
-	if (this->eMood != eSetMood)
-	{
-		//Mood has changed.
-		this->eMood = eSetMood;
-		this->bMoodDrawn = false;  //haven't drawn new mood yet
+	// No temporary mood and the new mood is the same to the old? No need to do anything
+	if (!bHasTemporaryMood && eSetMood == face->eMood)
+		return;
+
+	if (lDelay) {
+		if (face->eMoodSEID != SEID_NONE) // Sound-based temporary mood takes priority, do nothing
+			return;
+
+		face->dwMoodUntil = SDL_GetTicks() + lDelay;
 	}
 
-	SetMoodDelay(lDelay);
-	this->bIsSleeping = false;
+	if (!bHasTemporaryMood)
+		face->ePrevMood = face->eMood;
+
+	face->eMood = eSetMood;
+	face->bIsDrawn = false;
+	face->bIsSleeping = false;
 }
 
 //*****************************************************************************
@@ -260,51 +280,71 @@ void CFaceWidget::SetMoodToSoundEffect(
 //Sets mood state of the face.  Mood will last until a sound effect finishes playing.
 //
 //Params:
+	const FaceWidgetLayer eLayer, //(in) Layer to modify
 	MOOD eSetMood,    //(in)   Mood to show.
 	SEID eUntilSEID)  //(in)   Sound effect to show mood during.
 {
 	ASSERT(eUntilSEID > SEID_NONE && eUntilSEID < SEID_COUNT);
 
-	this->eMoodSEID = eUntilSEID;
-	if (this->eMood != eSetMood)
-	{
-		//Mood has changed.
-		this->ePrevMood = this->eMood;  //keep track of previous mood
-		this->eMood = eSetMood;
-		this->bMoodDrawn = false;  //haven't drawn new mood yet
-	}
-}
+	Face* face = GetFace(eLayer);
 
-//*****************************************************************************
-void CFaceWidget::SetMoodDelay(
-//Changes mood for a specified amount of time.
-//
-//Accepts:
-  const Uint32 dwDelay)          //(in) Amount of time in msecs to pass before mood reverts to previous.
-{
-	this->dwDelayMood = dwDelay;
-	this->dwStartDelayMood = SDL_GetTicks();
+	const bool bHasTemporaryMood = face->eMoodSEID != SEID_NONE || face->dwMoodUntil > 0;
+	face->eMoodSEID = eUntilSEID;
+
+	// No temporary mood and the new mood is the same to the old? No need to do anything
+	if (!bHasTemporaryMood && eSetMood == face->eMood)
+		return;
+
+	if (!bHasTemporaryMood)
+		face->ePrevMood = face->eMood;
+
+	face->eMood = eSetMood;
+	face->bIsDrawn = false;
+	face->bIsSleeping = false;
 }
 
 //****************************************************************************
-void CFaceWidget::SetIsDeathAnimation(const bool bIsDeathAnimation)
+void CFaceWidget::SetDying(const bool bIsDying, MOOD eDyingMood)
 {
-	this->bIsDeathAnimation = bIsDeathAnimation;
+	faceDying.bIsActive = bIsDying;
+	faceDying.pHoldCharacter = NULL;
+
+	if (bIsDying) {
+		faceDying.eMood = eDyingMood;
+		faceDying.eCharacter = facePlayer.eCharacter;
+		faceDying.dwImageID = facePlayer.dwImageID;
+		faceDying.bIsDrawn = false;
+	}
+}
+
+//****************************************************************************
+void CFaceWidget::SetSpeaker(
+	const bool bIsSpeaking,
+	const SPEAKER eSpeaker,
+	const HoldCharacter* pHoldCharacter,
+	MOOD eSpeakingMood)
+{
+	faceSpeaker.bIsActive = bIsSpeaking;
+	faceSpeaker.pHoldCharacter = NULL;
+
+	if (bIsSpeaking) {
+		SetCharacter(Speaker, eSpeaker, pHoldCharacter);
+		SetMood(Speaker, eSpeakingMood);
+	}
 }
 
 //****************************************************************************
 void CFaceWidget::SetReading(const bool bReading)
 {
-	this->bIsReading = bReading;
+	facePlayer.bIsReading = bReading;
 }
 
 //****************************************************************************
 void CFaceWidget::SetSleeping()
 {
-	SetMood(Mood_Talking);
-	this->bIsSleeping = true;
-	this->bIsBlinking = true;
-	this->bMoodDrawn = false;
+	facePlayer.bIsSleeping = true;
+	facePlayer.bIsBlinking = true;
+	facePlayer.bIsDrawn = false;
 }
 
 //****************************************************************************
@@ -313,11 +353,12 @@ void CFaceWidget::DrawPupils()
 {
 	SDL_Surface *pDestSurface = LockDestSurface();
 
+	const Face* face = GetActiveFace();
 	//Draw left pupil.
 	const UINT CX_LEFT_PUPIL_OFFSET =
-		m_LeftPupilOffsetArray[this->eMood].x - CX_PUPIL_HALF + this->nPupilX;
+		m_LeftPupilOffsetArray[face->eMood].x - CX_PUPIL_HALF + this->nPupilX;
 	const UINT CY_PUPIL_OFFSET =
-		m_LeftPupilOffsetArray[this->eMood].y - CY_PUPIL_HALF + this->nPupilY;
+		m_LeftPupilOffsetArray[face->eMood].y - CY_PUPIL_HALF + this->nPupilY;
 
 	DrawPupils_DrawOnePupil(pDestSurface,
 
@@ -355,7 +396,6 @@ void CFaceWidget::DrawPupils_DrawOnePupil(
 	SDL_Surface *pDestSurface,       //(in)   Already-locked surface.
 	const int nDestX, const int nDestY, //(in)   Dest coords.
 	const int nMaskX, const int nMaskY) //(in)   Mask coords.
-const
 {
 	//I am going to copy pixels from a source surface to a dest surface.
 	//The source surface contains the pupil image.  A mask surface contains
@@ -385,7 +425,8 @@ const
 	ASSERT(pDestSurface->format->Bmask == 0x0000ff);
 #endif
 
-	const bool bGunthro = GetCharacter() == Speaker_Gunthro;
+	const Face* face = GetActiveFace();
+	const bool bGunthro = face->eCharacter == Speaker_Gunthro;
 	const int xPupil = bGunthro ? X_PUPIL_GUNTHRO : X_PUPIL;
 	const UINT cyPupil = bGunthro ? CY_GUNTHRO_PUPIL : CY_PUPIL;
 
@@ -444,8 +485,9 @@ void CFaceWidget::MovePupils(
 //Params:
 	const UINT wLookAtX, const UINT wLookAtY) //optional screen position to look at [default=(-1,-1)]
 {
-	const bool is_gunthro = GetCharacter() == Speaker_Gunthro;
+	const bool is_gunthro = GetActiveFace()->eCharacter == Speaker_Gunthro;
 
+	Face* face = GetActiveFace();
 	int xRightBound = CX_PUPIL - 1;
 	int xLeftBound = -xRightBound;
 	int yBottomBound = (getEyeMask()->h - CY_PUPIL - CY_PUPIL) / 2;
@@ -454,12 +496,12 @@ void CFaceWidget::MovePupils(
 		xRightBound -= 1;
 		xLeftBound -= 1;
 		yTopBound -= 3;
-		if (this->eMood == Mood_Aggressive)
+		if (face->eMood == Mood_Aggressive)
 			yBottomBound -= 1;
 	} else {
-		if (this->eMood == Mood_Nervous)
+		if (face->eMood == Mood_Nervous)
 			yTopBound += 2; //Nervous mood has big eye corners that pupils can disappear into.
-		if (this->eMood == Mood_Happy)
+		if (face->eMood == Mood_Happy)
 			yTopBound += 1; //Happy mood--same thing, but corners are a little smaller.
 	}
 
@@ -475,7 +517,7 @@ void CFaceWidget::MovePupils(
 		bTarget = true;
 	}
 
-	if (this->bIsReading)
+	if (face->bIsReading)
 	{
 		//Scroll eyes across as if reading.
 		if (--(this->nPupilX) < xLeftBound)
@@ -487,7 +529,7 @@ void CFaceWidget::MovePupils(
 	}
 	else
 	{
-		switch (this->eMood)
+		switch (face->eMood)
 		{
 			case Mood_Dying:
 			case Mood_Strike:
@@ -500,7 +542,7 @@ void CFaceWidget::MovePupils(
 				//Figure out the relaxation level.  Higher value means
 				//that the pupils are less likely to move around.
 				int nRelaxationLevel;
-				switch (this->eMood)
+				switch (face->eMood)
 				{
 					case Mood_Happy: case Mood_Talking: nRelaxationLevel = 6; break;
 					case Mood_Aggressive: case Mood_Nervous: nRelaxationLevel = 0; break;
@@ -571,36 +613,37 @@ void CFaceWidget::PaintClipped(
 }
 
 //*****************************************************************************
-FACE_FRAME CFaceWidget::ResolveFace()
+FACE_FRAME CFaceWidget::ResolveFaceFrame(Face *face)
 {
 	//Figure out what face frame to use.
 	//Select src image based on this->eSpeaker.
+	ASSERT(face);
 
 	FACE_FRAME eFrame = FF_Normal;
-	if (this->dwImageID)
+	if (face->dwImageID)
 		return eFrame;
 
-	switch (this->eSpeaker)
+	switch (face->eCharacter)
 	{
 		case Speaker_Clone:
 		case Speaker_Beethro:
 		case Speaker_BeethroInDisguise:
-		switch (this->eMood)
+		switch (face->eMood)
 		{
 			case Mood_Normal:
-				eFrame = this->bIsBlinking ? FF_Normal_Blinking : FF_Normal;
+				eFrame = face->bIsBlinking ? FF_Normal_Blinking : FF_Normal;
 			break;
 			case Mood_Aggressive:
-				eFrame = this->bIsBlinking ? FF_Aggressive_Blinking : FF_Aggressive;
+				eFrame = face->bIsBlinking ? FF_Aggressive_Blinking : FF_Aggressive;
 			break;
 			case Mood_Nervous:
-				eFrame = this->bIsBlinking ? FF_Nervous_Blinking : FF_Nervous;
+				eFrame = face->bIsBlinking ? FF_Nervous_Blinking : FF_Nervous;
 			break;
 			case Mood_Happy:
-				eFrame = this->bIsBlinking ? FF_Happy_Blinking : FF_Happy;
+				eFrame = face->bIsBlinking ? FF_Happy_Blinking : FF_Happy;
 			break;
 			case Mood_Talking:
-				eFrame = this->bIsBlinking ? FF_Talking_Blinking : FF_Talking;
+				eFrame = face->bIsBlinking ? FF_Talking_Blinking : FF_Talking;
 			break;
 			case Mood_Strike:
 				eFrame = FF_Striking;
@@ -629,22 +672,22 @@ FACE_FRAME CFaceWidget::ResolveFace()
 		break;
 
 		case Speaker_Gunthro:
-		switch (this->eMood)
+		switch (face->eMood)
 		{
 			case Mood_Normal:
-				eFrame = this->bIsBlinking ? FF_GNormal_Blinking : FF_GunthroNormal;
+				eFrame = face->bIsBlinking ? FF_GNormal_Blinking : FF_GunthroNormal;
 			break;
 			case Mood_Aggressive:
-				eFrame = this->bIsBlinking ? FF_GAggressive_Blinking : FF_GAggressive;
+				eFrame = face->bIsBlinking ? FF_GAggressive_Blinking : FF_GAggressive;
 			break;
 			case Mood_Nervous:
-				eFrame = this->bIsBlinking ? FF_GNervous_Blinking : FF_GNervous;
+				eFrame = face->bIsBlinking ? FF_GNervous_Blinking : FF_GNervous;
 			break;
 			case Mood_Happy:
-				eFrame = this->bIsBlinking ? FF_GHappy_Blinking : FF_GHappy;
+				eFrame = face->bIsBlinking ? FF_GHappy_Blinking : FF_GHappy;
 			break;
 			case Mood_Talking:
-				eFrame = this->bIsBlinking ? FF_GTalking_Blinking : FF_GTalking;
+				eFrame = face->bIsBlinking ? FF_GTalking_Blinking : FF_GTalking;
 			break;
 			case Mood_Strike:
 				eFrame = FF_GStriking;
@@ -675,7 +718,7 @@ FACE_FRAME CFaceWidget::ResolveFace()
 		//Speakers with a few moods implemented.
 		case Speaker_Halph:
 		case Speaker_Halph2:
-		switch (this->eMood)
+		switch (face->eMood)
 		{
 			case Mood_Aggressive: eFrame = FF_HalphAggressive; break;
 			case Mood_Nervous: eFrame = FF_HalphNervous; break;
@@ -756,9 +799,9 @@ void CFaceWidget::Paint(
 //
 //Params:
 	bool bUpdateRect)             //(in)   If true (default) and destination
-										//    surface is the screen, the screen
-										//    will be immediately updated in
-										//    the widget's rect.
+								  //       surface is the screen, the screen
+								  //       will be immediately updated in
+								  //       the widget's rect.
 {
 	//Drawing code below needs to be modified to accept offsets.  Until then,
 	//this widget can't be offset.
@@ -767,47 +810,45 @@ void CFaceWidget::Paint(
 	//Make things easy and insist on standard width and height.
 	ASSERT(this->w == CX_FACE && this->h == CY_FACE);
 
-	SDL_Surface *pDestSurface = GetDestSurface();
-	SDL_Rect Dest = MAKE_SDL_RECT(this->x, this->y, this->w, this->h);
+	PaintFace(GetActiveFace());
 
-	const bool bWasBlinking = this->bIsBlinking;
-	if (!this->bIsSleeping)
-	{
-		if (this->bIsBlinking || this->bIsDeathAnimation)
-			this->bIsBlinking = false;
-		else
-		{
-			if (this->eMood == Mood_Strike || this->eMood == Mood_Dying)
-				this->bIsBlinking = false; //No blinking in these moods.
-			else
-				this->bIsBlinking = this->bDoBlink || ((rand() % 20) == 0);
-		}
-	}
-	this->bDoBlink = false;
+	if (bUpdateRect) UpdateRect();
+}
+
+//******************************************************************************
+void CFaceWidget::PaintFace(
+	//Paint the provided face
+	//Params:
+	Face* face
+) {
+	SDL_Surface* pDestSurface = GetDestSurface();
+	SDL_Rect Dest = MAKE_SDL_RECT(this->x, this->y, this->w, this->h);
 
 	//Figure out what face frame to use.
 	//Select src image based on this->eSpeaker.
-	FACE_FRAME eFrame = ResolveFace();
+	FACE_FRAME eFrame = ResolveFaceFrame(face);
 
 	//Blit entire face frame if needed.
-	const bool bDrawPupils = IsSpeakerAnimated() && !this->bIsBlinking;
-	if (this->bAlwaysPaintFull ||
-			!this->bMoodDrawn || this->bIsBlinking != bWasBlinking ||
-			this->eMood == Mood_Dying)
+	const bool bDrawPupils = IsSpeakerAnimated(face) && !face->bIsBlinking;
+	if (
+		this->bAlwaysPaintFull
+		|| !face->bIsDrawn
+		|| face->eMood == Mood_Dying) // For simplicity always animate death
 	{
 		//Draw special image, if set.
-		if (this->pImage)
+		if (face->dwImageID)
 		{
 			SDL_Rect Src = MAKE_SDL_RECT(0, 0, this->w, this->h);
-			SDL_BlitSurface(this->pImage, &Src, pDestSurface, &Dest);
-		} else {
+			SDL_BlitSurface(this->faceImages[face->dwImageID], &Src, pDestSurface, &Dest);
+		}
+		else {
 			//Bounds check -- just revert to default if this face frame is not loaded.
 			if (eFrame == FF_Default || yFace(eFrame) >= (UINT)this->images[0]->h)
 			{
-				if (this->eSpeaker != Speaker_Beethro)
+				if (face->eCharacter != Speaker_Beethro)
 				{
-					this->eSpeaker = Speaker_Beethro;
-					Paint(bUpdateRect);
+					face->eCharacter = Speaker_Beethro;
+					PaintFace(face);
 				}
 				return;
 			}
@@ -816,7 +857,7 @@ void CFaceWidget::Paint(
 			SDL_BlitSurface(this->images[0], &Src, pDestSurface, &Dest);
 		}
 
-		this->bMoodDrawn = true;
+		face->bIsDrawn = true;
 	}
 	else if (bDrawPupils)
 	{
@@ -824,33 +865,21 @@ void CFaceWidget::Paint(
 		//So I will first blit the eye mask area to the dest surface on which
 		//the pupils will be drawn below.  This is how the current pupils
 		//are "erased".
-		SDL_Rect EyeMaskSrc = {static_cast<Sint16>(xFace(eFrame) + getEyeMaskOffset()->x),
+		SDL_Rect EyeMaskSrc = { static_cast<Sint16>(xFace(eFrame) + getEyeMaskOffset()->x),
 			static_cast<Sint16>(yFace(eFrame) + getEyeMaskOffset()->y),
-			getEyeMask()->w, getEyeMask()->h};
-		SDL_Rect EyeMaskDest = {static_cast<Sint16>(this->x + getEyeMaskOffset()->x),
+			getEyeMask()->w, getEyeMask()->h };
+		SDL_Rect EyeMaskDest = { static_cast<Sint16>(this->x + getEyeMaskOffset()->x),
 			static_cast<Sint16>(this->y + getEyeMaskOffset()->y),
-			EyeMaskSrc.w, EyeMaskSrc.h};
+			EyeMaskSrc.w, EyeMaskSrc.h };
 		SDL_BlitSurface(this->images[0], &EyeMaskSrc, pDestSurface, &EyeMaskDest);
 	}
 
 	//Draw the pupils if needed.
 	if (bDrawPupils)
 	{
-		//Move pupils over time.
-		static const Uint32 dwPupilFrameLength = 200;	//ms
-		const Uint32 dwNow = SDL_GetTicks();
-		if (dwNow - this->dwLastFrame > dwPupilFrameLength)
-		{
-			MovePupils();
-			this->dwLastFrame = dwNow;
-		}
-
 		DrawPupils();
 	}
-
-	if (bUpdateRect) UpdateRect();
 }
-
 //
 //Protected methods.
 //
@@ -859,37 +888,74 @@ void CFaceWidget::Paint(
 void CFaceWidget::HandleAnimate()
 //Handle animation of the widget.
 {
+	const Face* face = GetActiveFace();
 	const Uint32 dwNow = SDL_GetTicks();
 
-	//After timing of a temporary face is done (i.e., happy for a moment after
-	//a monster kill) go back to previous mood
-	if (  (this->eMood != this->ePrevMood) && (
-
-			//Check for specified time elapsed.
-			(this->dwDelayMood > 0 &&
-			dwNow - this->dwStartDelayMood > this->dwDelayMood) ||
-
-			//Check for sound effect finished.
-			(this->eMoodSEID != SEID_NONE &&
-			!g_pTheSound->IsSoundEffectPlaying(this->eMoodSEID))
-		))
-	{
-		//Set members so that face will be redrawn below in new mood.
-		this->eMood = this->ePrevMood;
-		this->eMoodSEID = SEID_NONE;
-		this->dwDelayMood = 0;
-		this->bMoodDrawn = false;
-	}
+	static const Uint32 dwFrameLength = 200;	//ms
+	const bool bFrameEnded = dwNow - this->dwLastFrame > dwFrameLength;
+	const bool bForceDraw = !GetActiveFace()->bIsDrawn;
 
 	//Animate widget 
 	//Animation frame rate is slower (probably) than screen animation rate.
-	static const Uint32 dwFrameLength = 200;	//ms
-	if (!this->bMoodDrawn ||
-		(IsSpeakerAnimated() && dwNow - this->dwLastFrame > dwFrameLength))
+	if (bForceDraw || bFrameEnded)
 	{
+		// Blinking should always take one animation frame to ensure it looks decent
+		if (bFrameEnded && (rand() % 20) == 0) {
+			this->bDoBlink = true;
+		}
+
+		HandleAnimateFace(&facePlayer);
+		HandleAnimateFace(&faceSpeaker);
+		HandleAnimateFace(&faceDying);
+		MovePupils();
+
+		faceDying.bIsBlinking = false; // Never blink on death
+
+		if (bFrameEnded) {
+			this->bDoBlink = false;
+			this->dwLastFrame = dwNow;
+		}
+
 		RequestPaint(true);
-		this->dwLastFrame = dwNow;
 	}
+}
+
+//******************************************************************************
+void CFaceWidget::HandleAnimateFace(Face* face)
+//Handle animation of the widget.
+{
+	const Uint32 dwNow = SDL_GetTicks();
+
+	const bool bHasMoodTimedOut = face->dwMoodUntil > 0 && dwNow > face->dwMoodUntil;
+	const bool bHasMoodSoundFinished = face->eMoodSEID != SEID_NONE && !g_pTheSound->IsSoundEffectPlaying(face->eMoodSEID);
+
+	//After timing of a temporary face is done (i.e., happy for a moment after
+	//a monster kill) go back to previous mood
+	if (bHasMoodTimedOut || bHasMoodSoundFinished)
+	{
+		// Only redraw mood if the old mood was different from the temporary one
+		if (face->eMood != face->ePrevMood)
+			face->bIsDrawn = false;
+
+		//Cleanup all timing data
+		face->eMood = face->ePrevMood;
+		face->eMoodSEID = SEID_NONE;
+		face->dwMoodUntil = 0;
+	}
+
+	const bool bWasBlinking = face->bIsBlinking;
+	if (!face->bIsSleeping)
+	{
+		if (face->bIsBlinking)
+			face->bIsBlinking = false;
+		else if (face->eMood == Mood_Strike || face->eMood == Mood_Dying)
+			face->bIsBlinking = false; //No blinking in these moods.
+		else
+			face->bIsBlinking = this->bDoBlink;
+	}
+
+	if (bWasBlinking != face->bIsBlinking)
+		face->bIsDrawn = false;
 }
 
 //*****************************************************************************
@@ -904,14 +970,15 @@ void CFaceWidget::HandleMouseUp(const SDL_MouseButtonEvent &Button)
 		//Clicking on eyes makes face blink.
 		this->bDoBlink = true;
 	} else {
+		Face* face = GetActiveFace();
 		//Briefly show a random mood.
-		if (!this->bIsSleeping)
+		if (!face->bIsSleeping)
 		{
 			MOOD eMood;
 			do {
 				eMood = (MOOD)(rand()%Mood_Count);
-			} while (eMood == this->eMood);
-			SetMood(eMood, 300);
+			} while (eMood == face->eMood);
+			SetMood(face->eLayer, eMood, 300);
 			RequestPaint();
 		}
 	}

--- a/DROD/GameScreen.h
+++ b/DROD/GameScreen.h
@@ -175,7 +175,8 @@ private:
 	void           ShowBigMap();
 	void           ShowDemosForRoom(const UINT roomID);
 	void           ShowLockIcon(const bool bShow=true);
-	void           ShowPlayerFace(const bool bOverrideLock=false, const bool bLockMood=false);
+	void           UpdatePlayerFace();
+	void           ResolvePlayerFace(SPEAKER& pSpeaker, HoldCharacter **playerHoldCharacter);
 	void           ShowRoom(CCurrentGame *pGame, CCueEvents& CueEvents);
 	void           ShowRoomTemporarily(const UINT roomID);
 	void           ShowSpeechLog();

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -57,6 +57,9 @@ void CCharacterCommand::swap(CCharacterCommand &that) {
 SPEAKER getSpeakerType(const MONSTERTYPE eType)
 //Return: corresponding speaker enumeration for monster type, if supported.
 {
+	if (eType > CUSTOM_CHARACTER_FIRST)
+		return Speaker_HoldCharacter;
+
 	switch (eType)
 	{
 		//Character monster psuedo-types.

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -77,7 +77,9 @@ enum SPEAKER
 	Speaker_TemporalClone=57,
 	Speaker_FluffBaby=58,
 
-	Speaker_Count=59
+	Speaker_Count=59,
+
+	Speaker_HoldCharacter = static_cast<UINT>(-1)
 };
 
 //Flags bits.


### PR DESCRIPTION
Why: I was chasing a bug, where the game would not switch back from custom image avatar to a built-in avatar if you changed player roles. Then when I fixed it something else broke. And then I fix what broke and yet another thing broke. Then I realized the way FaceWidget is written and used is flawed in two ways.

Flaw 1 - trying to fit as much state in as few variables. There was the whole thing with locking moods which was made to not have to have separate set of variables for speakers, which was the main source of issues.

Flaw 2 - a lot of logic that belonged in `FaceWidget` was spread around `GameScreen` , specifically figuring out how to manipulate the moods and the locks.

Analysis - when you think about it, there are essentially three differnt things displayed in the widget. Player's face, Speaker's face and Dying face. Technically Dying face is Player's face but because it behaves slightly differently (it has no special state beyond 'I am active') I think it makes sense to keep it separate to avoid issue.

Solution - there is a new struct that holds Face's state, and all the logic in `GameScreen` that previously had to do weird stuff to figure out how to manipulate the state to get the desired effect just directly tells the widget what to do and which face layer to modify. Speech on start enables Speech face, and disables it when speech ends. Ditto for dying. I think the solution is much more elegant, though there are likely ways to improve it still.

----

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=38410)