### PR TITLE
Editor ui issues

### DIFF
--- a/DROD/EditSelectScreen.cpp
+++ b/DROD/EditSelectScreen.cpp
@@ -703,6 +703,8 @@ void CEditSelectScreen::ResetSelectedHold()
 	delete this->pSelectedRoom;
 	this->pSelectedRoom = NULL;
 
+	this->selectedWorldMapID = 0;
+
 	GetLevelEntrancesInRoom(); //will clear list
 
 	//Clear widgets.

--- a/DROD/EditSelectScreen.cpp
+++ b/DROD/EditSelectScreen.cpp
@@ -1503,12 +1503,20 @@ void CEditSelectScreen::OnSelectChange(
 
 		case TAG_WORLDMAPDISPLAYLIST:
 		{
-			CListBoxWidget *pWorldMapDisplayListBox = DYN_CAST(CListBoxWidget*, CWidget*,
-					GetWidget(TAG_WORLDMAPDISPLAYLIST));
-			this->pSelectedHold->SetDisplayTypeForWorldMap(
-				this->pWorldMapListBoxWidget->GetSelectedItem(),
-				HoldWorldMap::DisplayType(pWorldMapDisplayListBox->GetSelectedItem()));
-			this->pSelectedHold->Update();
+			CListBoxWidget* pWorldMapDisplayListBox = DYN_CAST(CListBoxWidget*, CWidget*,
+				GetWidget(TAG_WORLDMAPDISPLAYLIST));
+			if (ModifyHold()) {
+				this->pSelectedHold->SetDisplayTypeForWorldMap(
+					this->pWorldMapListBoxWidget->GetSelectedItem(),
+					HoldWorldMap::DisplayType(pWorldMapDisplayListBox->GetSelectedItem()));
+				this->pSelectedHold->Update();
+			}
+			else {
+				pWorldMapDisplayListBox->SelectItem(
+					this->pSelectedHold->GetWorldMapDisplayType(pWorldMapDisplayListBox->GetSelectedItem())
+				);
+				pWorldMapDisplayListBox->Paint();
+			}
 		}
 		break;
 	}

--- a/DROD/EditSelectScreen.cpp
+++ b/DROD/EditSelectScreen.cpp
@@ -893,10 +893,12 @@ void CEditSelectScreen::OnClick(
 		break;
 
 		case TAG_SETIMAGE_WORLDMAP:
-			SetImageWorldMap();
-			this->pSelectedHold->Update();
-			DrawScaledWorldMapImage();
-			Paint();
+			if (ModifyHold()) {
+				SetImageWorldMap();
+				this->pSelectedHold->Update();
+				DrawScaledWorldMapImage();
+				Paint();
+			}
 		break;
 
 		case TAG_DELETE_WORLDMAP:

--- a/DROD/EditSelectScreen.cpp
+++ b/DROD/EditSelectScreen.cpp
@@ -1437,10 +1437,16 @@ void CEditSelectScreen::OnSelectChange(
 		{
 			COptionButtonWidget *pButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 					GetWidget(TAG_SHOWEXITLEVEL));
-			ASSERT(this->pSelectedLevel);
-			this->pSelectedLevel->bIsRequired = pButton->IsChecked();
-			this->pSelectedLevel->Update();
-			this->pSelectedHold->Update();
+			if (!ModifyHold())
+			{
+				pButton->SetChecked(this->pSelectedLevel->bIsRequired);
+				pButton->Paint();
+			} else {
+				ASSERT(this->pSelectedLevel);
+				this->pSelectedLevel->bIsRequired = pButton->IsChecked();
+				this->pSelectedLevel->Update();
+				this->pSelectedHold->Update();
+			}
 		}
 		break;
 

--- a/FrontEndLib/FocusWidget.cpp
+++ b/FrontEndLib/FocusWidget.cpp
@@ -69,7 +69,7 @@ void CFocusWidget::Unselect(
 	const bool bPaint)   //(in) whether to repaint widget
 {
 	this->bSelected = false;
-	if (bPaint && IsVisible())
+	if (bPaint && IsVisible(true))
 		RequestPaint();
 }
 

--- a/FrontEndLib/Widget.cpp
+++ b/FrontEndLib/Widget.cpp
@@ -685,6 +685,20 @@ const
 }
 
 //***************************************************************************
