### PR TITLE
RPG: Fix previewed rooms disappearing from minimap when loading a gam…

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -752,8 +752,6 @@ bool CGameScreen::LoadSavedGame(
 	if (!this->pCurrentGame)
 		return false;
 
-	this->pCurrentGame->AddRoomsPreviouslyExploredByPlayerToMap();
-
 	this->bPlayTesting = false;
 	this->wUndoToTurn = this->pCurrentGame->wTurnNo;
 //	this->bRoomClearedOnce = this->pCurrentGame->IsCurrentRoomPendingExit();

--- a/drodrpg/DROD/RestoreScreen.cpp
+++ b/drodrpg/DROD/RestoreScreen.cpp
@@ -497,9 +497,6 @@ bool CRestoreScreen::SetWidgets()
 void CRestoreScreen::ShowSave()
 //Show information pertaining to this saved game.
 {
-	if (this->pCurrentRestoreGame)
-		this->pCurrentRestoreGame->AddRoomsPreviouslyExploredByPlayerToMap();
-
 	UpdateWidgets();
 
 	//Update level and room location label.

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1656,17 +1656,18 @@ bool CCurrentGame::LoadFromSavedGame(
 	//Put room in correct beginning state and get cue events for the 
 	//last step the player has taken.
 	RetrieveExploredRoomData(*this->pRoom);
-	if (bAtRoomStart)
+
+	AddRoomsPreviouslyExploredByPlayerToMap(); //for front-end, to display preview of rooms explored in other play sessions
+
+	//Cue events coming from first step into the room.
+	SetMembersAfterRoomLoad(CueEvents, false);
+	ProcessCommand_EndOfTurnEventHandling(CueEvents);
+	if (!bAtRoomStart)
 	{
-		//Cue events come from first step into the room.
-		SetMembersAfterRoomLoad(CueEvents, false);
-		ProcessCommand_EndOfTurnEventHandling(CueEvents);
-	} else {
-		//Cue events come from processing of last command below.
 		//Ignore cue events from first step into the room.
-		CCueEvents IgnoredCueEvents;
-		SetMembersAfterRoomLoad(IgnoredCueEvents, false);
-		ProcessCommand_EndOfTurnEventHandling(IgnoredCueEvents);
+		CueEvents.Clear();
+
+		//Instead, populate cue events coming from processing of last command below.
 
 		//Play through any commands from the saved game.
 		//Truncate any commands that cannot be played back.

--- a/drodrpg/DRODLib/DbXML.cpp
+++ b/drodrpg/DRODLib/DbXML.cpp
@@ -694,53 +694,6 @@ bool CDbXML::UpdateLocalIDs()
 						case ST_Unknown:
 							bSkipRecord = true;	//these types always get skipped
 						break;
-/*
-						case ST_LevelBegin:
-						{
-							const UINT dwLevelID = CDbRooms::GetLevelIDForRoom(pSavedGame->dwRoomID);
-							if (!dwLevelID) {bSkipRecord = true; break;}
-							const UINT dwSavedGameID = g_pTheDB->SavedGames.FindByLevelBegin(dwLevelID);
-							if (dwSavedGameID && dwSavedGameID != pSavedGame->dwSavedGameID)
-								bSkipRecord = true;	//a saved game already exists here -- skip
-						}
-						break;
-						case ST_RoomBegin:
-						{
-							const UINT dwSavedGameID = g_pTheDB->
-									SavedGames.FindByRoomBegin(pSavedGame->dwRoomID);
-							if (dwSavedGameID && dwSavedGameID != pSavedGame->dwSavedGameID)
-								bSkipRecord = true;	//a saved game already exists here -- skip
-						}
-						break;
-						case ST_Checkpoint:
-						{
-							const UINT dwSavedGameID = g_pTheDB->
-									SavedGames.FindByCheckpoint(pSavedGame->dwRoomID,
-									pSavedGame->wCheckpointX, pSavedGame->wCheckpointY);
-							if (dwSavedGameID && dwSavedGameID != pSavedGame->dwSavedGameID)
-								bSkipRecord = true;	//a saved game already exists here -- skip
-							else
-							{
-								//Verify saved game's integrity for current room version.
-								CCueEvents Ignored;
-								CCurrentGame *pCurrentGame = g_pTheDB->GetSavedCurrentGame(
-										dwSavedGameID, Ignored, true,
-										true); //don't save to DB during playback
-								if (!pCurrentGame)
-								{
-									//Saved game can't even be loaded -- it was probably recorded in
-									//a room that no longer exists.
-									bSkipRecord = true;
-								} else {
-									if (!pCurrentGame->PlayCommands(
-											pCurrentGame->Commands.Count(), Ignored, true))
-										pCurrentGame->Update(); //truncate commands that can't be played back
-									delete pCurrentGame;
-								}
-							}
-						}
-						break;
-*/
 						case ST_Demo:		//when importing a player over itself, import demo saves as usual
 						{
 							const UINT dwSavedGameID = CDbSavedGames::GetSavedGameID(


### PR DESCRIPTION
…e where a map is picked up in the current room, then undoing before the map was obtained.

My approach was to move the call to AddRoomsPreviouslyExploredByPlayerToMap() earlier in loading a saved game, before any moves in the current room are played (i.e., before the map is picked up, or any script commands exploring rooms are executed).