### PR TITLE
Fix reversed logic on app focus gained/lost, which causes a hang when…

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -1109,12 +1109,12 @@ void CGameScreen::OnWindowEvent_GetFocus()
 {
 	CEventHandlerWidget::OnWindowEvent_GetFocus();
 
-	this->pCurrentGame->UpdateTime();
-	if (!this->dwTimeMinimized)
-		this->dwTimeMinimized = SDL_GetTicks();
-
-	if (this->bIsDialogDisplayed)
-		g_pTheSound->PauseSounds();
+	if (this->dwTimeMinimized)
+	{
+		if (this->dwNextSpeech)
+			this->dwNextSpeech += SDL_GetTicks() - this->dwTimeMinimized;
+		this->dwTimeMinimized = 0;
+	}
 }
 
 //*****************************************************************************
@@ -1122,12 +1122,12 @@ void CGameScreen::OnWindowEvent_LoseFocus()
 {
 	CEventHandlerWidget::OnWindowEvent_LoseFocus();
 
-	if (this->dwTimeMinimized)
-	{
-		if (this->dwNextSpeech)
-			this->dwNextSpeech += SDL_GetTicks() - this->dwTimeMinimized;
-		this->dwTimeMinimized = 0;
-	}
+	this->pCurrentGame->UpdateTime();
+	if (!this->dwTimeMinimized)
+		this->dwTimeMinimized = SDL_GetTicks();
+
+	if (this->bIsDialogDisplayed)
+		g_pTheSound->PauseSounds();
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -2095,12 +2095,12 @@ void CGameScreen::OnWindowEvent_GetFocus()
 {
 	CEventHandlerWidget::OnWindowEvent_GetFocus();
 
-	this->pCurrentGame->UpdateTime();
-	if (!this->dwTimeMinimized)
-		this->dwTimeMinimized = SDL_GetTicks();
-
-	if (this->bIsDialogDisplayed)
-		g_pTheSound->PauseSounds();
+	if (this->dwTimeMinimized)
+	{
+		if (this->dwNextSpeech)
+			this->dwNextSpeech += SDL_GetTicks() - this->dwTimeMinimized;
+		this->dwTimeMinimized = 0;
+	}
 }
 
 //*****************************************************************************
@@ -2108,12 +2108,12 @@ void CGameScreen::OnWindowEvent_LoseFocus()
 {
 	CEventHandlerWidget::OnWindowEvent_LoseFocus();
 
-	if (this->dwTimeMinimized)
-	{
-		if (this->dwNextSpeech)
-			this->dwNextSpeech += SDL_GetTicks() - this->dwTimeMinimized;
-		this->dwTimeMinimized = 0;
-	}
+	this->pCurrentGame->UpdateTime();
+	if (!this->dwTimeMinimized)
+		this->dwTimeMinimized = SDL_GetTicks();
+
+	if (this->bIsDialogDisplayed)
+		g_pTheSound->PauseSounds();
 }
 
 //*****************************************************************************


### PR DESCRIPTION
… this happens while a dialog box pops up during a cut scene.