### PR TITLE
Windows: Command line option to change default player data dir location.

### DIFF
--- a/BackEndLib/Files.h
+++ b/BackEndLib/Files.h
@@ -184,6 +184,10 @@ public:
 
 	static bool bad_data_path_file;
 
+#ifdef WIN32
+	static bool bWindowsDataFilesInUserSpecificDir;
+#endif
+
 private:
 	void                 DeinitClass();
 	void                 GetDatPathFromDataPathDotTxt();


### PR DESCRIPTION
To address Metakit filepath issue not working for Windows Steam users w/ non-ascii chars in their username.