### PR TITLE
Added some functionality to the buttons on the notices popup

### DIFF
--- a/DROD/HoldSelectScreen.cpp
+++ b/DROD/HoldSelectScreen.cpp
@@ -960,6 +960,16 @@ void CHoldSelectScreen::OnBetweenEvents()
 		this->bDownloadList = false;
 
 		this->pSelCNetHold = NULL;
+		PopulateHoldListBox();
+
+		UINT caravelNetSelectHoldId = (UINT)g_pTheNet->GetDownloadHold();
+		if (caravelNetSelectHoldId != 0) {
+			// User got here from a CaravelNet new/update hold notice.  Find the hold and select it.
+			this->pHoldListBoxWidget->SelectItem(caravelNetSelectHoldId);
+			g_pTheNet->SetDownloadHold(0);
+		}
+
+
 		SetHoldDesc();
 		Paint();
 	}
@@ -1617,12 +1627,6 @@ void CHoldSelectScreen::SetHoldFilter()
 				g_pTheSM->GetScreen(SCR_EditSelect));
 		if (pESS->GetPrevHoldID())
 			dwSelectHoldID = pESS->GetPrevHoldID();
-	}
-	UINT caravelNetSelectHoldId = (UINT)g_pTheNet->GetDownloadHold();
-	if (caravelNetSelectHoldId != 0) {
-		// User got here from a CaravelNet new/update hold notice.  Find the hold and select it.
-		dwSelectHoldID = caravelNetSelectHoldId;
-		g_pTheNet->SetDownloadHold(0);
 	}
 
 	this->pHoldListBoxWidget->SelectItem(dwSelectHoldID);

--- a/DROD/HoldSelectScreen.cpp
+++ b/DROD/HoldSelectScreen.cpp
@@ -962,7 +962,7 @@ void CHoldSelectScreen::OnBetweenEvents()
 		this->pSelCNetHold = NULL;
 		PopulateHoldListBox();
 
-		UINT caravelNetSelectHoldId = (UINT)g_pTheNet->GetDownloadHold();
+		UINT caravelNetSelectHoldId = g_pTheNet->GetDownloadHold();
 		if (caravelNetSelectHoldId != 0) {
 			// User got here from a CaravelNet new/update hold notice.  Find the hold and select it.
 			this->pHoldListBoxWidget->SelectItem(caravelNetSelectHoldId);

--- a/DROD/HoldSelectScreen.cpp
+++ b/DROD/HoldSelectScreen.cpp
@@ -958,7 +958,6 @@ void CHoldSelectScreen::OnBetweenEvents()
 		// Done downloading the list.
 		CScreen::HideStatusMessage();
 		this->bDownloadList = false;
-		PopulateHoldListBox();
 
 		this->pSelCNetHold = NULL;
 		SetHoldDesc();
@@ -1619,6 +1618,13 @@ void CHoldSelectScreen::SetHoldFilter()
 		if (pESS->GetPrevHoldID())
 			dwSelectHoldID = pESS->GetPrevHoldID();
 	}
+	UINT caravelNetSelectHoldId = (UINT)g_pTheNet->GetDownloadHold();
+	if (caravelNetSelectHoldId != 0) {
+		// User got here from a CaravelNet new/update hold notice.  Find the hold and select it.
+		dwSelectHoldID = caravelNetSelectHoldId;
+		g_pTheNet->SetDownloadHold(0);
+	}
+
 	this->pHoldListBoxWidget->SelectItem(dwSelectHoldID);
 
 	this->pHoldListBoxWidget->RequestPaint();

--- a/DROD/RoomScreen.cpp
+++ b/DROD/RoomScreen.cpp
@@ -475,7 +475,7 @@ void CRoomScreen::OpenNoticesBox(CRoomWidget* pRoomWidget)
 }
 
 //*****************************************************************************
-const void CRoomScreen::UpdateNoticesButton()
+void CRoomScreen::UpdateNoticesButton()
 {
 	const int num = this->notices.size();
 	CButtonWidget* pButton = dynamic_cast<CButtonWidget*>(this->GetWidget(TAG_OPEN_NOTICES));
@@ -492,7 +492,6 @@ const void CRoomScreen::UpdateNoticesButton()
 	UTF8ToUnicode(label, wLabel);
 	pButton->SetCaption(wLabel.c_str());
 	pButton->RequestPaint();
-
 }
 
 //*****************************************************************************

