### PR TITLE
RPG: Characters as monsters don't have a name

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1803,9 +1803,8 @@ WSTRING CRoomWidget::GetMonsterName(CMonster* pMonster) const
 				//custom character type was deleted, and this NPC's type left dangling
 				wstr += wszQuestionMark;
 			}
-		} else {
+		} else if (pCharacter->wIdentity >= CHARACTER_FIRST) {
 			bCharacterName = true;
-			ASSERT(pCharacter->wIdentity >= CHARACTER_FIRST);
 			UINT eMID = MID_UNKNOWN;
 			switch (pCharacter->wIdentity)
 			{


### PR DESCRIPTION
Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45005

The case where a character had an identity less than `CHARACTER_FIRST` was missed, meaning regular monster characters did not return the correct name.