### PR TITLE
Created Image Overlays get their time from the same source now as the…

### DIFF
--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -936,7 +936,7 @@ void CDrodScreen::ProcessImageEvents(
 		return;
 
 	const UINT currentTurn = pGame ? pGame->wTurnNo : 0;
-	const Uint32 dwNow = SDL_GetTicks();
+	const Uint32 dwNow = CScreen::dwCurrentTicks;
 
 	const CAttachableObject *pObj = CueEvents.GetFirstPrivateData(cid);
 	while (pObj)

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -2225,7 +2225,7 @@ void CRoomWidget::DisplayPersistingImageOverlays(CCueEvents& CueEvents)
 	}
 
 	const UINT currentTurn = this->pCurrentGame->wTurnNo;
-	const Uint32 dwNow = SDL_GetTicks();
+	const Uint32 dwNow = CScreen::dwCurrentTicks;
 
 	for (vector<CImageOverlay>::const_iterator it=this->pCurrentGame->persistingImageOverlays.begin();
 			it!=this->pCurrentGame->persistingImageOverlays.end(); ++it)


### PR DESCRIPTION
… image overlay advancing, instead of calling SDL_GetTicks(), which will fix an issue when on the first frame the first effect start time is later than dwNow used during processing

[Relevant thread](https://forum.caravelgames.com/viewtopic.php?TopicID=44801&page=0#436595)