### PR TITLE
RPG: Fix issues with changed monster movement types

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -122,7 +122,7 @@ const UINT MAX_ANSWERS = 9;
 #define DropTrapdoorsStr "DropTrapdoors"
 #define MoveIntoSwordsStr "MoveIntoSwords"
 #define PushObjectsStr "PushObjects"
-
+#define MovementTypeStr "MovementType"
 
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
 
@@ -4488,7 +4488,8 @@ void CCharacter::SetCurrentGame(
 	ResolveLogicalIdentity(this->pCurrentGame ? this->pCurrentGame->pHold : NULL);
 
 	//Set the movement type
-	SetDefaultMovementType();
+	if(bIsFirstTurn)
+		SetDefaultMovementType();
 
 	//If this NPC is a custom character with no script,
 	//then use the default script for this custom character type.
@@ -4784,6 +4785,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bDropTrapdoors = vars.GetVar(DropTrapdoorsStr, this->bDropTrapdoors);
 	this->bMoveIntoSwords = vars.GetVar(MoveIntoSwordsStr, this->bMoveIntoSwords);
 	this->bPushObjects = vars.GetVar(PushObjectsStr, this->bPushObjects);
+	this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
 
 	//Stats.
 	this->color = vars.GetVar(ColorStr, this->color);
@@ -4910,6 +4912,8 @@ const
 		vars.SetVar(MoveIntoSwordsStr, this->bMoveIntoSwords);
 	if (this->bPushObjects)
 		vars.SetVar(PushObjectsStr, this->bPushObjects);
+	if (this->eMovement)
+		vars.SetVar(MovementTypeStr, this->eMovement);
 
 	//Stats.
 	if (this->color)

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -339,10 +339,6 @@ CMonster* CCurrentGame::AddNewEntity(
 	}
 	this->pRoom->LinkMonster(pNew, bVisible);
 
-	//Affect tile being placed on.
-	if (this->pRoom->GetOSquare(wX, wY) == T_PRESSPLATE && !pCharacter->IsFlying())
-		this->pRoom->ActivateOrb(wX, wY, CueEvents, OAT_PressurePlate);
-
 	//Set up the NPC's properties by running the default script.
 	//Guard against creating new scripted entities that immediately
 	//create new scripted entities, ad infinitum.
@@ -367,6 +363,10 @@ CMonster* CCurrentGame::AddNewEntity(
 
 		SetExecuteNoMoveCommands(bExec);
 	}
+
+	//Affect tile being placed on.
+	if (this->pRoom->GetOSquare(wX, wY) == T_PRESSPLATE && !pCharacter->IsFlying())
+		this->pRoom->ActivateOrb(wX, wY, CueEvents, OAT_PressurePlate);
 
 	return pNew;
 }
@@ -6735,9 +6735,6 @@ void CCurrentGame::SetMembersAfterRoomLoad(
 */
 	}
 
-	//Mark which pressure plates are depressed on entrance.
-	this->pRoom->SetPressurePlatesState();
-
 	//No combat should be occurring at this point.
 	delete this->pCombat;
 	this->pCombat = NULL;
@@ -6755,6 +6752,9 @@ void CCurrentGame::SetMembersAfterRoomLoad(
 	ProcessScripts(CMD_WAIT, CueEvents, CDbSavedGame::pMonsterList);
 	this->pRoom->PreprocessMonsters(CueEvents);
 	this->bExecuteNoMoveCommands = false;
+
+	//Mark which pressure plates are depressed on entrance.
+	this->pRoom->SetPressurePlatesState();
 
 	ProcessSimultaneousSwordHits(CueEvents);  //destroy simultaneously-stabbed tar
 	this->pRoom->KillSeepOutsideWall(CueEvents); //check again if doors have changed


### PR DESCRIPTION
Testing for DROD RPG 1.3 has found an issue with pressure plates and characters with changed movement types: http://forum.caravelgames.com/viewtopic.php?TopicID=29976&page=0#438113. Additionally, character movement type is not serialized, but now needs to be.

Currently, when a monster is created or a room is loaded, pressure plate state is set before character scripts are run. This needs to be slightly delayed, so that characters with changed movement types correctly interact with plates on turn zero.