### PR TITLE
Now all cases should be fixed when leaving the room (via Go To Level …

### DIFF
--- a/DROD/MapWidget.cpp
+++ b/DROD/MapWidget.cpp
@@ -1264,7 +1264,7 @@ void CMapWidget::DrawMapSurfaceFromRoom(
 
 	//When there is no current game, then show everything fully.
 	if (this->pCurrentGame) {
-		if (bRoomIsCurrentRoom && pRoom->IsBeaconActive()) {
+		if (bRoomIsCurrentRoom && pRoom->IsBeaconActive() && !this->pCurrentGame->AreBeaconsIgnored()) {
 			bConquered = false;
 		} else {
 			bConquered = this->pCurrentGame->IsRoomAtCoordsConquered(pRoom->dwRoomX, pRoom->dwRoomY);

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -1027,9 +1027,17 @@ bool CCurrentGame::IsCurrentRoomPendingConquer() const
 {
 	// See WasRoomConqueredOnThisVisit() for more details
 	if (this->bWasRoomConqueredAtTurnStart && this->bIsLeavingLevel)
-		return true;
+		return !IsCurrentRoomConquered();
 
 	 return IsCurrentRoomPendingExit() && !this->pRoom->IsBeaconActive();
+}
+
+//*****************************************************************************
+bool CCurrentGame::AreBeaconsIgnored() const
+//Returns: whether there are any circumstances causing the beacons to be ignored when determing if room is being conquered right now
+{
+
+	return this->bWasRoomConqueredAtTurnStart && this->bIsLeavingLevel;
 }
 
 //*****************************************************************************
@@ -1957,8 +1965,8 @@ void CCurrentGame::ProcessCommand(
 	if (!this->dwCutScene)
 		ResetCutSceneStartTurn();
 
-	this->bWasRoomConqueredAtTurnStart = false; // Must set to false before the next line
-	this->bWasRoomConqueredAtTurnStart = WasRoomConqueredOnThisVisit();
+	this->bWasRoomConqueredAtTurnStart = !this->pRoom->IsBeaconActive()
+		&& (IsCurrentRoomPendingExit() || IsCurrentRoomConquered());
 
 	this->swordsman.bHasTeleported = false;
 
@@ -6336,7 +6344,7 @@ void CCurrentGame::ProcessPlayer_HandleLeaveLevel(
 		if (this->pRoom->bIsSecret)
 			UpdateHoldMastery(CueEvents);
 	} else {
-		if (this->pRoom->IsBeaconActive())
+		if (this->pRoom->IsBeaconActive() && !this->bWasRoomConqueredAtTurnStart)
 		{
 			CDbSavedGame::ConqueredRooms -= this->pRoom->dwRoomID;
 		}
@@ -7422,15 +7430,14 @@ const
 	// Level exit can be triggered by a scripting command and it's not fun for the player to be told right at this
 	// time that the room was actually not conquered, because something in the room caused that to be.
 	// Therefore we just assume that Go to level entrance keeps the room solved if it was solved when the turn started
-	if (this->bWasRoomConqueredAtTurnStart)
-		return true;
-
-	if (this->pRoom->wMonsterCount)
-		return false;     //Room is still in an unconquered state.
-	if (this->pRoom->bHasConquerToken && this->conquerTokenTurn == NO_CONQUER_TOKEN_TURN)
-		return false;  //none of the room's conquer tokens were touched
-	if (this->pRoom->IsBeaconActive())
-		return false;  //An active beacon reseeds the room
+	if (!this->bWasRoomConqueredAtTurnStart || !this->bIsLeavingLevel) {
+		if (this->pRoom->wMonsterCount)
+			return false;     //Room is still in an unconquered state.
+		if (this->pRoom->bHasConquerToken && this->conquerTokenTurn == NO_CONQUER_TOKEN_TURN)
+			return false;  //none of the room's conquer tokens were touched
+		if (this->pRoom->IsBeaconActive())
+			return false;  //An active beacon reseeds the room
+	}
 
 	//No monsters left in the room.
 	return !IsCurrentRoomConquered() ||

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -180,6 +180,7 @@ public:
 	WSTRING  AbbrevRoomLocation();
 	CMonster* AddNewEntity(CCueEvents& CueEvents, const UINT identity,
 			const UINT wX, const UINT wY, const UINT wO);
+	bool     AreBeaconsIgnored() const;
 	void     BeginDemoRecording(const WCHAR* pwczSetDescription,
 			const bool bUseCurrentTurnNo=true);
 	void     Clear(const bool bNewGame=true);


### PR DESCRIPTION
…Entrance) on the same turn as the room becomes not conquered. Specific cases fixed:

 - Hitting a beacon in a room that was cleared upon entry

 - Creating monsters in a room that was cleared upon entry and then triggering the script

Minimap no longer turns the room to green when this case happens

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=41104)