### PR TITLE
Allow players to view the path of Halphs

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -69,6 +69,7 @@
 #include "../DRODLib/FluffBaby.h"
 #include "../DRODLib/Gentryii.h"
 #include "../DRODLib/GameConstants.h"
+#include "../DRODLib/Halph.h"
 #include "../DRODLib/PlayerDouble.h"
 #include "../DRODLib/Monster.h"
 #include "../DRODLib/MonsterPiece.h"
@@ -1075,6 +1076,22 @@ void CRoomWidget::HighlightSelectedTile()
 				UINT wDestX, wDestY;
 				if (pPuff->GetGoal(wDestX,wDestY))
 					AddShadeEffect(wDestX, wDestY, PaleYellow);
+				bRemoveHighlightNextTurn = false;
+			}
+			break;
+
+			case M_HALPH: case M_HALPH2:
+			{
+				static const SURFACECOLOR Orange = { 255, 165, 0 };
+				//Show Halph's stored path
+				const CHalph* pHalph = DYN_CAST(const CHalph*, const CMonster*, pMonster);
+				for (UINT wPathIndex = 0; wPathIndex < pHalph->GetStoredPath().GetSize(); ++wPathIndex)
+				{
+					UINT wX, wY;
+					pHalph->GetStoredPath().GetAt(wPathIndex, wX, wY);
+					ASSERT(this->pRoom->IsValidColRow(wX, wY));
+					AddShadeEffect(wX, wY, Orange);
+				}
 				bRemoveHighlightNextTurn = false;
 			}
 			break;

--- a/DRODLib/Halph.h
+++ b/DRODLib/Halph.h
@@ -48,6 +48,7 @@ public:
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 
 	bool GetPathTo(CCueEvents &CueEvents, const CCoordSet &adjDests, const CCoordSet *pDirectDests=NULL);
+	virtual CCoordStack GetStoredPath() const { return this->pathToDest; }
 	virtual bool IsAggressive() const {return false;}
 	virtual bool IsFriendly() const {return true;}
 	bool IsOpeningDoorAt(const CCoordSet& doorSquares) const;


### PR DESCRIPTION
Halph's pathing is weird and confusing to many players. So there is a desire to visualize it. Using [code provided by bbb](http://forum.caravelgames.com/viewtopic.php?TopicID=44932&page=0#437954), this visualisation can now occur.