### PR TITLE
Global scripts would execute "no move" commands before room is finished…

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -2559,7 +2559,7 @@ void CCharacter::Process(
 			{
 				UINT dwCharID = (UINT)command.x;
 				if (!pGame->GlobalScriptsRunning.has(dwCharID))
-					room.AddNewGlobalScript(dwCharID, CueEvents);
+					room.AddNewGlobalScript(dwCharID, true, CueEvents);
 
 				bProcessNextCommand = true;
 			}

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2223,7 +2223,7 @@ void CDbRoom::ResetMonsterFirstTurnFlags()
 }
 
 //*****************************************************************************
-bool CDbRoom::AddNewGlobalScript(const UINT dwCharID, CCueEvents &CueEvents)
+bool CDbRoom::AddNewGlobalScript(const UINT dwCharID, const bool bProcessMove, CCueEvents &CueEvents)
 //Create a new global script character at (0,0)
 //
 //Returns: True if successful, false if not.
@@ -2259,10 +2259,12 @@ bool CDbRoom::AddNewGlobalScript(const UINT dwCharID, CCueEvents &CueEvents)
 	//Make sure that the current list of Global Scripts includes this ID
 	this->pCurrentGame->GlobalScriptsRunning += dwCharID;
 
-	const bool bExec = this->pCurrentGame->ExecutingNoMoveCommands();
-	this->pCurrentGame->SetExecuteNoMoveCommands();
-	pCharacter->Process(CMD_WAIT, CueEvents);
-	this->pCurrentGame->SetExecuteNoMoveCommands(bExec);
+	if (bProcessMove) {
+		const bool bExec = this->pCurrentGame->ExecutingNoMoveCommands();
+		this->pCurrentGame->SetExecuteNoMoveCommands();
+		pCharacter->Process(CMD_WAIT, CueEvents);
+		this->pCurrentGame->SetExecuteNoMoveCommands(bExec);
+	}
 
 	return true;
 }
@@ -2278,7 +2280,7 @@ void CDbRoom::AddRunningGlobalScripts(CCueEvents &CueEvents)
 
 	for (CIDSet::const_iterator c = this->pCurrentGame->GlobalScriptsRunning.begin();
 			c != this->pCurrentGame->GlobalScriptsRunning.end(); ++c)
-		if (!AddNewGlobalScript(*c, CueEvents))
+		if (!AddNewGlobalScript(*c, false, CueEvents))
 			BrokenGlobalScripts += *c;
 
 	this->pCurrentGame->GlobalScriptsRunning -= BrokenGlobalScripts;

--- a/DRODLib/DbRooms.h
+++ b/DRODLib/DbRooms.h
@@ -175,7 +175,7 @@ public:
 	bool           AddOrb(COrbData *pOrb);
 	COrbData *     AddOrbToSquare(const UINT wX, const UINT wY);
 	bool           AddPressurePlateTiles(COrbData* pPlate);
-	bool           AddNewGlobalScript(const UINT dwCharID, CCueEvents &CueEvents);
+	bool           AddNewGlobalScript(const UINT dwCharID, const bool bProcessMove, CCueEvents &CueEvents);
 	void           AddRunningGlobalScripts(CCueEvents &CueEvents);
 	bool           AddScroll(CScrollData *pScroll);
 	bool           AddExit(CExitData *pExit);


### PR DESCRIPTION
… initializaing, and then again when it's preprocessing monsters which caused setting player role to none act too early and be overriden

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=43144)