### PR TITLE
Reduce memory footprint on export and import to avoid OOM issues.

### DIFF
--- a/DROD/ClockWidget.cpp
+++ b/DROD/ClockWidget.cpp
@@ -111,7 +111,7 @@ UINT calcDisplayTime(CClockWidget::ClockState state, UINT wGameTime, bool halfSt
 	if (state >= CClockWidget::CS_ExplicitHalfTimeStart && state < CClockWidget::CS_ExplicitHalfTimeEnd)
 		return UINT(state) - CClockWidget::CS_ExplicitHalfTimeStart;
 	if (state == CClockWidget::CS_ShowBackwards) {
-		static const int maxval = (std::numeric_limits<int>::max() / TIME_INCREMENTS) * TIME_INCREMENTS;
+		static const int maxval = ((std::numeric_limits<int>::max)() / TIME_INCREMENTS) * TIME_INCREMENTS;
 		wGameTime = static_cast<UINT>(maxval - int(wGameTime));
 		if (halfStep)
 			--wGameTime; //show half step backwards

--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -41,7 +41,8 @@
 
 #include <cstdio>
 
-const char gzID[] = "\x1f\x8b";
+const char gzID[] = "\x1f\x8b"; //gzip file header id
+const UINT EXPORT_MAX_SIZE_THRESHOLD = 10 * 1024*1024; //10 MB
 
 //Literals used to query and store values for Hold Characters in the packed vars object.
 #define scriptIDstr "ScriptID"
@@ -96,11 +97,11 @@ void InitTokens()
 }
 
 //If buffer has more data than indicated amount, flush it to the file.
-bool streamingOutParams::flush(const ULONG minSizeThreshold) //[default=0]
+bool streamingOutParams::flush(const ULONG maxSizeThreshold) //[default=0]
 {
 	if (pOutBuffer) {
 		const ULONG srcLen = (ULONG)(pOutBuffer->size() * sizeof(char));
-		if (!srcLen || srcLen < minSizeThreshold)
+		if (!srcLen || srcLen < maxSizeThreshold)
 			return true;
 
 		const ULONG bytesWritten = gzwrite(*this->pGzf, (const BYTE*)pOutBuffer->c_str(), (unsigned int)srcLen);
@@ -245,7 +246,7 @@ void CDbXML::PerformCallbackf(float fVal) {
 	if (pCallbackObject)
 		pCallbackObject->Callbackf(fVal);
 
-	const bool successIgnored = CDbXML::streamingOut.flush(10 * 1024*1024); //10 MB
+	const bool successIgnored = CDbXML::streamingOut.flush(EXPORT_MAX_SIZE_THRESHOLD);
 }
 void CDbXML::PerformCallbackText(const WCHAR* wpText) {
 	if (pCallbackObject)

--- a/DRODLib/DbXML.h
+++ b/DRODLib/DbXML.h
@@ -36,6 +36,7 @@
 #include "../Texts/MIDs.h"
 
 #include <expat.h>
+#include <zlib.h>
 
 #include <map>
 #include <vector>
@@ -58,6 +59,27 @@ struct DEMO_UPLOAD
 	UINT dwDemoID;
 	UINT dwCreatedTime;
 	CDbDemo::DemoFlag flag;
+};
+
+struct streamingOutParams
+{
+	streamingOutParams()
+		: pOutBuffer(NULL)
+		, pGzf(NULL)
+	{ }
+	void reset() {
+		pOutBuffer = NULL;
+		pGzf = NULL;
+	}
+	void set(string* str, gzFile* gzf)
+	{
+		pOutBuffer = str;
+		pGzf = gzf;
+	}
+	bool flush(const ULONG minSizeThreshold = 0);
+
+	string* pOutBuffer;
+	gzFile* pGzf;
 };
 
 //*****************************************************************************
@@ -129,6 +151,8 @@ private:
 	static vector <VIEWTYPE> dbRecordTypes;   //record types
 	static vector <VIEWPROPTYPE> vpCurrentType;  //stack of viewprops being parsed
 	static vector <bool>  SaveRecord;   //whether record should be saved to the DB
+
+	static streamingOutParams streamingOut;
 };
 
 #endif //...#ifndef DBMXL_H

--- a/DRODLib/DbXML.h
+++ b/DRODLib/DbXML.h
@@ -76,7 +76,7 @@ struct streamingOutParams
 		pOutBuffer = str;
 		pGzf = gzf;
 	}
-	bool flush(const ULONG minSizeThreshold = 0);
+	bool flush(const ULONG maxSizeThreshold = 0);
 
 	string* pOutBuffer;
 	gzFile* pGzf;

--- a/FrontEndLib/SubtitleEffect.cpp
+++ b/FrontEndLib/SubtitleEffect.cpp
@@ -121,7 +121,7 @@ void CSubtitleEffect::FollowCoord(CMoveCoord *const pCoord, const bool bAttached
 //*****************************************************************************
 long CSubtitleEffect::GetDrawSequence() const
 {
-	return std::numeric_limits<long>::max(); //draw last
+	return (std::numeric_limits<long>::max)(); //draw last
 }
 
 //*****************************************************************************


### PR DESCRIPTION
[Relevant issue](https://forum.caravelgames.com/viewtopic.php?TopicID=38449)

This PR addresses OOM errors when attempting to export and import very large .player files (and possibly also .hold files, etc).

Here's what's in this change, which I welcome your feedback on if you have thoughts/opinions:
* Up till now, when exporting, all the data being compiled into the file is first concatenated into a text string in RAM, which is then zlib-compressed into another buffer in RAM, and then CStretchyBuffer-encoded, then written to a file on disk.  Large player profiles (or maybe holds) can run out of memory (in the 32-bit address space in our Windows build) during export.
* To mitigate this, I've changed the export process to use gzip verbs (instead of zlib format), which allow writing of multiple compressed data segments to a file on disk.  I've inserted this operation into the callbackf() method that's called periodically.  Whenever the string gets large (10MB is the heuristic threshold I chose), the buffer is written to disk and cleared out.  Multiple gzip-compressed chunks may be written in sequence to the file.  Now memory usage stays low during export!
* I removed the "Encode" call, which I'm not sure we really need (it's not really secure anyway).  Note this change enables treating the file written to disk as a standard gzip file, and the XML contents can be viewed by anyone who wishes to (rename it as a .gz file and) unpack the contents.  This is probably not a bad thing, but we could re-introduce the encode/decode step if we really want to.
* Both gzip and zlib-plus-encode formats are still supported for import.  Only the gzip version will be written going forward for exports.

_This format change would require adding code to the server to process new v5.1.1+ compressed file uploads, to check for a gzip-format file header (see DbXML.cpp changes) and uncompress the file from gzip format instead of zlib+encode format in that case._   (You don't need to check for any versioning info; just the file header for gzip id bytes.)

The above changes don't address import memory issues.  I spent a good while looking at the DROD address space, which appears to be highly fragmented for large .dat files (by Metakit, if I'm concluding correctly).  I tried out using a custom memory allocator, which greatly reduces the number of distinct mallocs that take place across the address space for sets and maps.  This helped reduce # of allocations (except Metakit char[] allocations).  In certain cases w/ large .dats, I found I wasn't even able to malloc 80MB of contiguous address space, even though the app itself is only using 100-200MB of RAM.  This is ridiculous, but without swapping out Metakit (which would be a lot of work), very large imports would need to be addressed in another way.  If you have any ideas, feel free to share them.  (I can add the custom stl container memory allocator implementation I used in a future PR if it seems interesting to you; I've not included it here.)

Edit: I made a heuristic update to reduce potential import memory allocation, which fortunately resolves the OOM issue on uncompression with the large .player files and large .dat files I tested with.  (Yay!)

Edit2: I also added a progress indicator to the status text being displayed while demos and saved games are being validated for each hold.