### PR TITLE
Memory usage optimizations

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -1943,6 +1943,7 @@ void CCurrentGame::ProcessCommand(
 
 	//Reset relative movement for the current turn.
 	UpdatePrevCoords();
+	this->pRoom->ClearDeadMonsters(true);
 	this->pRoom->ClearPushStates();
 
 	if (!this->dwCutScene)

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3253,6 +3253,23 @@ bool CDbRoom::KillMonster(
 }
 
 //*****************************************************************************
+void CDbRoom::KillInvisibleCharacter(
+	//Kills an invisible character
+	//
+	//Params:
+	CCharacter* pCharacter) //(in) Character to be removed
+{
+	ASSERT(pCharacter);
+	ASSERT(!pCharacter->IsVisible());
+	ASSERT(pCharacter->IsAlive());
+
+	UnlinkMonster(pCharacter);
+	this->DeadMonsters.push_back(pCharacter);
+
+	pCharacter->bAlive = false;
+}
+
+//*****************************************************************************
 bool CDbRoom::KillMonsterAtSquare(
 //Kills a monster in a specified square.
 //Supports monsters occupying multiple squares.
@@ -8217,16 +8234,38 @@ void CDbRoom::RemoveMonsterFromLayer(CMonster *pMonster)
 }
 
 //*****************************************************************************
-void CDbRoom::ClearDeadMonsters()
+void CDbRoom::ClearDeadMonsters(
+	bool bOnlySafe) //(in) When true will only delete monsters that are marked as safe to delete
 //Frees memory and resets members for dead monster list.
 {
-	for (list<CMonster *>::const_iterator iSeek = this->DeadMonsters.begin();
+	if (bOnlySafe) {
+		// Not the most elegant solution but I think that as long as the loop's logic is this simple
+		// it's fine to leave it as-is
+		list<CMonster*> KeptDeadMonsters;
+		for (list<CMonster*>::const_iterator iSeek = this->DeadMonsters.begin();
+			iSeek != this->DeadMonsters.end(); ++iSeek)
+		{
+			CMonster *pDelete = *iSeek;
+			ASSERT(pDelete);
+			if (pDelete->bSafeToDelete)
+				delete pDelete;
+			else
+				KeptDeadMonsters.push_back(pDelete);
+		}
+
+		this->DeadMonsters.clear();
+		this->DeadMonsters.splice(KeptDeadMonsters.end(), KeptDeadMonsters);
+		return;
+	}
+
+	for (list<CMonster*>::const_iterator iSeek = this->DeadMonsters.begin();
 		iSeek != this->DeadMonsters.end(); ++iSeek)
 	{
 		CMonster *pDelete = *iSeek;
 		ASSERT(pDelete);
 		delete pDelete;
 	}
+	
 	this->DeadMonsters.clear();
 }
 

--- a/DRODLib/DbRooms.h
+++ b/DRODLib/DbRooms.h
@@ -205,7 +205,7 @@ public:
 	void           ChangeTiles(const RoomTokenType tType);
 	void           CharactersCheckForCueEvents(CCueEvents &CueEvents);
 	void           CheckForFallingAt(const UINT wX, const UINT wY, CCueEvents& CueEvents, bool bTrapdoorFell=false);
-	void           ClearDeadMonsters();
+	void           ClearDeadMonsters(bool bOnlySafe = false);
 	void           ClearDeadRoomObjects();
 	void           ClearMonsters(const bool bRetainNonConquerableMonsters=false);
 	void           ClearPlatforms();
@@ -374,6 +374,7 @@ public:
 			const bool bForce=false, const CEntity* pKillingEntity=NULL);
 	bool           KillMonsterAtSquare(const UINT wX, const UINT wY,
 			CCueEvents &CueEvents, const bool bForce=false);
+	void           KillInvisibleCharacter(CCharacter* pCharacter);
 	void           LightFuse(CCueEvents &CueEvents, const UINT wCol, const UINT wRow);
 	void           LightFuseEnd(CCueEvents &CueEvents, const UINT wCol, const UINT wRow);
 	void           LinkMonster(CMonster *pMonster, const bool bInRoom=true, const bool bReverseRule=false);

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -109,6 +109,7 @@ CMonster::CMonster(
 	, bWaitedOnHotFloorLastTurn(false)
 	, pNext(NULL), pPrevious(NULL)
 	, pCurrentGame(NULL)
+	, bSafeToDelete(true)
 {
 	if (pSetCurrentGame)
 		SetCurrentGame(pSetCurrentGame);

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -331,6 +331,7 @@ public:
 	bool          bNewStun; //whether monster stun was inflicted this turn
 	bool          bPushedThisTurn; //whether monster was pushed this turn
 	bool          bWaitedOnHotFloorLastTurn; //for hasteable playerdoubles
+	bool          bSafeToDelete;
 
 	CDbPackedVars ExtraVars;
 	MonsterPieces Pieces;  //when monster fills more than one square


### PR DESCRIPTION
Made CRoom::DeadMonsters list be cleared every turn of monsters that are not needed anymore

And dead/ended invisible scripts are also removed from the room.

Previously DeadMonsters was only cleared once upon room object destruction. This caused issues with rooms that do some really heavy scripting and create a lot of temporary characters. Now dead monsters are deleted every turn, except the ones which must persist for longer because they might be processed by frontend for longer. Notably it seems the only case is Speech.

I've carefully inspected every usage of CueEvents private data and failed to find any other situation where a monster attached to an event is stored for future use except speech. Right now the characters used in speech are not 'released' until the room is deleted which shouldn't be a big deal. Even in the worst case I don't foresee more than a few hundred characters being kept like that

If I wasn't careful enough this may cause problems with accessing deleted monsters somewhere in frontend but I have high hopes it'll be fine.

----

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=39045)
[And another](http://forum.caravelgames.com/viewtopic.php?TopicID=41020&page=0#405452)
@mrimer You know the code base best, do you foresee this causing issues somewhere else?