### PR TITLE
Aumtlich beams double placement

### DIFF
--- a/DROD/AumtlichGazeEffect.cpp
+++ b/DROD/AumtlichGazeEffect.cpp
@@ -68,6 +68,9 @@ void CAumtlichGazeEffect::SharedStateUpdate(const UINT wDeltaTime)
 	static bool bMakeBrighter = false;
 	static Uint32 lastUpdatePresentCount = 0;
 
+	if (wDeltaTime == 0)
+		CAumtlichGazeEffect::brightness = 255;
+
 	// Already updated this frame
 	if (lastUpdatePresentCount == CScreen::dwPresentsCount)
 		return;

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -1135,9 +1135,8 @@ void CGameScreen::OnBetweenEvents()
 //Called between frames.
 {
 	UploadDemoPolling();
-	
-	// Effects should not animate when game is not focused or a dialog is displayed
-	this->pRoomWidget->SetEffectsFrozen(!WindowHasFocus() || this->bIsDialogDisplayed);
+
+	UpdateEffectsFreeze();
 
 	if (this->bShowingBigMap)
 		return;
@@ -6430,6 +6429,19 @@ void CGameScreen::UpdateSound()
 }
 
 //*****************************************************************************
+void CGameScreen::UpdateEffectsFreeze()
+{
+	const bool bIsPlacingDouble = this->pCurrentGame && this->pCurrentGame->swordsman.wPlacingDoubleType != 0;
+
+	bool bFreezeEffects =
+		!WindowHasFocus()
+		|| this->bIsDialogDisplayed
+		|| bIsPlacingDouble;
+
+	this->pRoomWidget->SetEffectsFrozen(bFreezeEffects);
+}
+
+//*****************************************************************************
 bool CGameScreen::UploadDemoPolling()
 //As the current game queues victory demos for upload, process them here.
 //As results are received,
@@ -6615,6 +6627,7 @@ void CGameScreen::UploadPlayerProgressToCloud(const UINT holdID)
 	}
 }
 
+//*****************************************************************************
 void CGameScreen::SendAchievement(const string& achievement)
 {
 #ifdef STEAMBUILD

--- a/DROD/GameScreen.h
+++ b/DROD/GameScreen.h
@@ -188,6 +188,7 @@ private:
 	void           SynchScroll();
 	void           ToggleBigMap();
 	void           UndoMove();
+	void           UpdateEffectsFreeze();
 	void           UpdateUIAfterRoomRestart();
 	void           UpdateUIAfterMoveUndo();
 	void           UpdateScroll();


### PR DESCRIPTION
Aumtlich beams now render during double placement + further cleanup in rendering logic

Previously placing doubles would have a lot of duplicate logic to, I
presume, improve rendering speed by caching almost the whole screen.
This had a couple of problems:

1. A lot of duplicate logic made it very difficult to understand what is
happening where.
2. It was easy to forget to keep both up to date.

As such I refactored it so that it uses common rendering path

----

Depends on PR #246, posting as draft.

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=33595)