### PR TITLE
Refactor logic for checking behaviors

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -761,31 +761,31 @@ bool CCharacter::IsImmuneToWeapon(WeaponType type) const
 	switch (type)
 	{
 		case WT_HotTile: {
-			return (behaviorFlags.count(ScriptFlag::HotTileImmune) == 1);
+			return HasBehavior(ScriptFlag::HotTileImmune);
 		}
 		case WT_Firetrap: {
-			return (behaviorFlags.count(ScriptFlag::FiretrapImmune) == 1);
+			return HasBehavior(ScriptFlag::FiretrapImmune);
 		}
 		case WT_FloorSpikes: {
-			return (behaviorFlags.count(ScriptFlag::FloorSpikeImmune) == 1);
+			return HasBehavior(ScriptFlag::FloorSpikeImmune);
 		}
 		case WT_Sword: {
-			return (behaviorFlags.count(ScriptFlag::SwordDamageImmune) == 1);
+			return HasBehavior(ScriptFlag::SwordDamageImmune);
 		}
 		case WT_Pickaxe: {
-			return (behaviorFlags.count(ScriptFlag::PickaxeDamageImmune) == 1);
+			return HasBehavior(ScriptFlag::PickaxeDamageImmune);
 		}
 		case WT_Spear: {
-			return (behaviorFlags.count(ScriptFlag::SpearDamageImmune) == 1);
+			return HasBehavior(ScriptFlag::SpearDamageImmune);
 		}
 		case WT_Staff: {
 			return true;
 		}
 		case WT_Dagger: {
-			return (behaviorFlags.count(ScriptFlag::DaggerDamageImmune) == 1);
+			return HasBehavior(ScriptFlag::DaggerDamageImmune);
 		}
 		case WT_Caber: {
-			return (behaviorFlags.count(ScriptFlag::CaberDamageImmune) == 1);
+			return HasBehavior(ScriptFlag::CaberDamageImmune);
 		}
 		default: {
 			ASSERT(!"Bad weapon type");
@@ -3428,13 +3428,13 @@ void CCharacter::BuildTiles(const CCharacterCommand& command, CCueEvents& CueEve
 
 //*****************************************************************************
 bool CCharacter::CanPushObjects() const {
-	return (behaviorFlags.count(ScriptFlag::PushObjects) == 1);
+	return HasBehavior(ScriptFlag::PushObjects);
 }
 
 //*****************************************************************************
 bool CCharacter::CanPushMonsters() const
 {
-	return (behaviorFlags.count(ScriptFlag::PushMonsters) == 1);
+	return HasBehavior(ScriptFlag::PushMonsters);
 }
 
 //*****************************************************************************
@@ -3447,7 +3447,7 @@ bool CCharacter::CanPushOntoOTileAt(UINT wX, UINT wY) const
 
 	// If the character is immune to "fatal pushes", only allow it to be pushed
 	// to tiles that won't cause it to fall
-	bool bOnlySafe = (behaviorFlags.count(ScriptFlag::FatalPushImmune) == 1);
+	bool bOnlySafe = HasBehavior(ScriptFlag::FatalPushImmune);
 
 	if (!bOnlySafe) {
 		// We don't care that these tiles might be deadly
@@ -3473,10 +3473,10 @@ bool CCharacter::CanDropTrapdoor(const UINT oTile) const
 	if (!bIsFallingTile(oTile))
 		return false;
 
-	if (behaviorFlags.count(ScriptFlag::DropTrapdoors) == 1)
+	if (HasBehavior(ScriptFlag::DropTrapdoors))
 		return true;
 	
-	if (behaviorFlags.count(ScriptFlag::DropTrapdoorsArmed) == 1) {
+	if (HasBehavior(ScriptFlag::DropTrapdoorsArmed)) {
 		if (bIsThinIce(oTile))
 			return true;
 
@@ -3606,7 +3606,7 @@ bool CCharacter::IsAttackableTarget() const
 	if (IsInvulnerable())
 		return false;
 
-	return (behaviorFlags.count(ScriptFlag::MonsterAttackable) == 1);
+	return HasBehavior(ScriptFlag::MonsterAttackable);
 }
 
 //*****************************************************************************
@@ -3634,7 +3634,7 @@ bool CCharacter::IsFriendly() const
 bool CCharacter::IsMonsterTarget() const
 //Returns: whether the character is a valid target for monsters
 {
-	if (behaviorFlags.count(ScriptFlag::MonsterTarget)) {
+	if (HasBehavior(ScriptFlag::MonsterTarget)) {
 		return true;
 	}
 
@@ -4424,7 +4424,7 @@ const
 			//If standing on a platform, check whether it can move.
 			case T_PIT: case T_PIT_IMAGE:
 				if (room.GetOSquare(this->wX, this->wY) == T_PLATFORM_P 
-						&& behaviorFlags.count(ScriptFlag::MovePlatforms) == 1)
+						&& HasBehavior(ScriptFlag::MovePlatforms))
 				{
 					const int nFirstO = nGetO((int)wCol - (int)this->wX, (int)wRow - (int)this->wY);
 					if (room.CanMovePlatform(this->wX, this->wY, nFirstO))
@@ -4433,7 +4433,7 @@ const
 			return true;
 			case T_WATER: /*case T_SHALLOW_WATER:*/
 				if (room.GetOSquare(this->wX, this->wY) == T_PLATFORM_W
-						&& behaviorFlags.count(ScriptFlag::MovePlatforms) == 1)
+						&& HasBehavior(ScriptFlag::MovePlatforms))
 				{
 					const int nFirstO = nGetO((int)wCol - (int)this->wX, (int)wRow - (int)this->wY);
 					// @FIXME - nDist is a temporary fix to prevent hard crashes 
@@ -4561,7 +4561,7 @@ bool CCharacter::IsOpenMove(const int dx, const int dy) const
 bool CCharacter::IsPuffTarget() const
 // Returns: whether Puff monsters should treat this character as a target
 {
-	return (behaviorFlags.count(ScriptFlag::PuffTarget) == 1);
+	return HasBehavior(ScriptFlag::PuffTarget);
 }
 
 //*****************************************************************************
@@ -5629,7 +5629,7 @@ void CCharacter::MoveCharacter(
 
 
 	//Process any and all of these item interactions.
-	if (bWasOnPlatform && behaviorFlags.count(ScriptFlag::MovePlatforms) == 1)
+	if (bWasOnPlatform && HasBehavior(ScriptFlag::MovePlatforms))
 	{
 		const UINT wOTile = room.GetOSquare(this->wX, this->wY);
 		if (bIsPit(wOTile) || bIsDeepWater(wOTile))
@@ -5638,13 +5638,13 @@ void CCharacter::MoveCharacter(
 
 	UINT tTile = room.GetTSquare(this->wX, this->wY);
 
-	if (bIsTLayerCoveringItem(tTile) && behaviorFlags.count(ScriptFlag::PushObjects) == 1)
+	if (bIsTLayerCoveringItem(tTile) && HasBehavior(ScriptFlag::PushObjects))
 	{
 		room.PushTLayerObject(this->wX, this->wY, this->wX + dx, this->wY + dy, CueEvents);
 		tTile = room.GetTSquare(this->wX, this->wY); //also check what was under the item
 	}
 
-	if (behaviorFlags.count(ScriptFlag::ActivateTokens) == 1) {
+	if (HasBehavior(ScriptFlag::ActivateTokens)) {
 		if (tTile == T_TOKEN)
 			room.ActivateToken(CueEvents, this->wX, this->wY, this);
 	}
@@ -5671,7 +5671,7 @@ void CCharacter::RefreshBriars()
 // Refresh briars if the NPC can block them
 // Do so by acting as if a new tile has been plotted at the character's position
 {
-	if (behaviorFlags.count(ScriptFlag::BriarImmune) == 1) {
+	if (HasBehavior(ScriptFlag::BriarImmune)) {
 		CDbRoom& room = *(this->pCurrentGame->pRoom);
 		room.briars.plotted(this->wX, this->wY, T_EMPTY);
 	}

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4836,10 +4836,10 @@ void CCharacter::SetCurrentGame(
 
 	if (bIsHuman(wResolvedIdentity))
 	{
-		behaviorFlags.insert(ScriptFlag::Behavior::ActivateTokens);
-		behaviorFlags.insert(ScriptFlag::Behavior::PushObjects);
+		behaviorFlags.insert(ScriptFlag::ActivateTokens);
+		behaviorFlags.insert(ScriptFlag::PushObjects);
 		behaviorFlags.insert(ScriptFlag::PushMonsters);
-		behaviorFlags.insert(ScriptFlag::Behavior::MovePlatforms);
+		behaviorFlags.insert(ScriptFlag::MovePlatforms);
 	}
 
 	if (!this->IsFlying() && this->GetIdentity() != M_SEEP) {
@@ -4848,7 +4848,7 @@ void CCharacter::SetCurrentGame(
 
 	if (bIsSmitemaster(wResolvedIdentity) || bIsStalwart(wResolvedIdentity)) {
 		//These types can be attacked and killed by default.
-		behaviorFlags.insert(ScriptFlag::Behavior::MonsterAttackable);
+		behaviorFlags.insert(ScriptFlag::MonsterAttackable);
 	}	else if (wResolvedIdentity == M_CLONE || wResolvedIdentity == M_TEMPORALCLONE) {
 		behaviorFlags.insert(ScriptFlag::MonsterTargetIfPlayerIs);
 	}

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -118,7 +118,7 @@ public:
 	virtual UINT   GetIdentity() const {return this->wIdentity;}
 	virtual UINT   GetResolvedIdentity() const;
 	UINT           GetNextSpeechID();
-	bool           HasBehavior(ScriptFlag::Behavior behavior) const { return behaviorFlags.count(behavior); };
+	bool           HasBehavior(ScriptFlag::Behavior behavior) const { return behaviorFlags.count(behavior) == 1; };
 	bool           HasSpecialDeath() const;
 	virtual bool   HasSword() const;
 

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -118,6 +118,7 @@ public:
 	virtual UINT   GetIdentity() const {return this->wIdentity;}
 	virtual UINT   GetResolvedIdentity() const;
 	UINT           GetNextSpeechID();
+	bool           HasBehavior(ScriptFlag::Behavior behavior) const { return behaviorFlags.count(behavior); };
 	bool           HasSpecialDeath() const;
 	virtual bool   HasSword() const;
 

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -92,7 +92,7 @@ public:
 	virtual CMonster* Replicate() const;
 
 	virtual bool   CanDropTrapdoor(const UINT oTile) const;
-	virtual bool   CanPressPressurePlates() const { return behaviorFlags.count(ScriptFlag::ActivatePlates) == 1; }
+	virtual bool   CanPressPressurePlates() const { return HasBehavior(ScriptFlag::ActivatePlates); }
 	virtual bool   CanPushObjects() const;
 	virtual bool   CanPushMonsters() const;
 	bool           CanPushOntoOTileAt(UINT wX, UINT wY) const;
@@ -139,12 +139,12 @@ public:
 	int getLocalVarInt(const WSTRING& varName) const;
 	WSTRING getLocalVarString(const WSTRING& varName) const;
 
-	bool           IsAdderImmune() const { return behaviorFlags.count(ScriptFlag::AdderImmune) == 1; }
+	bool           IsAdderImmune() const { return HasBehavior(ScriptFlag::AdderImmune); }
 	virtual bool   IsAlive() const {return this->bAlive && !this->bReplaced;}
 	virtual bool   IsAttackableTarget() const;
 	virtual bool   IsBrainPathmapObstacle() const;
-	bool           IsBriarImmune() const { return behaviorFlags.count(ScriptFlag::BriarImmune) == 1; }
-	bool           IsExplosionImmune() const {return behaviorFlags.count(ScriptFlag::ExplosionImmune) == 1;}
+	bool           IsBriarImmune() const { return HasBehavior(ScriptFlag::BriarImmune); }
+	bool           IsExplosionImmune() const {return HasBehavior(ScriptFlag::ExplosionImmune); }
 	virtual bool   IsFlying() const;
 	virtual bool   IsFriendly() const;
 	bool           IsGhostImage() const {return this->eDisplayMode != CDM_Normal;}
@@ -158,7 +158,7 @@ public:
 	virtual bool   IsMonsterTarget() const;
 	virtual bool   IsNPCPathmapObstacle() const;
 	virtual bool   IsOpenMove(const int dx, const int dy) const;
-	bool           IsPuffImmune() const { return behaviorFlags.count(ScriptFlag::PuffImmune) == 1; }
+	bool           IsPuffImmune() const { return HasBehavior(ScriptFlag::PuffImmune); }
 	bool           IsPuffTarget() const;
 	virtual bool   IsPushableByBody() const;
 	virtual bool   IsPushableByWeaponAttack() const;

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -11031,7 +11031,7 @@ void CDbRoom::SetPressurePlatesState()
 			}
 			break;
 		}
-		if (!(pMonster->IsFlying() || pMonster->wType == M_SEEP))
+		if (pMonster->CanPressPressurePlates())
 		{
 			COrbData *pPlate = GetPressurePlateAtCoords(pMonster->wX, pMonster->wY);
 			if (pPlate)

--- a/DRODLibTests/src/Runner.h
+++ b/DRODLibTests/src/Runner.h
@@ -26,7 +26,7 @@ public:
 	static CCueEvents& GetLastCueEvents();
 
 private:
-	static string pErrorLogPath;
+	static string errorLogPath;
 	static UINT GetErrorLogSize();
 	static CCurrentGame* currentGame;
 	static CCueEvents lastCueEvents;


### PR DESCRIPTION
This compacts the checks for character behaviors into a single function. Places that used to check `behaviorFlags` now use the `HasBehavior()` function. This should makes things a little more readable, and means if things outside of the character class need to check for behaviors, they can.

There's also a bit of tidying up, including plugging `CanPressPressurePlates()` into a place it should be used.