### PR TITLE
Death revamp

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3020,9 +3020,10 @@ int CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 		//Fade to black.
 		if (g_pTheBM->bAlpha && dwStart)
 		{
-			const float remainingFraction = 1 - (dwNow - dwStart) / (float)dwDeathDuration;
+			const float durationFraction = min(1, (dwNow - dwStart) / (float)dwDeathDuration);
+			const float remainingFraction = 1 - durationFraction;
 
-			this->pRoomWidget->SetDeathFadeOpacity(remainingFraction);
+			this->pRoomWidget->SetDeathFadeOpacity(durationFraction);
 			this->pRoomWidget->pMLayerEffects->SetOpacityForEffects(remainingFraction);
 			this->pRoomWidget->pLastLayerEffects->SetOpacityForEffects(remainingFraction);
 			this->pRoomWidget->DirtyRoom();  //repaint whole room each fade
@@ -3078,7 +3079,12 @@ int CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 		if (dwNow - dwStart > dwDeathDuration)
 			break;
 	}
-	delete pFade;
+	
+	this->pRoomWidget->preventDrawing = true;
+
+	this->pRoomWidget->SetDeathFadeOpacity(0);
+	this->pRoomWidget->pMLayerEffects->SetOpacityForEffects(1);
+	this->pRoomWidget->pLastLayerEffects->SetOpacityForEffects(1);
 	this->pCurrentGame->swordsman.SetOrientation(wOrigO);	//restore value
 
 	if (bPlayerFellInPit)
@@ -4516,9 +4522,6 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		}
 		CueEvents.Clear();	//clear after death sequence (whether move is undone or not)
 		//but before room restart so speech on room start can be retained
-
-		// Image overlay opacity must be restored, otherwise they'll keep their opacity while playing until they are regenerated
-		this->pRoomWidget->SetOpacityForEffectsOfType(EIMAGEOVERLAY, 1.0f);
 
 		ASSERT(!this->pCurrentGame->bIsGameActive || bUndoDeath);
 		if (GetScreenType() == SCR_Demo)

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3080,8 +3080,6 @@ int CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 			break;
 	}
 	
-	this->pRoomWidget->preventDrawing = true;
-
 	this->pRoomWidget->SetDeathFadeOpacity(0);
 	this->pRoomWidget->pMLayerEffects->SetOpacityForEffects(1);
 	this->pRoomWidget->pLastLayerEffects->SetOpacityForEffects(1);

--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -243,6 +243,11 @@ bool CImageOverlayEffect::AdvanceState(const UINT wDeltaTime)
 	// For infinite loop protection
 	const UINT wInitialIndex = this->index;
 
