### PR TITLE
Guards with daggers

### DIFF
--- a/BackEndLib/Files.cpp
+++ b/BackEndLib/Files.cpp
@@ -90,6 +90,7 @@ UINT CFiles::dwRefCount = 0;
 CIniFile CFiles::gameIni;
 bool CFiles::bInitedIni = false;
 bool CFiles::bIsDemo = false;
+bool CFiles::bIsRunningTests = false;
 bool CFiles::bad_data_path_file = false;
 WSTRING CFiles::wstrHomePath;
 
@@ -109,6 +110,7 @@ static const WCHAR wszDat[] = {We('.'),We('d'),We('a'),We('t'),We(0)};
 static const WCHAR wszData[] = {We('D'),We('a'),We('t'),We('a'),We(0)};
 static const WCHAR wszDataPathDotTxt[] = {We('D'),We('a'),We('t'),We('a'),We('P'),We('a'),We('t'),We('h'),We('.'),We('t'),We('x'),We('t'),We(0)};
 static const WCHAR wszDemo[] = {We('-'),We('d'),We('e'),We('m'),We('o'),We(0)};
+static const WCHAR wszTests[] = { We('-'),We('t'),We('e'),We('s'),We('t'),We('s'),We(0) };
 static const WCHAR wszCompanyName[] = {We('C'),We('a'),We('r'),We('a'),We('v'),We('e'),We('l'),We(' '),We('G'),We('a'),We('m'),We('e'),We('s'),We(0)}; // "Caravel Games"
 
 vector<string> CFiles::datFiles;
@@ -170,7 +172,8 @@ CFiles::CFiles(
 	const WCHAR *wszSetGameName,  //(in) base name of game
 	const WCHAR *wszSetGameVer,   //(in) game major version -- for finding resource files or paths
 	const bool bIsDemo,           //(in) whether we should be looking for files for a demo version or not [default=false]
-	const bool confirm_resource_file)
+	const bool confirm_resource_file,
+	const bool bIsRunningTests)   //(in) set to true by test runner to ensure it uses its own dat files
 {
 	ASSERT(this->dwRefCount == 0);
 
@@ -178,7 +181,7 @@ CFiles::CFiles(
 	ASSERT(wszSetGameName != NULL);
 	ASSERT(wszSetGameVer != NULL);
 
-	InitClass(wszSetAppPath, wszSetGameName, wszSetGameVer, bIsDemo, confirm_resource_file);
+	InitClass(wszSetAppPath, wszSetGameName, wszSetGameVer, bIsDemo, confirm_resource_file, bIsRunningTests);
 
 	++this->dwRefCount;
 }
@@ -400,6 +403,10 @@ const WSTRING CFiles::GetGameConfPath() {
 		+ CFiles::wGameName + wszHyphen	+ CFiles::wGameVer;
 	if (CFiles::bIsDemo)
 		path += CFiles::wszDemo;
+	
+	if (CFiles::bIsRunningTests)
+		path += wszTests;
+
 	return path;
 }
 
@@ -974,13 +981,15 @@ void CFiles::InitClass(
 	const WCHAR *wszSetGameName,     //(in)
 	const WCHAR *wszSetGameVer,      //(in)
 	const bool bIsDemo,              //(in)
-	const bool confirm_resource_file)
+	const bool confirm_resource_file,
+	const bool bIsRunningTests)
 {
 	ASSERT(wszSetAppPath);
 	ASSERT(wszSetGameName);
 	ASSERT(wszSetGameVer);
 
 	CFiles::bIsDemo = bIsDemo;
+	CFiles::bIsRunningTests = bIsRunningTests;
 
 	CFiles::wCompanyName = wszCompanyName;
 

--- a/BackEndLib/Files.h
+++ b/BackEndLib/Files.h
@@ -88,7 +88,8 @@ public:
 	//call this constructor first to init the class
 	CFiles(const WCHAR *wszSetAppPath,
 				const WCHAR *wszSetGameName, const WCHAR *wszSetGameVer,
-				const bool bIsDemo = false, const bool confirm_resource_file = true);
+				const bool bIsDemo = false, const bool confirm_resource_file = true,
+				const bool bIsRunningTests = false);
 	CFiles(); //may call this one after the class has been inited
 	~CFiles();
 
@@ -200,7 +201,7 @@ private:
 #endif
 	void                 InitClass(const WCHAR *pszSetAppPath,
 			const WCHAR *wszSetGameName, const WCHAR *wszSetGameVer, const bool bIsDemo,
-			const bool confirm_resource_file);
+			const bool confirm_resource_file, const bool bIsRunningTests);
 	static bool          InitINI();
 	static void          SetupHomePath();
 	static void          SetupHomePathSubDirs();
@@ -225,6 +226,7 @@ private:
 	static CIniFile gameIni;
 	static bool bInitedIni;
 	static bool bIsDemo;
+	static bool bIsRunningTests;
 
 #ifdef WIN32
 #define NUMDRIVES (26)

