### PR TITLE
Weather dialog sliders will no longer draw with weird artefacts + set…

### DIFF
--- a/DROD/WeatherDialogWidget.cpp
+++ b/DROD/WeatherDialogWidget.cpp
@@ -272,6 +272,9 @@ void CWeatherDialogWidget::SetWidgetStates()
 {
 	ASSERT(this->pRoom);
 
+	// Draw before setting widgets state, as some of them may cache what's drawn underneath them
+	this->RequestPaint(true);
+
 	COptionButtonWidget *pOptionButton;
 	CSliderWidget *pSliderWidget;
 

--- a/FrontEndLib/SliderWidget.cpp
+++ b/FrontEndLib/SliderWidget.cpp
@@ -119,6 +119,9 @@ void CSliderWidget::Paint(
 	ASSERT(static_cast<UINT>(this->w) >= CX_SLIDER);
 	ASSERT(static_cast<UINT>(this->y) >= CX_SLIDER);
 
+	if (!IsVisible(true))
+		return; // Invisible widgets should not be drawn
+
 	//Drawing code below needs to be modified to accept offsets.  Until then,
 	//this widget can't be offset.
 	ASSERT(!IsScrollOffset());


### PR DESCRIPTION
…tings are not reset on cancel anymore, which caused widgets from different pages to momentarily draw on the screen, as the screen state is reset every time the screen is opened anyway

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44845)