### PR TITLE
Mark movement commands as questionable ifs

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -4063,6 +4063,8 @@ const
 				wstr += wszExclamation;	//superfluous IfEnd
 		//no break
 		case CCharacterCommand::CC_Disappear:
+		case CCharacterCommand::CC_MoveTo:
+		case CCharacterCommand::CC_MoveRel:
 		case CCharacterCommand::CC_EndScript:
 		case CCharacterCommand::CC_EndScriptOnExit:
 		case CCharacterCommand::CC_FlushSpeech:


### PR DESCRIPTION
While you can technically use `If` commands on `Move` and `Move To`, the functionallity that occurs is a side-effect of how movement commands work. Marking these commands with `?` in the script editor warns of this.
See thread: http://forum.caravelgames.com/viewtopic.php?TopicID=38550