### PR TITLE
Synchronized Image Overlay effects + multiprocessor compilation

### DIFF
--- a/BackEndLib/BackEndLib.2019.vcxproj
+++ b/BackEndLib/BackEndLib.2019.vcxproj
@@ -211,6 +211,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/CaravelNet/CaravelNet.2019.vcxproj
+++ b/CaravelNet/CaravelNet.2019.vcxproj
@@ -192,6 +192,7 @@
       <ProgramDataBaseFileName>$(Configuration)/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/DROD/DROD.2019.vcxproj
+++ b/DROD/DROD.2019.vcxproj
@@ -139,7 +139,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(Configuration)\</OutDir>
     <IntDir>$(Configuration)-Temp\</IntDir>
-    <LinkIncremental>false</LinkIncremental>
+    <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>true</GenerateManifest>
     <IncludePath>..\Deps\Include;$(IncludePath)</IncludePath>
     <LibraryPath>..\Deps\Library\Release;$(LibraryPath)</LibraryPath>
@@ -277,6 +277,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;WIN32;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -31,6 +31,8 @@
 #include "../DRODLib/CharacterCommand.h"
 #include "../DRODLib/CurrentGame.h"
 
+#include <FrontEndLib/Screen.h>
+
 #include <map>
 #include <string>
 using std::map;
@@ -144,7 +146,7 @@ bool CImageOverlayEffect::Draw(SDL_Surface* pDestSurface)
 
 bool CImageOverlayEffect::AdvanceState()
 {
-	const Uint32 dwNow = SDL_GetTicks();
+	const Uint32 dwNow = CScreen::dwCurrentTicks;
 
 	const Uint32 maxCompletedEndMS = ProcessConcurrentCommands(dwNow);
 
@@ -462,7 +464,7 @@ void CImageOverlayEffect::FinishCommand(const ImageOverlayCommand& command, cons
 		case ImageOverlayCommand::TurnDuration:
 			// This is required for any time-based command that runs afterwards to correctly
 			// calculate the start time
-			this->startOfNextEffect = SDL_GetTicks();
+			this->startOfNextEffect = CScreen::dwCurrentTicks;
 			break;
 		default: break;
 	}

--- a/DRODLib/DRODLib.2019.vcxproj
+++ b/DRODLib/DRODLib.2019.vcxproj
@@ -231,6 +231,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -171,6 +171,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;WIN32;UNICODE;CARAVELBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/DRODUtil/DRODUtil.2019.vcxproj
+++ b/DRODUtil/DRODUtil.2019.vcxproj
@@ -233,6 +233,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/FrontEndLib/EventHandlerWidget.cpp
+++ b/FrontEndLib/EventHandlerWidget.cpp
@@ -207,6 +207,7 @@ void CEventHandlerWidget::Activate()
 	while (!this->bDeactivate)
 	{
 		//Process one frame.
+		CScreen::dwCurrentTicks = SDL_GetTicks();
 
 		//Get any events waiting in the queue.
 		while (!this->bDeactivate && PollEvent(&event))

--- a/FrontEndLib/FrontEndLib.2019.vcxproj
+++ b/FrontEndLib/FrontEndLib.2019.vcxproj
@@ -255,6 +255,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/FrontEndLib/Screen.cpp
+++ b/FrontEndLib/Screen.cpp
@@ -82,7 +82,11 @@ bool CScreen::bAllowFullScreen = true;  //allow full screen mode by default
 bool CScreen::bAllowWindowed = true;    //allow windowed mode by default too
 SDL_Rect CScreen::WindowTargetRect = { 0, 0, CScreen::CX_SCREEN, CScreen::CY_SCREEN };
 double CScreen::WindowScaleFactor = 1;
- 
+
+Uint32 CScreen::dwCurrentTicks = 0;
+Uint32 CScreen::dwLastRenderTicks = 0;
+Uint32 CScreen::dwPresentsCount = 0;
+
 UINT CScreen::MIDReallyQuit = 0;
 UINT CScreen::MIDOverwriteFilePrompt = 0;
 
@@ -157,6 +161,8 @@ void PresentFrame()
 	SDL_RenderClear(renderer); // clear border, if any
 	SDL_RenderCopy(renderer, GetWindowTexture(m_pWindow), NULL, &CScreen::WindowTargetRect);
 	SDL_RenderPresent(renderer);
+	CScreen::dwLastRenderTicks = SDL_GetTicks();
+	++CScreen::dwPresentsCount;
 }
 
 void PresentRect(SDL_Surface *shadow, const SDL_Rect *rect_in)

--- a/FrontEndLib/Screen.h
+++ b/FrontEndLib/Screen.h
@@ -154,6 +154,10 @@ public:
 	static SDL_Rect WindowTargetRect;      //position of logical screen in physical window
 	static double   WindowScaleFactor;
 
+	static Uint32 dwCurrentTicks; // SDL_GetTicks() value during the start of handling of the current frame
+	static Uint32 dwLastRenderTicks; // SDL_GetTicks() value during the last present frame call
+	static Uint32 dwPresentsCount; // Count of how many times SDL presented a frame to a window
+
 protected:
 	friend class CScreenManager;
 	friend class CEffectList;


### PR DESCRIPTION
Added static fields to `CScreen`. One of them is used to replace calls to SDL_Ticks() to ensure effects play synchronized, rather than desyncing in edge cases when ticks crosses a threshold to the next millisecond. Added two more variables which I will be using in future code

Also enabled multiprocessor compilation and incremental linking because they speed things up a lot.

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44754)