### PR TITLE
Newline and tab characters will be removed from: level name, hold nam…

### DIFF
--- a/BackEndLib/Wchar.cpp
+++ b/BackEndLib/Wchar.cpp
@@ -89,6 +89,18 @@ const WCHAR wszPTag[] = { We('<'),We('p'),We('>'), We(0) };
 static char buffer[WCHAR_INTERNAL_BUFFER];
 
 //*****************************************************************************
+void SanitizeSingleLineString(WSTRING &wstr)
+//Remove any unwanted characters from a single-line string. Currently strips:
+// * both newline characters
+// * horizontal tab
+// Ultimately if one day we can define the list of allowed characters we can convert it to a whitelist
+{
+	wstr.erase(std::remove(wstr.begin(), wstr.end(), '\n'), wstr.end());
+	wstr.erase(std::remove(wstr.begin(), wstr.end(), '\r'), wstr.end());
+	wstr.erase(std::remove(wstr.begin(), wstr.end(), '\t'), wstr.end());
+}
+
+//*****************************************************************************
 void AsciiToUnicode(const char *psz, WSTRING &wstr)
 {
 	WCHAR *pwczConvertBuffer = new WCHAR[strlen(psz) + 1];

--- a/BackEndLib/Wchar.h
+++ b/BackEndLib/Wchar.h
@@ -86,6 +86,7 @@ extern const WCHAR wszAmpersand[], wszAsterisk[], wszOpenAngle[], wszCloseAngle[
 extern const WCHAR wszHtml[], wszEndHtml[], wszBody[], wszEndBody[], wszHeader[],
 	wszEndHeader[], wszBTag[], wszEndBTag[], wszITag[], wszEndITag[], wszPTag[];
 
+void SanitizeSingleLineString(WSTRING& wstr);
 void AsciiToUnicode(const char *psz, WSTRING &wstr);
 void AsciiToUnicode(const std::string& str, WSTRING &wstr);
 void CTextToUnicode(const char *psz, WSTRING &wstr);

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -607,6 +607,8 @@ bool CCharacterDialogWidget::RenameCharacter()
 		return false;
 	ASSERT(!wstr.empty());
 
+	SanitizeSingleLineString(wstr);
+	
 	if (!pEditRoomScreen->pHold->RenameCharacter(charID, wstr))
 	{
 		pEditRoomScreen->ShowOkMessage(MID_CharNameDuplicationError);
@@ -1945,7 +1947,11 @@ void CCharacterDialogWidget::AddCustomCharacter()
 	const WCHAR *pCharName = this->pCharNameText->GetText();
 	ASSERT(WCSlen(pCharName) > 0);
 
-	const UINT dwNewCharID = pEditRoomScreen->pHold->AddCharacter(pCharName);
+	WSTRING charName(pCharName);
+
+	SanitizeSingleLineString(charName);
+
+	const UINT dwNewCharID = pEditRoomScreen->pHold->AddCharacter(charName.c_str());
 	if (!dwNewCharID)
 		pEditRoomScreen->ShowOkMessage(MID_CharNameDuplicationError);
 	else {

--- a/DROD/EditSelectScreen.cpp
+++ b/DROD/EditSelectScreen.cpp
@@ -2795,6 +2795,9 @@ void CEditSelectScreen::RenameHold()
 	{
 		if (!ModifyHold())
 			return;
+
+		SanitizeSingleLineString(wstr);
+
 		this->pSelectedHold->NameText = wstr.c_str();
 		this->pSelectedHold->Update();
 		this->pHoldListBoxWidget->SetSelectedItemText(wstr.c_str());
@@ -2816,6 +2819,8 @@ void CEditSelectScreen::RenameLevel()
 	const UINT dwAnswerTagNo = ShowTextInputMessage(MID_NameLevel, wstr);
 	if (dwAnswerTagNo == TAG_OK)
 	{
+		SanitizeSingleLineString(wstr);
+
 		this->pSelectedLevel->NameText = wstr.c_str();
 		this->pSelectedLevel->Update();
 		this->pLevelListBoxWidget->SetSelectedItemText(wstr.c_str());


### PR DESCRIPTION
…e and custom character names. This happens when editing them, on save.

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=32256)