--- a/DRODLib/Guard.cpp
+++ b/DRODLib/Guard.cpp
@@ -70,9 +70,10 @@ const
 			return true;
 		if (pMonster->wType == M_CHARACTER) {
 			CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
-			if (pCharacter->IsInvulnerable() || pCharacter->IsPushableByWeaponAttack() || !this->CanDaggerStep(pCharacter->GetIdentity())) {
+			if (pCharacter->IsInvulnerable()
+					|| pCharacter->IsPushableByWeaponAttack()
+					|| !this->CanDaggerStep(pCharacter->wType)) // wType instead of GetIdentity() to make it consistent with Player behavior
 				return true;
-			}
 		}
 
 	}

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -2159,7 +2159,7 @@ void CMonster::Move(
 			case M_CHARACTER:
 			{
 				const bool bCanStrike = bIsStalwart(pMonster->GetIdentity()) ||
-					this->CanDaggerStep(pMonster->GetIdentity(), false);
+					this->CanDaggerStep(pMonster->wType, false);
 				ASSERT(bIsSmitemaster(pMonster->GetIdentity()) ||
 					pMonster->GetIdentity() == M_BEETHRO_IN_DISGUISE ||
 					bCanStrike);

--- a/DRODLibTests/src/CTestDb.cpp
+++ b/DRODLibTests/src/CTestDb.cpp
@@ -40,6 +40,7 @@ void CTestDb::Init(int argc, char* const argv[])
 	CTestDb::InitializeLevel();
 	CTestDb::InitializeRoom();
 	CTestDb::InitializeEntrance();
+	CTestDb::db->Commit();
 }
 
 void CTestDb::Teardown()
@@ -48,6 +49,7 @@ void CTestDb::Teardown()
 	CTestDb::db->Levels.Delete(CTestDb::globalLevelID);
 	CTestDb::db->Holds.Delete(CTestDb::globalHoldID);
 	CTestDb::db->Players.Delete(CTestDb::globalPlayerID, false);
+	CTestDb::db->Commit();
 }
 
 CCurrentGame* CTestDb::GetGame(const UINT playerX, const UINT playerY, const UINT playerO){
@@ -88,7 +90,7 @@ void CTestDb::InitializeCFiles(char* const argv[]){
 	playerDataSubDirs.push_back("Music");
 	playerDataSubDirs.push_back("Sounds");
 	CFiles::InitAppVars(wszUniqueResFile, datFiles, playerDataSubDirs);
-	CTestDb::files = new CFiles(wstrPath.c_str(), wszDROD, wszDROD_VER, false);
+	CTestDb::files = new CFiles(wstrPath.c_str(), wszDROD, wszDROD_VER, false, true, true);
 	if (CFiles::bad_data_path_file) {
 		throw 1;
 	}
@@ -226,6 +228,7 @@ void CTestDb::RegenerateRoom(){
 
 	InitializeRoom();
 	InitializeEntrance();
+	CTestDb::db->Commit();
 }
 
 void CTestDb::GetAppPath(

--- a/DRODLibTests/src/Runner.cpp
+++ b/DRODLibTests/src/Runner.cpp
@@ -107,7 +107,7 @@ void Runner::InitializeDatPath(){
 	wstrDatPathTxt += wstrExtension;
 
 	pErrorLogPath = new char[wstrDatPathTxt.length() * 2];
-	UnicodeToUTF8(wstrDatPathTxt.c_str(), pErrorLogPath);
+	UnicodeToAscii(wstrDatPathTxt.c_str(), pErrorLogPath);
 }
 
 CDbRoom* Runner::GetRoom(){

--- a/DRODLibTests/src/tests/Monsters/ArmedMonsters/RearmedGuards.cpp
+++ b/DRODLibTests/src/tests/Monsters/ArmedMonsters/RearmedGuards.cpp
@@ -66,6 +66,18 @@ TEST_CASE("Guards wielding different weapons", "[game][guard][weapon]") {
 		AssertMonsterType(11, 10, M_GUARD);
 	}
 
+	SECTION("Guard with a dagger will kill-step vulnerable characters (even if role that normally can't be stepped on)") {
+		RoomBuilder::AddMonsterWithWeapon(M_GUARD, WT_Dagger, 10, 10, N);
+		CCharacter* pCharacter = RoomBuilder::AddVisibleCharacter(11, 10, S, M_CITIZEN);
+		RoomBuilder::AddCommand(pCharacter, CCharacterCommand::CC_Imperative, ScriptFlag::Vulnerable);
+
+		CCurrentGame* game = Runner::StartGame(13, 10, S);
+		Runner::ExecuteCommand(CMD_WAIT);
+
+		AssertEvent(CID_MonsterDiedFromStab);
+		AssertMonsterType(11, 10, M_GUARD);
+	}
+
 	SECTION("Guard with a dagger will walk around invulnerable (naturally) characters") {
 		RoomBuilder::AddMonsterWithWeapon(M_GUARD, WT_Dagger, 10, 10, N);
 		RoomBuilder::AddVisibleCharacter(11, 10, S, M_CITIZEN);


### PR DESCRIPTION
 - Guards with daggers can now dagger step vulnerable characters regardless of their appearance
 - Also tests were broken by the Ascii -> Utf8 change so I fixed them 
 - Fixed the assertion that kept failing during test teardown since forever
 - Also tests are now  guaranteed to run with their own dats
