### PR TITLE
Make constructed Relay Stations functional and match Citizen group

### DIFF
--- a/DRODLib/BuildUtil.cpp
+++ b/DRODLib/BuildUtil.cpp
@@ -334,6 +334,8 @@ bool BuildUtil::BuildNormalTile(CDbRoom& room, const UINT baseTile, const UINT t
 		} else if (wOldTTile == T_BRIAR_LIVE && baseTile == T_BRIAR_DEAD) {
 			//this case isn't handled in briars.plotted() via room plot below
 			room.briars.forceRecalc();
+		} else if (baseTile == T_STATION) {
+			room.stations.push_back(new CStation(x, y, &room));
 		}
 	}
 

--- a/DRODLib/Citizen.cpp
+++ b/DRODLib/Citizen.cpp
@@ -188,8 +188,7 @@ void CCitizen::Process(
 
 	//Init.
 	CDbRoom& room = *(this->pCurrentGame->pRoom);
-	if (room.stations.empty())
-		this->bDone = true;
+	this->bDone = room.stations.empty();
 
 	if (HasSupply() && !room.building.empty())
 	{

--- a/DRODLib/Citizen.cpp
+++ b/DRODLib/Citizen.cpp
@@ -301,6 +301,12 @@ void CCitizen::BuildTile(CCueEvents& CueEvents)
 
 	if (BuildUtil::BuildTileAt(room, wBuildTile, this->goal.wX, this->goal.wY, true, CueEvents)){
 		this->bHasSupply = false;
+		if (wBuildTile == T_STATION && this->wType == M_CITIZEN) {
+			// When a citizen builds a station, the station inherits its group
+			room.SetTParam(this->goal.wX, this->goal.wY, this->nStationType);
+			CStation* builtStation = room.stations.back();
+			builtStation->UpdateType();
+		}
 	}
 }
 

--- a/DRODLib/Station.cpp
+++ b/DRODLib/Station.cpp
@@ -164,6 +164,13 @@ bool CStation::UpdateTurn(const UINT wTurnNo)
 	return bRes;
 }
 
+//******************************************************************************
+void CStation::UpdateType()
+// Updates the type of the station to its tile's T parameter
+{
+	this->wType = pRoom->GetTParam(wX, wY);
+}
+
 //
 //Private methods
 //

--- a/DRODLib/Station.h
+++ b/DRODLib/Station.h
@@ -44,6 +44,7 @@ public:
 	inline UINT GetType() const {return this->wType;}
 	void RecalcPathmap();
 	bool UpdateTurn(const UINT wTurnNo);
+	void UpdateType();
 	inline UINT X() const {return this->wX;}
 	inline UINT Y() const {return this->wY;}
 

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -304,6 +304,7 @@
     <ClCompile Include="src\tests\Scripting\Build\BuildingKegs.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildingMirrors.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildingOrbs.cpp" />
+    <ClCompile Include="src\tests\Scripting\Build\BuildingRelayStations.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildingTarstuff.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildSanityTest.cpp" />
     <ClCompile Include="src\tests\Scripting\GoToLevelEntrance.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClCompile Include="src\tests\Scripting\SetPlayerWeapon.cpp">
       <Filter>Tests\Scripting</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Scripting\Build\BuildingRelayStations.cpp">
+      <Filter>Tests\Scripting\Build</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />

--- a/DRODLibTests/src/RoomBuilder.cpp
+++ b/DRODLibTests/src/RoomBuilder.cpp
@@ -174,6 +174,14 @@ void RoomBuilder::PlotToken(const RoomTokenType tokenType, const UINT wX, const 
 	GetRoom()->SetTParam(wX, wY, tokenType);
 }
 