--- a/DROD/RoomScreen.cpp
+++ b/DROD/RoomScreen.cpp
@@ -43,6 +43,7 @@
 #include <BackEndLib/Exception.h>
 #include <BackEndLib/Files.h>
 #include <BackEndLib/Wchar.h>
+#include <BackEndLib/Browser.h>
 
 #define BG_SURFACE      (0)
 #define PARTS_SURFACE   (1)
@@ -427,11 +428,71 @@ void CRoomScreen::AddNoticesDialog()
 void CRoomScreen::OpenNoticesBox(CRoomWidget* pRoomWidget)
 {
 	this->pNoticesDialog->SetBetweenEventsHandler(GetEventHandlerWidget()); //keep updating room effects
-	const UINT returnTag = this->pNoticesDialog->Display(false);
+	UINT returnTag = 0;
+	do {
+		if (returnTag == TAG_NOTICESDELETE) {
+			UINT selected = this->pNoticesList->GetSelectedItem();
+			this->pNoticesList->RemoveItem(selected);
+			this->notices.erase(this->notices.find(selected));
+		}
+		returnTag = this->pNoticesDialog->Display(false);
+		this->UpdateNoticesButton();
+
+	} while (returnTag == TAG_NOTICESDELETE);
+
+	switch (returnTag) {
+	case TAG_NOTICESNOTICE:
+		// This button should go to whatever the notice was about. 
+		UINT selected = this->pNoticesList->GetSelectedItem();
+		std::map<UINT, CNetNotice>::const_iterator item = this->notices.find(selected);
+		if (item != this->notices.end()) {
+			// Found it!
+			switch (item->second.type) {
+			case NOTICE_NEWHOLD:
+			case NOTICE_UPDATEDHOLD:
+				// go to the hold select screen so the user can update it
+				g_pTheNet->SetDownloadHold(item->second.dwServerHoldId);
+				GoToScreen(SCR_HoldSelect);
+				break;
+
+			case NOTICE_GENERICURL:
+				// open a web browser to the specified URL
+				OpenExtBrowser(item->second.url.c_str());
+				break;
+
+			case NOTICE_ROOMSPECIFIC:
+				// Go to the hold/level/room specified.  
+				break;
+			}
+		}
+		break;
+	}
+
 	this->pNoticesDialog->SetBetweenEventsHandler(NULL);
 
 	pRoomWidget->DirtyRoom();
 	pRoomWidget->Paint();
+}
+
+//*****************************************************************************
+const void CRoomScreen::UpdateNoticesButton()
+{
+	const int num = this->notices.size();
+	CButtonWidget* pButton = dynamic_cast<CButtonWidget*>(this->GetWidget(TAG_OPEN_NOTICES));
+	string label;
+	WSTRING wLabel;
+	if (num >= 10) {
+		label = "...";
+	}
+	else {
+		char buffer[5];
+		sprintf(buffer, "%d", num);
+		label = buffer;
+	}
+	UTF8ToUnicode(label, wLabel);
+	pButton->SetCaption(wLabel.c_str());
+	pButton->RequestPaint();
+
 }
 
 //*****************************************************************************
@@ -443,28 +504,9 @@ void CRoomScreen::GrabNewNotices(CRoomWidget* pRoomWidget)
 		this->dwLastNotice = i->id;
 		CCaravelNetNoticeEffect *pEffect = new CCaravelNetNoticeEffect(pRoomWidget, *i, pRoomWidget->notices);
 		pRoomWidget->AddLastLayerEffect(pEffect);
-
-		CButtonWidget* pButton = dynamic_cast<CButtonWidget*>(this->GetWidget(TAG_OPEN_NOTICES));
-		if (pButton) {
-			// Increment the number on the button
-			WSTRING wstr = pButton->GetCaption();
-			string str = UnicodeToUTF8(wstr);
-			int num;
-			sscanf(str.c_str(), "%d", &num);
-			num++;
-			if (num >= 10) {
-				str = "...";
-			} else {
-				char buffer[5];
-				sprintf(buffer, "%d", num);
-				str = buffer;
-			}
-			UTF8ToUnicode(str, wstr);
-			pButton->SetCaption(wstr.c_str());
-			pButton->RequestPaint();
-		}
-
 		this->pNoticesList->AddItem(i->id, i->text.c_str());