+void CWidget::Show(const bool bFlag)
+{
+	this->bIsVisible = bFlag;
+	if (!bFlag)
+		this->Hide(false);
+}
+
+//***************************************************************************
+void CWidget::Hide(const bool /*bPaint*/)
+{
+	this->bIsVisible = false;
+}
+
+//***************************************************************************
 void CWidget::HideChildren()
 //Hides all children of this widget, but not the widget itself.  If you wish
 //to hide both, simply call Hide().
@@ -746,6 +760,20 @@ const
 	return (nX >= this->x + nOffsetX && nY >= this->y + nOffsetY &&
 			nX < this->x + nOffsetX + static_cast<int>(this->w) && nY < this->y +
 			nOffsetY + static_cast<int>(this->h));
+}
+
+//*****************************************************************************
+bool CWidget::IsVisible(
+	// Is this widget visible?
+	const bool bInParent // Also check if all the parents are visible
+) const {
+	if (bInParent) {
+		for (CWidget* pParent = this->pParent; pParent != NULL; pParent = pParent->pParent)
+			if (!pParent->IsVisible())
+				return false;
+	}
+
+	return this->bIsVisible;
 }
 
 //*****************************************************************************

--- a/FrontEndLib/Widget.cpp
+++ b/FrontEndLib/Widget.cpp
@@ -689,11 +689,11 @@ void CWidget::Show(const bool bFlag)
 {
 	this->bIsVisible = bFlag;
 	if (!bFlag)
-		this->Hide(false);
+		Hide(false);
 }
 
 //***************************************************************************
-void CWidget::Hide(const bool /*bPaint*/)
+void CWidget::Hide(const bool bPaint)
 {
 	this->bIsVisible = false;
 }

--- a/FrontEndLib/Widget.h
+++ b/FrontEndLib/Widget.h
@@ -372,7 +372,7 @@ public:
 	UINT        GetW() const {return this->w;}
 	UINT        GetH() const {return this->h;}
 
-	virtual void   Hide(const bool /*bPaint*/ = true);
+	virtual void   Hide(const bool bPaint = true);
 	void        HideChildren();
 	bool        IsActive() const {return IsEnabled() && IsVisible();}
 	bool        IsEnabled() const {return bIsEnabled;}

--- a/FrontEndLib/Widget.h
+++ b/FrontEndLib/Widget.h
@@ -372,7 +372,7 @@ public:
 	UINT        GetW() const {return this->w;}
 	UINT        GetH() const {return this->h;}
 
-	virtual void   Hide(const bool /*bPaint*/ = true) {this->bIsVisible = false;}
+	virtual void   Hide(const bool /*bPaint*/ = true);
 	void        HideChildren();
 	bool        IsActive() const {return IsEnabled() && IsVisible();}
 	bool        IsEnabled() const {return bIsEnabled;}
@@ -381,7 +381,7 @@ public:
 	bool        IsInsideOfRect(const int nX, const int nY, const UINT wW,
 			const UINT wH) const;
 	bool        IsLoaded() const {return this->bIsLoaded;}
-	bool        IsVisible() const {return this->bIsVisible;}
+	bool        IsVisible(const bool bInParent = false) const;
 	virtual void   Move(const int nSetX, const int nSetY);
 	void        MoveChildren(const int dx, const int dy);
 	bool        OverlapsRect(const int nX, const int nY, const UINT wW,
@@ -398,7 +398,7 @@ public:
 	void        ScrollAbsolute(const int nScrollX, const int nScrollY);
 	void        SetHeight(const UINT wHeight);
 	void        SetWidth(const UINT wWidth);
-	void        Show(const bool bFlag=true) {this->bIsVisible = bFlag;}
+	void        Show(const bool bFlag = true);
 	void        ShowChildren();
 	static WCHAR TranslateUnicodeKeysym(const SDL_Keysym& keysym, const bool bConsiderCaps=true);
 	static void  TranslateUnicodeKeysym(WCHAR& wc, const SDL_Keycode sym, const bool bCaps);


### PR DESCRIPTION
- It is no longer possible to change map's display type for a hold you don't own
- It is no longer possible to change map image for a hold you don't own
- When in EditSelectScreen you change from a hold that has world map to one that is not editable, map buttons become disabled now
- It's no longer possible to change 'Show Exit level' for a hold you don't own
- UI elements in EditSelectScreen will no longer be redrawn on top of different elements when changing tabs and focus is on the element outside the tabbed interface

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=42247)