### PR TITLE
Critical NPCs will now always play generic 'splat' sound when killed,…

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -1869,7 +1869,7 @@ void CGameScreen::OnSelectChange(
 //
 
 //*****************************************************************************
-void CGameScreen::AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coord)
+void CGameScreen::AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coord, const bool bIsCriticalNpc)
 //Adds an effect for a monster type getting damaged to the room.
 {
 	//If player stabs monster, center sound on player for nicer effect.
@@ -1907,6 +1907,8 @@ void CGameScreen::AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coo
 		default: seid = SEID_SPLAT;
 			break;
 	}
+	if (bIsCriticalNpc)
+		seid = SEID_SPLAT;
 	PlaySoundEffect(seid, this->fPos);
 
 	//Effect shown based on monster type.
@@ -3845,7 +3847,9 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		const UINT wO = IsValidOrientation(pMonster->wKillInfo) ?
 				pMonster->wKillInfo : NO_ORIENTATION;
 		CMoveCoord coord(pMonster->wX,pMonster->wY,wO);
-		AddDamageEffect(pMonster->GetIdentity(), coord);
+		// Mission-critical NPCs should get the generic death sound, as they all have a personalized scream
+		const CCharacter* pCharacter = dynamic_cast<const CCharacter*>(pMonster);
+		AddDamageEffect(pMonster->GetIdentity(), coord, pCharacter && pCharacter->IsMissionCritical());
 	}
 	for (pObj = CueEvents.GetFirstPrivateData(CID_Stun);
 			pObj != NULL; pObj = CueEvents.GetNextPrivateData())

--- a/DROD/GameScreen.h
+++ b/DROD/GameScreen.h
@@ -128,7 +128,7 @@ protected:
 private:
 	void           AddBloodEffect(const CMoveCoord& coord, const UINT wAppearance);
 	void           AddComboEffect(CCueEvents& CueEvents);
-	void           AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coord);
+	void           AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coord, const bool bIsCriticalNpc = false);
 	void           AddRoomStatsDialog();
 	void           AmbientSoundSetup();
 	void           ApplyPlayerSettings();


### PR DESCRIPTION
… so as to not double whatever is their personalized or default death shout

[Related thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44474)