-		this->pNoticesList->SelectLine(0);
+		this->notices[i->id] = *i;
+
 	}
+	this->UpdateNoticesButton();
 }

--- a/DROD/RoomScreen.h
+++ b/DROD/RoomScreen.h
@@ -73,7 +73,7 @@ protected:
 	void     ShowScroll() {this->bIsScrollVisible = true; PaintScroll();}
 	void     OpenNoticesBox(CRoomWidget *pRoomWidget);
 	void     GrabNewNotices(CRoomWidget *pRoomWidget);
-	const void UpdateNoticesButton();
+	void     UpdateNoticesButton();
 
 	//These are accessed by CDemoScreen.
 	CMapWidget *      pMapWidget;

--- a/DROD/RoomScreen.h
+++ b/DROD/RoomScreen.h
@@ -73,6 +73,7 @@ protected:
 	void     ShowScroll() {this->bIsScrollVisible = true; PaintScroll();}
 	void     OpenNoticesBox(CRoomWidget *pRoomWidget);
 	void     GrabNewNotices(CRoomWidget *pRoomWidget);
+	const void UpdateNoticesButton();
 
 	//These are accessed by CDemoScreen.
 	CMapWidget *      pMapWidget;
@@ -83,6 +84,8 @@ protected:
 
 	WSTRING           wstrSignText;
 	SDL_Color         signColor;    //color of text on sign
+
+	std::map<UINT, CNetNotice> notices;
 
 	bool              bIsScrollVisible;
 

--- a/DRODLib/NetInterface.h
+++ b/DRODLib/NetInterface.h
@@ -139,8 +139,9 @@ public:
 	WSTRING title;	// "Hold updated", "#1 score beaten", etc.
 	WSTRING text;	// Specifics for the notice.  What hold, what room, what is the URL for, etc.
 	// URL
-	WSTRING url;	// Only relevant for NOTICE_GENERICURL
+	string url;		// Only relevant for NOTICE_GENERICURL
 	// HOLD/ROOM
+	int dwServerHoldId;
 	CNetRoom room;	// Used for hold specific and room specific notices
 	// CLOUD
 	UINT dwCloudId;	// The given ID should be downloaded and imported.
@@ -221,6 +222,8 @@ public:
 	// Notices
 	virtual void SetLastNotice(const UINT /*dwNoticeID*/) {}
 	virtual void QueryNotices(vector<CNetNotice> &/*notices*/, UINT /*typeMask*/, UINT /*lastId*/) const {}
+	virtual void SetDownloadHold(const int /*dwServerHoldId*/) {}
+	virtual int GetDownloadHold() const { return 0; }
 
 	int getIndexForName(const WCHAR* pName, const MediaType mediaType=MT_Hold);
 

--- a/DRODLib/NetInterface.h
+++ b/DRODLib/NetInterface.h
@@ -222,8 +222,8 @@ public:
 	// Notices
 	virtual void SetLastNotice(const UINT /*dwNoticeID*/) {}
 	virtual void QueryNotices(vector<CNetNotice> &/*notices*/, UINT /*typeMask*/, UINT /*lastId*/) const {}
-	virtual void SetDownloadHold(const int /*dwServerHoldId*/) {}
-	virtual int GetDownloadHold() const { return 0; }
+	virtual void SetDownloadHold(const UINT /*dwServerHoldId*/) {}
+	virtual UINT GetDownloadHold() const { return 0; }
 
 	int getIndexForName(const WCHAR* pName, const MediaType mediaType=MT_Hold);
 


### PR DESCRIPTION
This makes the buttons on the notices popup do something:
- The delete button removes the selected notice from the list
- The watch button will do different things depending on the type of notice:
-- Hold release/update - take user to hold select screen with the new/updated hold selected
-- URL - open a browser with the selected URL.  Currently there are no notices that use this, but now we can add them!
-- There is a third type defined in DROD that we also haven't used, one that specifies a room.  The main idea was to have a "your #1 score was beaten" notice, and the button would take you to that room if installed & available.  

Relevant thread: https://forum.caravelgames.com/viewtopic.php?TopicID=39139