+	if (this->index == (UINT)-1) {
+		++this->index;
+		StartNextCommand();
+	}
+
 	// do{} is used because on the first draw wDeltaTime will be 0, and we still want non time-based commands to happen
 	do {
 		Uint32 dwConsumedTime = UpdateCommand(this->commands[this->index], this->executionState, dwRemainingTime);

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -4433,7 +4433,7 @@ void CRoomWidget::Paint(
 			PopulateBuildMarkerEffects(room);
 
 		if (this->fDeathFadeOpacity > 0)
-			g_pTheBM->DarkenRect(this->x, this->y, this->w, this->h, this->fDeathFadeOpacity, pDestSurface);
+			g_pTheBM->DarkenRect(this->x, this->y, this->w, this->h, 1.0f - this->fDeathFadeOpacity, pDestSurface);
 
 		//4. Draw player.
 		if (this->bShowingPlayer && !bIsPlacingDouble)
@@ -7318,7 +7318,7 @@ void CRoomWidget::DrawOverheadLayer(SDL_Surface *pDestSurface)
 					src.y = nI % wHeight;
 
 					if (this->fDeathFadeOpacity > 0)
-						EnableSurfaceBlending(pTileTexture, 255 * this->fDeathFadeOpacity);
+						EnableSurfaceBlending(pTileTexture, 255 * (1 - this->fDeathFadeOpacity));
 					SDL_BlitSurface(pTileTexture, &src, pDestSurface, &dest);
 					if (this->fDeathFadeOpacity > 0)
 						DisableSurfaceBlending(pTileTexture);

--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -339,6 +339,7 @@ public:
 	void           ResetJitter();
 	void           ResetRoom() {this->pRoom = NULL;}
 	void           SetAnimateMoves(const bool bAnimate) {this->bAnimateMoves = bAnimate;}
+	void           SetDeathFadeOpacity(const float opacity) { this->fDeathFadeOpacity = opacity;  }
 	void           SetEffectsFrozen(const bool bIsFrozen);
 	void           SetMoveDuration(const UINT dwDuration) {this->dwMoveDuration = dwDuration;}
 	void           SetOpacityForMLayerEffectsOfType(const EffectType eEffectType, float fOpacity);
@@ -643,6 +644,7 @@ private:
 	void           flag_weather_refresh();
 	void           SetFrameVarsForWeather();
 
+	float          fDeathFadeOpacity;
 	Uint32         time_of_last_weather_render;
 	int            redrawingRowForWeather;
 	bool           need_to_update_room_weather;

--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -321,7 +321,7 @@ public:
 	void           RemoveMLayerEffectsOfType(const EffectType eEffectType);
 	void           RemoveOLayerEffectsOfType(const EffectType eEffectType);
 	void           RemoveTLayerEffectsOfType(const EffectType eEffectType);
-	void				RenderEnvironment(SDL_Surface *pDestSurface=NULL);
+	void	       RenderEnvironment(SDL_Surface *pDestSurface=NULL);
 	void           RenderRoom(int wCol=0, int wRow=0,
 			int wWidth=CDrodBitmapManager::DISPLAY_COLS, int wHeight=CDrodBitmapManager::DISPLAY_ROWS,
 			const bool bEditor=true);

--- a/FrontEndLib/EffectList.cpp
+++ b/FrontEndLib/EffectList.cpp
@@ -362,6 +362,16 @@ SDL_Rect CEffectList::GetBoundingBoxForEffectsOfType(const UINT eEffectType) con
 }
 
 //*****************************************************************************
+void CEffectList::SetOpacityForEffects(const float fOpacity) const
+{
+	for (list<CEffect*>::const_iterator iSeek = this->Effects.begin();
+		iSeek != this->Effects.end(); ++iSeek)
+	{
+		(*iSeek)->SetOpacity(fOpacity);
+	}
+}
+
+//*****************************************************************************
 void CEffectList::SetOpacityForEffectsOfType(const UINT eEffectType, float fOpacity) const
 {
 	for (list<CEffect *>::const_iterator iSeek = this->Effects.begin();

--- a/FrontEndLib/EffectList.h
+++ b/FrontEndLib/EffectList.h
@@ -55,7 +55,8 @@ public:
 	CEffect*       GetEffectOfType(const UINT eEffectType) const;
 	SDL_Rect       GetBoundingBoxForEffectsOfType(const UINT eEffectType) const;
 	virtual void   RemoveEffectsOfType(const UINT eEffectType);
-	void           SetOpacityForEffectsOfType(const UINT eEffectType, float fOpacity) const;
+	void           SetOpacityForEffects(const float fOpacity) const;
+	void           SetOpacityForEffectsOfType(const UINT eEffectType, const float fOpacity) const;
 	void           SetEffectsFrozen(const bool bIsFrozen);
 
 	list<CEffect *> Effects;

--- a/FrontEndLib/EffectList.h
+++ b/FrontEndLib/EffectList.h
@@ -52,6 +52,7 @@ public:
 			SDL_Surface *pDestSurface=NULL,
 			const UINT eDrawnType = (UINT)-1);
 	void           EraseEffects(SDL_Surface* pBackground, const SDL_Rect& rect, const bool bUpdate=false);
+	bool           GetEffectsFrozen() const { return this->bIsFrozen; }
 	CEffect*       GetEffectOfType(const UINT eEffectType) const;
 	SDL_Rect       GetBoundingBoxForEffectsOfType(const UINT eEffectType) const;
 	virtual void   RemoveEffectsOfType(const UINT eEffectType);


### PR DESCRIPTION
Reworked death animation to no longer cache most of the room in a surface and doing shenanigans with effects and other things which caused a lot of issues with image overlays on lower levels, some effects not playing etc. This also makes the death animations much smoother.

[Relevant thred](http://forum.caravelgames.com/viewtopic.php?TopicID=44801)

----

Essentially that will mean death animation will be slightly more CPU intensive, but it will be smoother and all effects will play and there will be no issues with lower-layer image overlays suddenly appearing on top of other things.