### PR TITLE
Clone movement order will now be preserved when swapping together wit…

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -7266,10 +7266,10 @@ void CCurrentGame::TallyKill()
 }
 
 //*****************************************************************************
-bool cloneComparator::operator() (const CClone *a, const CClone *b) const
+bool cloneComparator::operator() (const CMoveCoordEx &a, const CMoveCoordEx &b) const
 //Compare clones by wCreationIndex
 {
-    return a->wCreationIndex < b->wCreationIndex;
+    return a.wValue < b.wValue;
 }
 
 //*****************************************************************************
@@ -7314,20 +7314,41 @@ bool CCurrentGame::SwitchToCloneAt(const UINT wX, const UINT wY)
 	if (this->swordsman.IsTarget())
 		this->pRoom->SetPathMapsTarget(wX,wY);
 
-	// Sort the clones by creationIndex and relink them in the room
+	// Sort the clones by creationIndex and reposition them
+	// We do the weird positiong swapping instead of unlink/relink to preserve movement order
+	// of every other monster
 	{
 		std::vector<CClone*> clones;
-		pMonster = this->pRoom->GetMonsterOfType(M_CLONE);
-		while (pMonster && pMonster->wType == M_CLONE) {
-			pClone = DYN_CAST(CClone*, CMonster*, pMonster);
-			clones.push_back(pClone);
-			this->pRoom->UnlinkMonster(pClone);
+		pMonster = this->pRoom->GetMonsterOfType(M_CLONE, true);
+		while (pMonster && pMonster->wProcessSequence == SPD_PDOUBLE) {
+			if (pMonster->wType == M_CLONE) {
+				pClone = DYN_CAST(CClone*, CMonster*, pMonster);
+				clones.push_back(pClone);
+				this->pRoom->RemoveMonsterFromTileArray(pClone);
+			}
 			pMonster = pMonster->pNext;
 		}
-		std::sort(clones.begin(), clones.end(), cloneComparator());
 
-		for (vector<CClone*>::const_iterator iter = clones.begin(); iter != clones.end(); ++iter)
-			this->pRoom->LinkMonster(*iter, false);
+		std::vector<CMoveCoordEx> sortedClones;
+		for (UINT i = 0; i < clones.size(); ++i) {
+			CClone* clone = clones[i];
+			sortedClones.push_back(CMoveCoordEx(clone->wX, clone->wY, clone->wO, clone->wCreationIndex));
+		}
+
+		std::sort(sortedClones.begin(), sortedClones.end(), cloneComparator());
+
+		ASSERT(sortedClones.size() == clones.size());
+		for (UINT i = 0; i < clones.size(); ++i) {
+			CClone* existingClone = clones[i];
+			CMoveCoordEx sortedClone = sortedClones[i];
+
+			existingClone->wPrevX = existingClone->wX = sortedClone.wX;
+			existingClone->wPrevY = existingClone->wY = sortedClone.wY;
+			existingClone->wPrevO = existingClone->wO = sortedClone.wO;
+			existingClone->wCreationIndex = sortedClone.wValue;
+
+			this->pRoom->SetMonsterSquare(existingClone);
+		}
 
 	}
 

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -149,7 +149,7 @@ struct RoomCompletionData
 };
 
 struct cloneComparator {
-    bool operator() (const CClone *a, const CClone *b) const;
+    bool operator() (const CMoveCoordEx &a, const CMoveCoordEx &b) const;
 };
 
 //*******************************************************************************

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2930,12 +2930,14 @@ bool CDbRoom::DoesSquareContainTeleportationObstacle(
 CMonster* CDbRoom::FindNextClone()
 //Returns: pointer to next monster of type M_CLONE, else NULL if none
 {
-	CClone* pFirstClone = DYN_CAST(CClone*, CMonster*, GetMonsterOfType(M_CLONE));
+	CClone* pFirstClone = DYN_CAST(CClone*, CMonster*, GetMonsterOfType(M_CLONE, true));
 	CMonster* pMonster = pFirstClone;
-	while (pMonster && pMonster->wType == M_CLONE) {
-		CClone* pClone = DYN_CAST(CClone*, CMonster*, pMonster);
-		if (pClone->wCreationIndex > this->wLastCloneIndex) {
-			return pClone;
+	while (pMonster && pMonster->wProcessSequence == SPD_PDOUBLE) {
+		if (pMonster->wType == M_CLONE) {
+			CClone* pClone = DYN_CAST(CClone*, CMonster*, pMonster);
+			if (pClone->wCreationIndex > this->wLastCloneIndex) {
+				return pClone;
+			}
 		}
 
 		pMonster = pMonster->pNext;
@@ -3578,7 +3580,7 @@ const CMonster* CDbRoom::GetOwningMonsterOnSquare(const UINT wX, const UINT wY) 
 }
 
 //*****************************************************************************
-CMonster* CDbRoom::GetMonsterOfType(const UINT wType) const
+CMonster* CDbRoom::GetMonsterOfType(const UINT wType, const bool bIgnoreCharacterAppearance) const
 //Returns: first monster of specified type in monster list, or NULL if none
 {
 	CMonster *pMonster = this->pFirstMonster;
@@ -3592,7 +3594,9 @@ CMonster* CDbRoom::GetMonsterOfType(const UINT wType) const
 			CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
 			if (pCharacter->IsVisible()) //Character must be in room to count.
 			{
-				if (wType == M_CHARACTER || pCharacter->GetIdentity() == wType)
+				if (wType == M_CHARACTER)
+					return pMonster;
+				else if (pCharacter->GetIdentity() == wType && !bIgnoreCharacterAppearance)
 					return pMonster;
 			}
 		}

--- a/DRODLib/DbRooms.h
+++ b/DRODLib/DbRooms.h
@@ -302,7 +302,7 @@ public:
 			const bool bIgnoreDagger = false, const bool bIgnoreNonCuts = false, CMonster *pIgnore=NULL) const;
 	CMonster*      GetMonsterAtSquare(const UINT wX, const UINT wY) const;
 	const CMonster* GetOwningMonsterOnSquare(const UINT wX, const UINT wY) const;
-	CMonster*      GetMonsterOfType(const UINT wType) const;
+	CMonster*      GetMonsterOfType(const UINT wType, const bool bIgnoreCharacterAppearance = false) const;
 	UINT           GetMonsterTypeAt(const UINT wX, const UINT wY,
 			const bool bConsiderNPCIdentity=false, const bool bOnlyLiveMonsters=true) const;
 	bool           GetNearestEntranceTo(const UINT wX, const UINT wY, const MovementType eMovement, UINT &wEX, UINT &wEY);

--- a/DRODLibTests/src/tests/Monsters/Clone.cpp
+++ b/DRODLibTests/src/tests/Monsters/Clone.cpp
@@ -8,22 +8,35 @@
 #include "../../../../DRODLib/CharacterCommand.h"
 
 namespace {
-	void _AssertProcessingSequence(const char* file, int line, const UINT expectedIndex, const UINT wO) {
+
+	void _AssertProcessingSequence(const char* file, int line, const UINT expectedIndex, const UINT wX, const UINT wY, const UINT wO, const UINT wType) {
+		INFO(MakeLogMessage(file, line));
+
+		stringstream message;
+
+		message << "Monster at (";
+		message << wX;
+		message << ",";
+		message << wY;
+		message << ") Orientation=";
+		message << wO;
+		message << " Type=";
+		message << wType;
+
+		INFO(message.str());
+
 		CCurrentGame* pCurrentGame = Runner::GetCurrentGame();
 		CDbRoom* pRoom = pCurrentGame->pRoom;
 
 		CMonster* pMonster = pRoom->pFirstMonster;
 		UINT index = 0;
-		const UINT wExpectedX = wO == S ? 10 : 20;
-		const UINT wExpectedY = wO == N ? 10 : 20;
 		while (pMonster)
 		{
-			if (pMonster->wO == wO) {
+			if (pMonster->wX == wX && pMonster->wY == wY) {
 				REQUIRE(index == expectedIndex);
-				REQUIRE(wExpectedX == pMonster->wX);
-				REQUIRE(wExpectedY == pMonster->wY);
+				REQUIRE(wO == pMonster->wO);
 				REQUIRE(pRoom->GetMonsterAtSquare(pMonster->wX, pMonster->wY) == pMonster);
-				REQUIRE(pMonster->wType == M_CLONE);
+				REQUIRE(pMonster->wType == wType);
 				return;
 			}
 
@@ -31,80 +44,100 @@ namespace {
 			++index;
 		}
 
-		INFO(MakeLogMessage(file, line));
-		FAIL("Failed to find the clone");
+		FAIL("Failed to find monster");
+	}
+	void _AssertProcessingSequence_Clone(const char* file, int line, const UINT expectedCloneIndex, const UINT wO) {
+		CCurrentGame* pCurrentGame = Runner::GetCurrentGame();
+		CDbRoom* pRoom = pCurrentGame->pRoom;
+
+		CMonster* pMonster = pRoom->pFirstMonster;
+		UINT index = 0;
+		const UINT wExpectedX = wO == S ? 10 : 20;
+		const UINT wExpectedY = wO == N ? 10 : 20;
+
+		UINT expectedIndex = 0;
+		switch (expectedCloneIndex) {
+			case 0: expectedIndex = 1; break;
+			case 1: expectedIndex = 3; break;
+			case 2: expectedIndex = 6; break;
+		}
+		
+		_AssertProcessingSequence(file, line, expectedIndex, wExpectedX, wExpectedY, wO, M_CLONE);
 	}
 }
 
-#define AssertProcessingSequence(expectedIndex, wO) _AssertProcessingSequence(__FILE__, __LINE__, expectedIndex, wO)
+#define AssertProcessingSequence_Common() \
+	_AssertProcessingSequence(__FILE__, __LINE__, 0, 0, 0, S,  M_CHARACTER); \
+	_AssertProcessingSequence(__FILE__, __LINE__, 1, 1, 5, N,  M_CLONE); \
+	_AssertProcessingSequence(__FILE__, __LINE__, 2, 2, 0, S,  M_CHARACTER); \
+	_AssertProcessingSequence(__FILE__, __LINE__, 3, 3, 5, SE, M_CLONE); \
+	_AssertProcessingSequence(__FILE__, __LINE__, 4, 4, 0, S,  M_DECOY); \
+	_AssertProcessingSequence(__FILE__, __LINE__, 5, 5, 0, S,  M_MIMIC); \
+	_AssertProcessingSequence(__FILE__, __LINE__, 6, 6, 5, SW, M_CLONE); \
+	_AssertProcessingSequence(__FILE__, __LINE__, 7, 7, 0, S,  M_CHARACTER);
 
 TEST_CASE("Clone", "[game]") {
 	RoomBuilder::ClearRoom();
 
-	SECTION("Switching clones preserves movement order") {
-		RoomBuilder::AddMonster(M_CLONE, 20, 10, N);
-		RoomBuilder::AddMonster(M_CLONE, 20, 20, E);
-		RoomBuilder::AddMonster(M_CLONE, 10, 20, S);
+	SECTION("Switching clones preserves movement order - supports different monsters on same processing sequence") {
+		CCharacter* pCharacter;
 
-		Runner::StartGame(10, 10, W);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		/* INDEX=0 */ pCharacter = RoomBuilder::AddVisibleCharacter(0, 0, S, M_CLONE);
+		              pCharacter->wProcessSequence = 1;
+
+		/* INDEX=1 */ RoomBuilder::AddMonster(M_CLONE, 1, 5, N);
+		/* INDEX=2 */ pCharacter = RoomBuilder::AddVisibleCharacter(2, 0, S, M_CLONE);
+		              pCharacter->wProcessSequence = SPD_PDOUBLE;
+		/* INDEX=3 */ RoomBuilder::AddMonster(M_CLONE, 3, 5, SE);
+		/* INDEX=4 */ RoomBuilder::AddMonster(M_DECOY, 4, 0, S);
+		/* INDEX=5 */ RoomBuilder::AddMonster(M_MIMIC, 5, 0, S);
+		/* INDEX=6 */ RoomBuilder::AddMonster(M_CLONE, 6, 5, SW);
+
+		/* INDEX=7 */ RoomBuilder::AddVisibleCharacter(7, 0, S, M_CLONE);
+
+		Runner::StartGame(8, 5, N);
+		AssertProcessingSequence_Common();
 
 		// Full cycle of tabbing
 		Runner::ExecuteCommand(CMD_CLONE, 4);
-		AssertPlayerAt(10, 10);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		AssertPlayerAt(8, 5);
+		AssertProcessingSequence_Common();
 
 		// Click on each clone and back
-		Runner::ClickClone(20, 10);
-		Runner::ClickClone(10, 10);
-		AssertPlayerAt(10, 10);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		Runner::ClickClone(1, 5);
+		Runner::ClickClone(8, 5);
+		AssertPlayerAt(8, 5);
+		AssertProcessingSequence_Common();
 
-		Runner::ClickClone(20, 20);	
-		Runner::ClickClone(10, 10);
-		AssertPlayerAt(10, 10);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		Runner::ClickClone(3, 5);
+		Runner::ClickClone(8, 5);
+		AssertPlayerAt(8, 5);
+		AssertProcessingSequence_Common();
 
-		Runner::ClickClone(10, 20);
-		Runner::ClickClone(10, 10);
-		AssertPlayerAt(10, 10);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		Runner::ClickClone(6, 5);
+		Runner::ClickClone(8, 5);
+		AssertPlayerAt(8, 5);
+		AssertProcessingSequence_Common();
 
 		// Click various combinations
-		Runner::ClickClone(10, 20);
-		Runner::ClickClone(20, 20);
-		Runner::ClickClone(10, 10);
-		AssertPlayerAt(10, 10);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		Runner::ClickClone(6, 5);
+		Runner::ClickClone(3, 5);
+		Runner::ClickClone(8, 5);
+		AssertPlayerAt(8, 5);
+		AssertProcessingSequence_Common();
 
-		Runner::ClickClone(20, 10);
-		Runner::ClickClone(10, 20);
-		Runner::ClickClone(10, 10);
-		AssertPlayerAt(10, 10);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		Runner::ClickClone(1, 5);
+		Runner::ClickClone(6, 5);
+		Runner::ClickClone(8, 5);
+		AssertPlayerAt(8, 5);
+		AssertProcessingSequence_Common();
 
-		Runner::ClickClone(20, 10);
-		Runner::ClickClone(20, 20);
-		Runner::ClickClone(10, 20);
-		Runner::ClickClone(20, 10);
-		Runner::ClickClone(10, 10);
-		AssertPlayerAt(10, 10);
-		AssertProcessingSequence(0, N);
-		AssertProcessingSequence(1, E);
-		AssertProcessingSequence(2, S);
+		Runner::ClickClone(1, 5);
+		Runner::ClickClone(3, 5);
+		Runner::ClickClone(6, 5);
+		Runner::ClickClone(1, 5);
+		Runner::ClickClone(8, 5);
+		AssertPlayerAt(8, 5);
+		AssertProcessingSequence_Common();
 	}
 }


### PR DESCRIPTION
…h movement order of ALL other monsters + swapping clones with tabs will now work correctly if there are non-clones in between (characters with same processing sequence or other doubles) + swapping with tab now works at all

[Relevant thread](http://forum.caravelgames.com/viewtopic.php?TopicID=44934)