### PR TITLE
Image overlay bugs

### DIFF
--- a/DROD/DrodScreen.h
+++ b/DROD/DrodScreen.h
@@ -139,7 +139,7 @@ protected:
 	UINT          SelectFiles(WSTRING& filePath, vector<WSTRING>& fileName,
 			const MESSAGE_ID messagePromptID, const UINT extensionTypes);
 	SCREENTYPE    SelectSellScreen() const;
-	void          ShowChatHistory(CEntranceSelectDialogWidget *pBox);
+	virtual void  ShowChatHistory(CEntranceSelectDialogWidget *pBox);
 	UINT          ShowGetCloudPlayerDialog();
 	UINT          ShowOkMessage(const MESSAGE_ID dwMessageID);
 	UINT          ShowOkMessage(const WCHAR *pwczText);

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -6097,6 +6097,26 @@ void CGameScreen::ShowLockIcon(const bool bShow)
 }
 
 //*****************************************************************************
+void CGameScreen::ShowChatHistory(CEntranceSelectDialogWidget* pBox)
+{
+	g_pTheSound->PauseSounds();
+
+	const Uint32 dwSpeechRemaining = this->dwNextSpeech - SDL_GetTicks();
+	this->bIsDialogDisplayed = true;
+	this->pRoomWidget->SetEffectsFrozen(true);
+
+	CDrodScreen::ShowChatHistory(pBox);
+
+	// We compute remaining speech time and replace it instead of just calculating the time the dialog
+	// was visible because dwNextSpeech can also be updated by focus changes
+	if (this->dwNextSpeech)
+		this->dwNextSpeech = SDL_GetTicks() + dwSpeechRemaining;
+	this->bIsDialogDisplayed = false;
+
+	g_pTheSound->UnpauseSounds();
+}
+
+//*****************************************************************************
 void CGameScreen::UpdatePlayerFace()
 // Refresh player face to match reality
 {

--- a/DROD/GameScreen.h
+++ b/DROD/GameScreen.h
@@ -175,6 +175,7 @@ private:
 	void           SendAchievement(const string& achievement);
 	bool           ShouldShowLevelStart();
 	void           ShowBigMap();
+	virtual void   ShowChatHistory(CEntranceSelectDialogWidget* pBox);
 	void           ShowDemosForRoom(const UINT roomID);
 	void           ShowLockIcon(const bool bShow=true);
 	void           UpdatePlayerFace();

--- a/DROD/GameScreen.h
+++ b/DROD/GameScreen.h
@@ -103,7 +103,9 @@ protected:
 	virtual void   OnBetweenEvents();
 	virtual void   OnDeactivate();
 	virtual void   OnSelectChange(const UINT dwTagNo);
-	virtual void   OnWindowEvent(const SDL_WindowEvent &wevent);
+	virtual void   OnWindowEvent(const SDL_WindowEvent& wevent);
+	virtual void   OnWindowEvent_GetFocus();
+	virtual void   OnWindowEvent_LoseFocus();
 	virtual void   Paint(bool bUpdateRect=true);
 	void           PaintClock(const bool bShowImmediately=false);
 	void           PlaySoundEffect(const UINT eSEID, float* pos=NULL, float* vel=NULL,
@@ -200,6 +202,7 @@ private:
 	bool        bNeedToProcessDelayedQuestions;
 	bool        bShowingBigMap;
 	bool        bShowingCutScene;
+	bool        bIsDialogDisplayed;
 
 	bool        bAutoUndoOnDeath;
 

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -2208,6 +2208,7 @@ void CRoomWidget::DisplayPersistingImageOverlays(CCueEvents& CueEvents)
 		const CImageOverlay *pImageOverlay = DYN_CAST(const CImageOverlay*, const CAttachableObject*, pObj);
 
 		if (pImageOverlay->loopsForever()) {
+			// These effects were already added to `persistingImageOverlays`
 			CueEvents.Remove(cid, pObj);
 			pObj = CueEvents.GetFirstPrivateData(cid);
 			continue;
@@ -2219,6 +2220,7 @@ void CRoomWidget::DisplayPersistingImageOverlays(CCueEvents& CueEvents)
 			RemoveLayerEffects(EIMAGEOVERLAY, clearsLayer);
 			CueEvents.Remove(cid, pObj);
 			pObj = CueEvents.GetFirstPrivateData(cid);
+			continue;
 		}
 
 		pObj = CueEvents.GetNextPrivateData();

--- a/FrontEndLib/DialogWidget.cpp
+++ b/FrontEndLib/DialogWidget.cpp
@@ -434,3 +434,33 @@ void CDialogWidget::CheckTextBox()
 		pOKButton->RequestPaint();
 	}
 }
