### PR TITLE
Friendly/Unfriendly imperatives are not change imperatives

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -2646,9 +2646,11 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::Friendly:
 						this->bFriendly = true;
+						bChangeImperative = false;
 					break;
 					case ScriptFlag::Unfriendly:
 						this->bFriendly = false;
+						bChangeImperative = false;
 					break;
 					default: break;
 				}


### PR DESCRIPTION
I made a small oversight when adding the Friendly and Unfriendly imperatives. When set, they should change `bChangeImperative` to false. Without this, the required monster count may be incorrectly decremated.