### PR TITLE
RPG: Fix regression in temporary room display where player interacts with room (e.g., collecting an item).

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -5250,6 +5250,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 					this->pCommand->w = _Wtoi(pOperandText);
 					this->pCommand->label.resize(0);
 				} else {
+					this->pCommand->w = 0;
 					this->pCommand->label = pOperandText;
 				}
 			}

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8047,6 +8047,8 @@ void CGameScreen::ShowRoomTemporarily(UINT roomID)
 	if (!roomID)
 		return;
 
+	RemoveToolTip();
+
 Loop:
 	CCurrentGame *pTempGame = g_pTheDB->GetDummyCurrentGame();
 	*pTempGame = *this->pCurrentGame;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -161,6 +161,7 @@ CCurrentGame::CCurrentGame()
 	, pCombat(NULL)
 //	, pSnapshotGame(NULL)
 	, pPendingPriorLocation(NULL)
+	, bRoomDisplayOnly(false)
 	, bNoSaves(false) // Clear() does not set this
 	, bValidatingPlayback(false)
 {
@@ -5041,6 +5042,8 @@ void CCurrentGame::ProcessPlayer(
 							//    be aware of by looking at the modified game
 							//    data on return.
 {
+	ASSERT(!this->bRoomDisplayOnly);
+
 	CSwordsman& p = *this->pPlayer; //shorthand
 	bool bMoved = false;
 	const UINT wOldX = p.wX;
@@ -6358,6 +6361,7 @@ void CCurrentGame::SetMembers(const CCurrentGame &Src)
 
 //	this->dwAutoSaveOptions = Src.dwAutoSaveOptions;
 	this->CompletedScriptsPending = Src.CompletedScriptsPending;
+	this->bRoomDisplayOnly = Src.bRoomDisplayOnly;
 	this->bNoSaves = Src.bNoSaves;
 	this->bValidatingPlayback = Src.bValidatingPlayback;
 
@@ -6493,8 +6497,8 @@ void CCurrentGame::SetMembersAfterRoomLoad(
 	if (bResetCommands && !this->Commands.IsFrozen())
 		this->Commands.Clear();
 
-	//Player should always be visible if no cut scene is playing.
-	if (!this->pPlayer->IsInRoom() && !this->dwCutScene) {
+	//Player should always be visible if no cut scene is playing during normal play.
+	if (!this->pPlayer->IsInRoom() && !this->dwCutScene && !this->bRoomDisplayOnly) {
 		SetPlayerRole(defaultPlayerType()); //place player in room now as default type
 		if (!bProcessedPlayerWait)
 			ProcessPlayer(CMD_WAIT, CueEvents);
@@ -7253,7 +7257,7 @@ UINT CCurrentGame::WriteScoreCheckpointSave(const WSTRING& name)
 			pPlayer->Update();
 		}
 	}
-   delete pPlayer;
+	delete pPlayer;
 	return this->dwSavedGameID;
 }
 
@@ -7261,6 +7265,8 @@ UINT CCurrentGame::WriteScoreCheckpointSave(const WSTRING& name)
 //Returns: whether prep operation succeeded
 bool CCurrentGame::PrepTempGameForRoomDisplay(const UINT roomID)
 {
+	this->bRoomDisplayOnly = true;
+
 	SaveExploredRoomData(*this->pRoom); //so current room can be viewed while panning the map
 
 	this->pPlayer->wIdentity = this->pPlayer->wAppearance = M_NONE; //not in room

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -368,9 +368,9 @@ public:
 //	bool     bBrainSensesSwordsman;
 //	UINT     wLastCheckpointX, wLastCheckpointY;
 //	vector<UINT> checkpointTurns; //turn #s a checkpoint was activated
-	UINT    dwStartTime;   //keeps track of real play time elapsed
+	UINT     dwStartTime;   //keeps track of real play time elapsed
 //	bool     bHoldMastered; //whether player has mastered hold being played
-	UINT    dwCutScene;    //if set, play cut scene moves at specified rate
+	UINT     dwCutScene;    //if set, play cut scene moves at specified rate
 	bool     bContinueCutScene;
 //	bool     bWaitedOnHotFloorLastTurn;
 	CDbPackedVars statsAtRoomStart; //stats when room was begun
@@ -465,6 +465,7 @@ private:
 //	UINT    dwAutoSaveOptions;
 	CIDSet   CompletedScriptsPending;   //saved permanently on room exit
 
+	bool     bRoomDisplayOnly; //indicates player is not in room and no player interaction should be processed
 	bool     bNoSaves;   //don't save anything to DB when set (e.g., for dummy game sessions)
 	bool     bValidatingPlayback; //for streamlining parts of the playback process
 


### PR DESCRIPTION
Also:
* Script command phantom data fix
* Tool tip display fix