### PR TITLE
RPG: Allow editing of hold variables in Global Variable Editor

### DIFF
--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -929,6 +929,7 @@ void CDrodScreen::EditGlobalVars(
 	pListBox->SetPrompt(MID_GameVarsTitle);
 	pListBox->PrepareToPopulateList(CEntranceSelectDialogWidget::GlobalVars);
 	pListBox->PopulateListBoxFromGlobalVars(*st);
+	pListBox->PopulateListBoxFromHoldVars(pGame);
 	pListBox->SelectItem(0);
 
 	SetCursor();
@@ -969,6 +970,7 @@ void CDrodScreen::EditGlobalVars(
 				//Update value in widget list.
 				pListBox->PrepareToPopulateList(CEntranceSelectDialogWidget::GlobalVars);
 				pListBox->PopulateListBoxFromGlobalVars(*st);
+				pListBox->PopulateListBoxFromHoldVars(pGame->pHold);
 				pListBox->SelectItem(itemID);
 			}
 		}

--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -929,7 +929,9 @@ void CDrodScreen::EditGlobalVars(
 	pListBox->SetPrompt(MID_GameVarsTitle);
 	pListBox->PrepareToPopulateList(CEntranceSelectDialogWidget::GlobalVars);
 	pListBox->PopulateListBoxFromGlobalVars(*st);
-	pListBox->PopulateListBoxFromHoldVars(pGame);
+	if (pGame) {
+		pListBox->PopulateListBoxFromHoldVars(pGame);
+	}
 	pListBox->SelectItem(0);
 
 	SetCursor();
@@ -970,7 +972,9 @@ void CDrodScreen::EditGlobalVars(
 				//Update value in widget list.
 				pListBox->PrepareToPopulateList(CEntranceSelectDialogWidget::GlobalVars);
 				pListBox->PopulateListBoxFromGlobalVars(*st);
-				pListBox->PopulateListBoxFromHoldVars(pGame->pHold);
+				if (pGame) {
+					pListBox->PopulateListBoxFromHoldVars(pGame);
+				}
 				pListBox->SelectItem(itemID);
 			}
 		}

--- a/drodrpg/DROD/EntranceSelectDialogWidget.cpp
+++ b/drodrpg/DROD/EntranceSelectDialogWidget.cpp
@@ -527,13 +527,22 @@ void CEntranceSelectDialogWidget::PopulateListBoxFromHoldVars(CCurrentGame* pGam
 		_itoa(var->dwVarID, varID, 10);
 		strcat(varName, varID);
 
-		const WCHAR* varValue = stats.GetVar(varName, L"0");
+		UNPACKEDVARTYPE vType;
+		WSTRING wVarValue;
+		vType = stats.GetVarType(varName);
+
+		if (vType == UVT_int) {
+			int iVarValue = stats.GetVar(varName, (int)0);
+			wVarValue = std::to_wstring(iVarValue);
+		} else {
+			wVarValue = stats.GetVar(varName, L"0");
+		}
 
 		WSTRING wstr = var->varNameText.c_str();
 		wstr += wszSpace;
 		wstr += wszEqual;
 		wstr += wszSpace;
-		wstr += varValue;
+		wstr += wVarValue;
 		this->pListBoxWidget->AddItem(var->dwVarID, wstr.c_str());
 	}
 }

--- a/drodrpg/DROD/EntranceSelectDialogWidget.cpp
+++ b/drodrpg/DROD/EntranceSelectDialogWidget.cpp
@@ -516,6 +516,29 @@ void CEntranceSelectDialogWidget::PopulateListBoxFromGlobalVars(const PlayerStat
 }
 
 //*****************************************************************************
+void CEntranceSelectDialogWidget::PopulateListBoxFromHoldVars(CCurrentGame* pGame)
+{
+	CDbPackedVars& stats = pGame->stats;
+
+	for (vector<HoldVar>::const_iterator var = pGame->pHold->vars.begin();
+		var != pGame->pHold->vars.end(); ++var) {
+		char varID[10], varName[11] = "v";
+		//Get local hold var.
+		_itoa(var->dwVarID, varID, 10);
+		strcat(varName, varID);
+
+		const WCHAR* varValue = stats.GetVar(varName, L"0");
+
+		WSTRING wstr = var->varNameText.c_str();
+		wstr += wszSpace;
+		wstr += wszEqual;
+		wstr += wszSpace;
+		wstr += varValue;
+		this->pListBoxWidget->AddItem(var->dwVarID, wstr.c_str());
+	}
+}
+
+//*****************************************************************************
 void CEntranceSelectDialogWidget::SelectItem(
 	const UINT dwTagNo) //(in)
 {

--- a/drodrpg/DROD/EntranceSelectDialogWidget.h
+++ b/drodrpg/DROD/EntranceSelectDialogWidget.h
@@ -74,6 +74,7 @@ public:
 	virtual void   OnSelectChange(const UINT dwTagNo);
 	void     PopulateList(const DATATYPE datatype=Entrances);
 	void     PopulateListBoxFromGlobalVars(const PlayerStats& st);
+	void     PopulateListBoxFromHoldVars(CCurrentGame* pGame);
 	void     PrepareToPopulateList(const DATATYPE datatype=Entrances);
 
 	void     SelectItem(const UINT dwTagNo);


### PR DESCRIPTION
When F4 is pressed during playtesting, a list of all game variables is displayed with their values. From this list, the values can be edited.

This PR extends the list to include hold variables, allowed them to be viewed and editing, both with integer and string values. Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=41659