### PR TITLE
Fixed a bug where during double placement, moving a cursor to a tile …

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -7947,6 +7947,7 @@ void CRoomWidget::DrawDoubleCursor(
 	if (bObstacle)
 	{
 		g_pTheBM->ShadeTile(xPixel,yPixel,Red,GetDestSurface());
+		this->pTileImages[this->pRoom->ARRAYINDEX(wCol, wRow)].dirty = 1;
 	} else {
 		//Fade in and out.
 		static Uint8 nOpacity = 160;


### PR DESCRIPTION
…in the same row as the player, to the west of them, with an obstacle, would sometimes not clear up the red marking when moving the cursor East. Caused by not marking the shaded tile as dirty

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=34843&page=0#344804)