+
+
+//*****************************************************************************
+void CDialogWidget::OnWindowEvent_GetFocus()
+{
+	// As a rule, dialogs appear as part of a screen, and the screen may need to do special handling
+	// when focus is restored/lost, so just pass the responsibility to them
+	ASSERT(this->pParent);
+	CEventHandlerWidget* pParent = dynamic_cast<CEventHandlerWidget*>(this->pParent);
+	if (pParent)
+		pParent->OnWindowEvent_GetFocus();
+	else {
+		ASSERT(!"Dialogs should always exist as a child of CEventHandlerWidget, will fallback!");
+		CEventHandlerWidget::OnWindowEvent_GetFocus();
+	}
+}
+
+//*****************************************************************************
+void CDialogWidget::OnWindowEvent_LoseFocus()
+{
+	// See OnWindowEvent_GetFocus() for explanation
+	ASSERT(this->pParent);
+	CEventHandlerWidget* pParent = dynamic_cast<CEventHandlerWidget*>(this->pParent);
+	if (pParent)
+		pParent->OnWindowEvent_LoseFocus();
+	else {
+		ASSERT(!"Dialogs should always exist as a child of CEventHandlerWidget, will fallback!");
+		CEventHandlerWidget::OnWindowEvent_LoseFocus();
+	}
+}

--- a/FrontEndLib/DialogWidget.h
+++ b/FrontEndLib/DialogWidget.h
@@ -91,6 +91,8 @@ protected:
 	virtual void      OnTextInput(const UINT dwTagNo, const SDL_TextInputEvent &text);
 	virtual void      OnSelectChange(const UINT dwTagNo);
 	virtual bool      OnQuit();
+	virtual void      OnWindowEvent_GetFocus();
+	virtual void      OnWindowEvent_LoseFocus();
 
 	UINT          dwDeactivateValue;
 

--- a/FrontEndLib/EventHandlerWidget.cpp
+++ b/FrontEndLib/EventHandlerWidget.cpp
@@ -435,20 +435,11 @@ void CEventHandlerWidget::OnWindowEvent(const SDL_WindowEvent &wevent)
 	switch (wevent.event)
 	{
 		case SDL_WINDOWEVENT_FOCUS_GAINED:
-			CBitmapManager::bGameHasFocus = true;
-			g_pTheSound->Unmute();
-			g_pTheSound->UnpauseSounds();
-			ClearEvents();  // !!! do we still need this?
+			OnWindowEvent_GetFocus();
 			break;
 
 		case SDL_WINDOWEVENT_FOCUS_LOST:
-			CBitmapManager::bGameHasFocus = false;
-			//Disable sound/music when app is inactive.
-			if (!g_pTheSound->bNoFocusPlaysMusic)
-				g_pTheSound->Mute();
-			else
-				g_pTheSound->PauseSounds();
-			ClearEvents();  // !!! do we still need this?
+			OnWindowEvent_LoseFocus();
 			break;
 
 		case SDL_WINDOWEVENT_EXPOSED:
@@ -468,6 +459,27 @@ void CEventHandlerWidget::OnWindowEvent(const SDL_WindowEvent &wevent)
 
 		default: break;
 	}
+}
+
+//*****************************************************************************
+void CEventHandlerWidget::OnWindowEvent_GetFocus()
+{
+	CBitmapManager::bGameHasFocus = true;
+	g_pTheSound->Unmute();
+	g_pTheSound->UnpauseSounds();
+	ClearEvents();  // !!! do we still need this?
+}
+
+//*****************************************************************************
+void CEventHandlerWidget::OnWindowEvent_LoseFocus()
+{
+	CBitmapManager::bGameHasFocus = false;
+	//Disable sound/music when app is inactive.
+	if (!g_pTheSound->bNoFocusPlaysMusic)
+		g_pTheSound->Mute();
+	else
+		g_pTheSound->PauseSounds();
+	ClearEvents();  // !!! do we still need this?
 }
 
 //**********************************************************************************

--- a/FrontEndLib/EventHandlerWidget.h
+++ b/FrontEndLib/EventHandlerWidget.h
@@ -205,6 +205,12 @@ public:
 	//Called when the window received an event, including losing/gaining
 	//focus, minimizing/restoring, and mouse entering/leaving window.
 
+	virtual void   OnWindowEvent_GetFocus();
+	//Called when window receives focus
+
+	virtual void   OnWindowEvent_LoseFocus();
+	//Called when window loses focus
+
 protected:
 	friend class CScreenManager;
 	friend class CWidget;


### PR DESCRIPTION
 - Undoing while a infinitely looping overlay is playing every turn won't duplicate the effect for one turn
 -  Effects now pause correctly when speech log is opened and resume when it's closed. Everything also works correctly with losing and regaining focus.
 - Chat history dialog will also pause effects and audio now"
 -  Finally, dialogs will delegate handling windows focus back to their parent (who should either be a screen or another dialog, which in turn will delegate it all the way back to a screen). This allows having special handling for focus, eg. repausing sound if dialog is open

----

Marked as draft since it depends on changes from #228 and #245.

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44825)