### PR TITLE
Temporal projection preview will now reverse direction in the middle …

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -7730,14 +7730,14 @@ void CRoomWidget::AddTemporalCloneNextMoveEffect(const CTemporalClone *pTC, cons
 	const UINT apparentIdentity = getApparentIdentity(logicalIdentity);
 	const UINT wTI = GetEntityTile(apparentIdentity, logicalIdentity, newO, frame);
 
-	CTemporalMoveEffect *pTME = new CTemporalMoveEffect(this, coord, wTI);
+	CTemporalMoveEffect *pTME = new CTemporalMoveEffect(this, coord, wTI, bIsBumpCommand(command));
 	AddMLayerEffect(pTME);
 
 	if (pTC->HasSword()) {
 		coord.wX += nGetOX(newO);
 		coord.wY += nGetOY(newO);
 		const UINT wSwordTI = GetSwordTileFor(pTC, newO, logicalIdentity);
-		pTME = new CTemporalMoveEffect(this, coord, wSwordTI,
+		pTME = new CTemporalMoveEffect(this, coord, wSwordTI, bIsBumpCommand(command),
 				EFFECTLIB::EGENERIC); //don't prevent another similar effect from originating here
 		AddMLayerEffect(pTME);
 	}

--- a/DROD/TemporalMoveEffect.h
+++ b/DROD/TemporalMoveEffect.h
@@ -36,13 +36,14 @@ class CTemporalMoveEffect : public CAnimatedTileEffect
 {
 public:
 	CTemporalMoveEffect(CWidget *pSetWidget,
-		const CMoveCoord &SetCoord, const UINT wTI, const UINT type=ETEMPORALMOVE);
+		const CMoveCoord &SetCoord, const UINT wTI, const bool isBump, const UINT type=ETEMPORALMOVE);
 
 	virtual bool Draw(SDL_Surface* pDestSurface=NULL);
 
 private:
 	UINT startX, startY;
 	int deltaX, deltaY;
+	bool isBump;
 
 	Uint32 startDelay, endDelay;
 


### PR DESCRIPTION
…of a bump-command preview + opacity stays 100% until half of the animation to make it more legible

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=38468)