### PR TITLE
Fixes to effect and rendering:

### DIFF
--- a/DROD/EditRoomWidget.cpp
+++ b/DROD/EditRoomWidget.cpp
@@ -1591,12 +1591,17 @@ void CEditRoomWidget::DrawMonsters(
 	SDL_Surface *pDestSurface,
 	const bool bMoveInProgress)   //
 {
+	vector<CMonster*> drawnMonsters;
 	CMonster *pMonster = pMonsterList;
 	while (pMonster)
 	{
+		drawnMonsters.push_back(pMonster);
+
 		DrawMonster(pMonster, this->pRoom, pDestSurface, bMoveInProgress);
 		pMonster = pMonster->pNext;
 	}
+
+	DrawSwordsFor(drawnMonsters, pDestSurface);
 }
 
 //******************************************************************************

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -2054,18 +2054,6 @@ void CRoomWidget::ProcessCueEventsBeforeRoomDraw(const CCueEvents &CueEvents)
 }
 
 //*****************************************************************************
-void CRoomWidget::PutTLayerEffectsOnMLayer()
-//During death sequence, only m-layer effects show up.
-//This places all effects in the o- and t-layers at the beginning of the m-layer (to be drawn first).
-{
-	this->pMLayerEffects->Effects.insert(this->pMLayerEffects->Effects.begin(), this->pTLayerEffects->Effects.begin(), this->pTLayerEffects->Effects.end());
-	this->pTLayerEffects->Effects.clear();
-
-	this->pMLayerEffects->Effects.insert(this->pMLayerEffects->Effects.begin(), this->pOLayerEffects->Effects.begin(), this->pOLayerEffects->Effects.end());
-	this->pOLayerEffects->Effects.clear();
-}
-
-//*****************************************************************************
 void CRoomWidget::SetMoveCountText()
 {
 	if (!this->bShowMoveCount || !this->pCurrentGame)
@@ -4368,8 +4356,8 @@ void CRoomWidget::Paint(
 	// O-Layers need to be updated and dirtied before O-Layer is drawn to ensure lighting is correctly applied for
 	// pieces of the effects that enter a new tile
 	this->pOLayerEffects->UpdateEffects();
-	this->pMLayerEffects->UpdateEffects();
 	this->pTLayerEffects->UpdateEffects();
+	this->pMLayerEffects->UpdateEffects();
 	this->pLastLayerEffects->UpdateEffects();
 	this->pOLayerEffects->DirtyTiles();
 
@@ -4528,6 +4516,8 @@ void CRoomWidget::Paint(
 
 	//If any widgets are attached to this one, draw them now.
 	PaintChildren();
+
+	this->pOLayerEffects->DirtyTiles();
 
 	//7. Show changes on screen.
 	if (bUpdateRect)

--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -310,7 +310,6 @@ public:
 			const UINT wH, const bool bUpdateRect = true);
 	bool           PlayerLightTurnedOff() const;
 	void           ProcessCueEventsBeforeRoomDraw(const CCueEvents &CueEvents);
-	void           PutTLayerEffectsOnMLayer();
 
 	void           QueueRemoveLayerEffectsOfType(const EffectType eEffectType, int layer) {
 		queued_layer_effect_type_removal.insert(make_pair(eEffectType, layer)); }

--- a/DROD/SteamEffect.cpp
+++ b/DROD/SteamEffect.cpp
@@ -78,8 +78,8 @@ void CSteamEffect::Draw(SDL_Surface& destSurface)
 	//Fade out.
 	g_pTheBM->BlitTileImagePart(this->wDrawTile, 
 			this->wDrawX, this->wDrawY,
-			0, this->wDrawY,
-			CDrodBitmapManager::CX_TILE, CDrodBitmapManager::CY_TILE - this->wDrawY,
+			0, this->wDrawClipY,
+			CDrodBitmapManager::CX_TILE, CDrodBitmapManager::CY_TILE - this->wDrawClipY,
 			&destSurface, false, this->nDrawOpacity);
 }
 

--- a/DROD/StrikeOrbEffect.cpp
+++ b/DROD/StrikeOrbEffect.cpp
@@ -45,6 +45,7 @@ CStrikeOrbEffect::CStrikeOrbEffect(
 	SDL_Surface *pSetPartsSurface,   //(in)   Preloaded surface containing bolt parts.
 	const bool bSetDrawOrb)          //(in)   True if the orb should be drawn
 	: CEffect(pSetWidget, StrikeOrbEffectDuration, EORBHIT)
+	, bSuppressDraw(false)
 {
 	ASSERT(pSetWidget->GetType() == WT_Room);
 	ASSERT(pSetPartsSurface);
@@ -102,9 +103,12 @@ CStrikeOrbEffect::~CStrikeOrbEffect()
 bool CStrikeOrbEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 {
 	this->dirtyRects.clear();  //Reset dirty regions.
+	this->bSuppressDraw = false;
 
-	if (this->eOrbType == OT_BROKEN && RAND(5) != 0)
+	if (this->bDrawOrb && this->eOrbType == OT_BROKEN && RAND(5) != 0) {
+		this->bSuppressDraw = true;
 		return true; //flicker when broken
+	}
 
 	if (bDrawOrb)
 		this->dirtyRects.push_back(MAKE_SDL_RECT(this->wOrbX, this->wOrbY, CBitmapManager::CX_TILE, CBitmapManager::CY_TILE));
@@ -129,6 +133,9 @@ bool CStrikeOrbEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 //********************************************************************************
 void CStrikeOrbEffect::Draw(SDL_Surface& destSurface)
 {
+	if (this->bSuppressDraw)
+		return;
+
 	//Draw activated orb tile.
 	if (bDrawOrb)
 	    g_pTheBM->BlitTileImage(TI_ORB_L, this->wOrbX, this->wOrbY, &destSurface, false);

--- a/DROD/StrikeOrbEffect.h
+++ b/DROD/StrikeOrbEffect.h
@@ -63,6 +63,7 @@ private:
 
 	Uint8 nOpacity;
 	vector<BOLT_SEGMENTS*> drawBolts;
+	bool bSuppressDraw;
 
 	SDL_Surface *  pPartsSurface;
 };

--- a/DROD/TemporalMoveEffect.cpp
+++ b/DROD/TemporalMoveEffect.cpp
@@ -48,6 +48,8 @@ CTemporalMoveEffect::CTemporalMoveEffect(
 	, startDelay(START_DELAY)
 	, endDelay(END_DELAY)
 	, isBump(isBump)
+	, nOpacity(0)
+	, wDrawX(0), wDrawY(0)
 {
 	ASSERT(pSetWidget);
 	ASSERT(pSetWidget->GetType() == WT_Room);
@@ -61,6 +63,8 @@ CTemporalMoveEffect::CTemporalMoveEffect(
 	this->startY = this->wY;
 	this->deltaX = nGetOX(SetCoord.wO) * CBitmapManager::CX_TILE;
 	this->deltaY = nGetOY(SetCoord.wO) * CBitmapManager::CY_TILE;
+
+	this->blitRect = MAKE_SDL_RECT(this->wX, this->wY, CBitmapManager::CX_TILE, CBitmapManager::CY_TILE);
 }
 
 //********************************************************************************

--- a/DROD/VarMonitorEffect.cpp
+++ b/DROD/VarMonitorEffect.cpp
@@ -114,7 +114,6 @@ void CVarMonitorEffect::SetTextForNewTurn()
 	}
 
 	this->lastTurn = turn;
-	this->dwTimeElapsed = 0;
 }
 
 //*****************************************************************************

--- a/FrontEndLib/DialogWidget.cpp
+++ b/FrontEndLib/DialogWidget.cpp
@@ -442,25 +442,38 @@ void CDialogWidget::OnWindowEvent_GetFocus()
 	// As a rule, dialogs appear as part of a screen, and the screen may need to do special handling
 	// when focus is restored/lost, so just pass the responsibility to them
 	ASSERT(this->pParent);
-	CEventHandlerWidget* pParent = dynamic_cast<CEventHandlerWidget*>(this->pParent);
+	CEventHandlerWidget* pParent = FindEventHandlerParent();
 	if (pParent)
 		pParent->OnWindowEvent_GetFocus();
-	else {
-		ASSERT(!"Dialogs should always exist as a child of CEventHandlerWidget, will fallback!");
+	else
 		CEventHandlerWidget::OnWindowEvent_GetFocus();
-	}
 }
 
 //*****************************************************************************
 void CDialogWidget::OnWindowEvent_LoseFocus()
 {
 	// See OnWindowEvent_GetFocus() for explanation
-	ASSERT(this->pParent);
-	CEventHandlerWidget* pParent = dynamic_cast<CEventHandlerWidget*>(this->pParent);
+	CEventHandlerWidget* pParent = FindEventHandlerParent();
 	if (pParent)
 		pParent->OnWindowEvent_LoseFocus();
-	else {
-		ASSERT(!"Dialogs should always exist as a child of CEventHandlerWidget, will fallback!");
+	else
 		CEventHandlerWidget::OnWindowEvent_LoseFocus();
+}
+
+//*****************************************************************************
+CEventHandlerWidget* CDialogWidget::FindEventHandlerParent() const
+{
+	ASSERT(this->pParent);
+	CWidget* pParent = this->pParent;
+
+	while (pParent) {
+		CEventHandlerWidget* pEventHandlerParent = dynamic_cast<CEventHandlerWidget*>(pParent);
+		if (pEventHandlerParent)
+			return pEventHandlerParent;
+
+		pParent = pParent->GetParent();
 	}
+
+	ASSERT(!"Dialogs should always exist as a child of CEventHandlerWidget, will fallback!");
+	return NULL;
 }

--- a/FrontEndLib/DialogWidget.h
+++ b/FrontEndLib/DialogWidget.h
@@ -97,6 +97,7 @@ protected:
 	UINT          dwDeactivateValue;
 
 private:
+	CEventHandlerWidget* FindEventHandlerParent() const;
 	UINT          dwReqTextField;   //when a text box is present as a child
 	bool           bListBoxDoubleClickReturns;
 	SDL_Rect       centerRect;

--- a/FrontEndLib/Widget.h
+++ b/FrontEndLib/Widget.h
@@ -236,6 +236,9 @@ class CScalerWidget;
 class CScreenManager;
 class CWidget : public CAttachableObject
 {
+public:
+	CWidget* GetParent() const { return this->pParent; }
+
 protected:
 	friend class CEffectList;
 	friend class CEventHandlerWidget;


### PR DESCRIPTION
 - O-layer effects dirty room at the end of room drawing to avoid artifacts being left
 - Temporal projection preview no longer assertion beeps
 - Steam Effect now draws again
 - Var Monitor no longer redraws every turn when no changes to variables
 were detected
 - Strike orb effect will no longer leave artifacts when triggered by
 one-use plate or cracked orb
 - Dialogs which attach to RoomWidget (Current Game Info) will no longer
 assert beep when getting/losing focus
 - In the editor characters' swords will not flicker or disapper when
 sub menus are opened

 - Removed dead code `CRoomWidget::PutTLayerEffectsOnMLayer()`

----

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44919)