+void RoomBuilder::PlotStation(const UINT wX, const UINT wY, const UINT stationType)
+{
+	PlotRect(T_STATION, wX, wY, wX, wY);
+	GetRoom()->stations.push_back(new CStation(wX, wY, GetRoom()));
+	GetRoom()->SetTParam(wX, wY, stationType);
+	GetRoom()->stations.back()->UpdateType();
+}
+
 void RoomBuilder::PlotRect(const UINT tileType, const UINT startX, const UINT startY, const UINT endX, const UINT endY){
 	for (UINT x = startX; x <= endX; ++x){
 		for (UINT y = startY; y <= endY; ++y){

--- a/DRODLibTests/src/RoomBuilder.h
+++ b/DRODLibTests/src/RoomBuilder.h
@@ -27,6 +27,7 @@ public:
 	static void LinkOrb(const UINT wOrbX, const UINT wOrbY, const UINT wDoorX, const UINT wDoorY, const OrbAgentType eLinkType);
 	static void Plot(const UINT tileType, const UINT wX, const UINT wY);
 	static void PlotToken(const RoomTokenType tokenType, const UINT wX, const UINT wY);
+	static void PlotStation(const UINT wX, const UINT wY, const UINT stationType);
 	static void PlotRect(const UINT tileType, const UINT startX, const UINT startY, const UINT endX, const UINT endY);
 
 private:

--- a/DRODLibTests/src/tests/Scripting/Build/BuildingRelayStations.cpp
+++ b/DRODLibTests/src/tests/Scripting/Build/BuildingRelayStations.cpp
@@ -1,0 +1,69 @@
+#include "../../../test-include.hpp"
+#include "../../../CAssert.h"
+#include "DRODLib/Citizen.h"
+
+TEST_CASE("Scripting: Build Relay Station", "[game][scripting][engineer][citizen]") {
+	RoomBuilder::ClearRoom();
+
+	CCharacter* pScript = RoomBuilder::AddVisibleCharacter(1, 1);
+	RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_Wait);
+	RoomBuilder::AddMonster(M_CITIZEN, 5, 5);
+
+	SECTION("Build station with command") {
+		RoomBuilder::AddCommand(
+			pScript, CCharacterCommand::CC_Build, 5, 7, 0, 0, T_STATION);
+
+		CCurrentGame* pGame = Runner::StartGame(15, 15, N);
+		Runner::ExecuteCommand(CMD_WAIT, 5);
+
+		CDbRoom* pRoom = pGame->pRoom;
+		CCitizen* pCitizen = dynamic_cast<CCitizen*>(
+			pGame->pRoom->GetMonsterAtSquare(5, 6));
+
+		AssertTile(5,7, T_STATION);
+		CHECK(pRoom->GetTParam(5, 7) == 0);
+		REQUIRE(pCitizen);
+		CHECK(pCitizen->StationType() == 0);
+	}
+
+	SECTION("Build station with engineer") {
+		RoomBuilder::AddMonster(M_ARCHITECT, 5, 8);
+		RoomBuilder::AddCommand(
+			pScript, CCharacterCommand::CC_BuildMarker, 5, 7, 0, 0, T_STATION);
+
+		CCurrentGame* pGame = Runner::StartGame(15, 15, N);
+		Runner::ExecuteCommand(CMD_WAIT, 3);
+		
+		CDbRoom* pRoom = pGame->pRoom;
+		CCitizen* pCitizen = dynamic_cast<CCitizen*>(
+			pRoom->GetMonsterAtSquare(5, 6));
+
+		AssertTile(5, 7, T_STATION);
+		CHECK(pRoom->GetTParam(5, 7) == 0);
+		REQUIRE(pCitizen);
+		CHECK(pCitizen->StationType() == 0);
+	}
+
+	SECTION("Build station with citizen") {
+		RoomBuilder::PlotRect(T_WALL, 4, 8, 6, 11);
+		RoomBuilder::PlotRect(T_FLOOR, 5, 8, 5, 10);
+		RoomBuilder::Plot(T_ARROW_N, 5, 8);
+		RoomBuilder::PlotStation(5, 10, 3);
+
+		RoomBuilder::AddMonster(M_CITIZEN, 5, 9);
+		RoomBuilder::AddCommand(
+			pScript, CCharacterCommand::CC_BuildMarker, 5, 7, 0, 0, T_STATION);
+
+		CCurrentGame* pGame = Runner::StartGame(15, 15, N);
+		Runner::ExecuteCommand(CMD_WAIT, 5);
+
+		CDbRoom* pRoom = pGame->pRoom;
+		CCitizen* pCitizen = dynamic_cast<CCitizen*>(
+			pRoom->GetMonsterAtSquare(5, 6));
+
+		AssertTile(5, 7, T_STATION);
+		CHECK(pRoom->GetTParam(5, 7) == 3);
+		REQUIRE(pCitizen);
+		CHECK(pCitizen->StationType() == 3);
+	}
+}


### PR DESCRIPTION
When Relay Stations are built, they are not added to `CDBRoom::stations`. This means they are never used by citizens. By adding them when construction occurs, they now work.

Additionally, this PR implements a request to make Relay Stations constructed by Citizens inherit the constructing citizen's group.

Bug thread: http://forum.caravelgames.com/viewtopic.php?TopicID=44680
Feature thread: http://forum.caravelgames.com/viewtopic.php?TopicID=44681