### PR TITLE
New debug drawing options + gentryii chains correctly update their pa…

### DIFF
--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -490,6 +490,9 @@ protected:
 	bool           UpdateDrawSquareInfo(const CCoordSet *pSet=NULL, const CCoordSet *pGeometryChanges=NULL);
 	void           UpdateRoomRects();
 
+	void           DebugDraw_Pathmap(SDL_Surface* pDestSurface, MovementType eType);
+	void           DebugDraw_MarkedTiles(SDL_Surface* pDestSurface);
+
 	UINT             dwRoomX, dwRoomY;
 	WSTRING           style;
 	UINT              wShowCol, wShowRow;

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -75,6 +75,8 @@ ROOMCOORD      importCheckpoint;
 #define WEATHER_SKY "sky"
 #define WEATHER_RAIN "rain"
 
+CCoordSet CDbRoom::debugMarkedTiles;
+
 //
 //CDbRooms public methods.
 //

--- a/DRODLib/DbRooms.h
+++ b/DRODLib/DbRooms.h
@@ -477,6 +477,10 @@ public:
 	set<const CMonster*> pushed_monsters;
 	bool pushed_player;
 
+	// Var used for debugging, clear tile positions at a convenient spot, then add tile positions
+	// here and uncomment DebugDraw_MarkedTiles() in CRoomWidget
+	static CCoordSet debugMarkedTiles;
+
 private:
 	enum tartype {oldtar, newtar, notar};
 

--- a/DRODLib/Gentryii.cpp
+++ b/DRODLib/Gentryii.cpp
@@ -151,12 +151,12 @@ void CGentryii::MoveGentryii(UINT destX, UINT destY, CCueEvents& CueEvents)
 
 		if (bThisMoved || bLastMoved)
 		{
-			if (wLastX1 != pPiece->wX && wLastY1 != pPiece->wY)
+			if (wLastX1 != pPiece->wX || wLastY1 != pPiece->wY)
 			{
 				updateTiles.insert(wLastX1,pPiece->wY);
 				updateTiles.insert(pPiece->wX,wLastY1);
 			}
-			if (wLastX2 != dest.first && wLastY1 != dest.second)
+			if (wLastX2 != dest.first || wLastY1 != dest.second)
 			{
 				updateTiles.insert(wLastX2,dest.second);
 				updateTiles.insert(dest.first,wLastY2);


### PR DESCRIPTION
…thmaps now

The old mechanism for detecting for which tiles to update pathmaps had the unfortunate issue of not correctly handling a situation where two diagonally adjacent chain links move in the same orthogonal direction. The new mechanism is much greedier and might cause some duplicates, but for the most part it should be fine, since duplicates are discarded in CCoordSet

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=43499&page=0#436084)