### PR TITLE
Fixed a bug: briar growth clearing all tarstuff would immediately tog…

### DIFF
--- a/DRODLib/Briar.h
+++ b/DRODLib/Briar.h
@@ -87,11 +87,16 @@ private:
 	friend class CBriar;
 	CDbRoom     *pRoom;
 	std::list<CBriar*> briars;   //sources in the room
-	CCoordIndex_T<USHORT>  briarIndices;  //quick access to which component is at what tile
-	std::vector<CCoordSet> briarComponents, briarEdge; //connected components
-	std::vector<CoordPair> connectedBriars;     //tile pairs where two components connect
+	CCoordIndex_T<USHORT>  briarIndices;    //quick access to which component is at what tile
+	std::vector<CCoordSet> briarComponents; //connected components
+	std::vector<CCoordSet> briarEdge;       //connected components
+	std::vector<CoordPair> connectedBriars; //tile pairs where two components connect
+	
 	CCoordSet pressurePlates;  //set of pressure plate tiles depressed on a turn
-	bool bRecalc;              //indicates components must be reconstructed
+	CCoordSet pendingRootRemovals;  //Brair roots that are pending removal
+
+	bool      bRecalc;         //indicates components must be reconstructed
+	bool      bIsProcessing;   // Whether currently in the middle of briar processing
 };
 
 #endif //...#ifndef BRIAR_H

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -698,7 +698,15 @@ bool CMonster::ConfirmPath()
 	for (UINT wIndex=wSize; wIndex--; ) //from top of stack down to bottom
 	{
 		this->pathToDest.GetAt(wIndex, wX, wY);
-		if (DoesSquareContainObstacle(wX, wY))
+
+		// Backwards compatibility hack: if a path resides on monster's current position it should
+		// theorethically regenerate the path, but that could potentially break too many demos
+		// at this point. We can't run DoesSquareContainObstacle() either, because it will (correctly)
+		// ASSERT if given monster's current coords. So we just skip that one specific check.
+
+		const bool bIsCurrentMonsterTile = wX == this->wX && wY == this->wY;
+
+		if (!bIsCurrentMonsterTile && DoesSquareContainObstacle(wX, wY))
 		{
 			bPathOpen = false;
 			break;


### PR DESCRIPTION
…gle black gates, which in turn would immediately remove from Briars list all the roots that were on top of open black gates. This would sometimes crash the game because root processing would try to access memory of a deleted briar node. Now briar roots are removed at the end of processing, which also makes it consistent with how things worked in 5.1.0 and older, as this was changed at some popoint in 5.1.1 development (in 5807acedbf99f01e7f12c15de1c35fade0d78ea5).

[Relevant thread](https://forum.caravelgames.com/viewtopic.php?TopicID=44948)