### PR TITLE
Add script expression parsing support for primitive functions with parameter lists

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -52,6 +52,12 @@ const UINT MAX_ANSWERS = 9;
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
 
 //*****************************************************************************
+inline bool isVarCharValid(WCHAR wc)
+{
+	return iswalnum(wc) || wc == W_t('_');
+}
+
+//*****************************************************************************
 bool addWithClamp(int& val, const int operand)
 //Multiplies two integers, ensuring the product doesn't overflow.
 //
@@ -91,6 +97,15 @@ inline bool multWithClamp(int& val, const int operand)
 	}
 	val *= operand;
 	return true;
+}
+
+void LogParseError(const WCHAR* pwStr, const char* message)
+{
+	CFiles f;
+	string str = UnicodeToUTF8(pwStr);
+	str += ": ";
+	str += message;
+	f.AppendErrorLog(str.c_str());
 }
 
 inline bool bCommandHasData(const UINT eCommand)
@@ -818,7 +833,7 @@ bool CCharacter::IsValidExpression(
 //
 //Params:
 	const WCHAR *pwStr, UINT& index, CDbHold *pHold,
-	const bool bExpectCloseParen) //[default=false] whether a close paren should mark the end of this (nested) expression
+	const char closingChar) ////[default=0] if set, indicates that the specified character (e.g., close paren) can mark the end of this (nested) expression
 {
 	ASSERT(pwStr);
 	ASSERT(pHold);
@@ -836,7 +851,7 @@ bool CCharacter::IsValidExpression(
 		//Parse another term.
 		if (pwStr[index] == W_t('+') || pwStr[index] == W_t('-'))
 			++index;
-		else if (bExpectCloseParen && pwStr[index] == W_t(')')) //closing nested expression
+		else if (closingChar && pwStr[index] == closingChar) //closing nested expression
 			return true; //caller will parse the close paren
 		else
 			return false; //invalid symbol between terms
@@ -883,7 +898,7 @@ bool CCharacter::IsValidFactor(const WCHAR *pwStr, UINT& index, CDbHold *pHold)
 	if (pwStr[index] == W_t('('))
 	{
 		++index;
-		if (!IsValidExpression(pwStr, index, pHold, true)) //recursive call
+		if (!IsValidExpression(pwStr, index, pHold, ')')) //recursive call
 			return false;
 		if (pwStr[index] != W_t(')')) //should be parsing the close parenthesis at this point
 			return false; //missing close parenthesis
@@ -936,12 +951,63 @@ bool CCharacter::IsValidFactor(const WCHAR *pwStr, UINT& index, CDbHold *pHold)
 		if (pHold->GetVarID(wVarName.c_str()))
 			return true;
 
+		//Is it a function primitive?
+		ScriptVars::PrimitiveType ePrimitive = ScriptVars::parsePrimitive(wVarName);
+		if (ePrimitive != ScriptVars::NoPrimitive)
+			return IsValidPrimitiveParameters(ePrimitive, pwStr, index, pHold);
+
 		//Unrecognized identifier.
 		return false;
 	}
 
 	//Invalid identifier
 	return false;
+}
+
+//*****************************************************************************
+bool CCharacter::IsValidPrimitiveParameters(
+	ScriptVars::PrimitiveType ePrimitive,
+	const WCHAR* pwStr, UINT& index, CDbHold* pHold)
+{
+	SKIP_WHITESPACE(pwStr, index);
+
+	//Parse arguments surrounded by parens
+	if (pwStr[index] != W_t('('))
+		return false;
+	++index;
+
+	SKIP_WHITESPACE(pwStr, index);
+
+	UINT numArgs = 0;
+	if (pwStr[index] != W_t(')'))
+	{
+		UINT lookaheadIndex = index;
+		while (IsValidExpression(pwStr, lookaheadIndex, pHold, ',')) //recursive call
+		{
+			index = lookaheadIndex;
+			if (pwStr[index] != W_t(','))
+				return false;
+
+			++index;
+			++numArgs;
+			lookaheadIndex = index;
+		}
+
+		//no more commas; parse final argument
+		if (!IsValidExpression(pwStr, index, pHold, ')')) //recursive call
+			return false;
+		++numArgs;
+	}
+
+	if (pwStr[index] != W_t(')')) //should be parsing the close parenthesis at this point
+		return false; //missing close parenthesis
+	++index;
+
+	//Confirm correct parameter count for this primitive
+	if (numArgs != ScriptVars::getPrimitiveRequiredParameters(ePrimitive))
+		return false;
+
+	return true;
 }
 
 //*****************************************************************************
@@ -956,7 +1022,7 @@ int CCharacter::parseExpression(
 //
 //Params:
 	const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC, //[default=NULL]
-	const bool bExpectCloseParen) //[default=false] whether a close paren should mark the end of this (nested) expression
+	const char closingChar) //[default=0] if set, indicates that the specified character (e.g., close paren) can mark the end of this (nested) expression
 {
 	ASSERT(pwStr);
 	ASSERT(pGame);
@@ -988,15 +1054,12 @@ int CCharacter::parseExpression(
 			bAdd = false;
 			++index;
 		}
-		else if (bExpectCloseParen && pwStr[index] == W_t(')')) //closing nested expression
-			return val; //caller will parse the close paren
+		else if (closingChar && pwStr[index] == closingChar) //closing nested expression
+			return val; //caller will parse the closing char
 		else
 		{
 			//parse error -- return the current value
-			CFiles f;
-			string str = UnicodeToUTF8(pwStr + index);
-			str += ": Parse error (bad symbol)";
-			f.AppendErrorLog(str.c_str());
+			LogParseError(pwStr + index, "Parse error (bad symbol)");
 			return val;
 		}
 
@@ -1010,6 +1073,9 @@ int CCharacter::parseExpression(
 //*****************************************************************************
 int CCharacter::parseTerm(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC)
 //Parse and evaluate a term in an expression.
+//
+// term = factor {("*"|"/"|"%") factor}
+//
 {
 	int val = parseFactor(pwStr, index, pGame, pNPC);
 
@@ -1057,6 +1123,51 @@ int CCharacter::parseTerm(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, 
 }
 
 //*****************************************************************************
+int CCharacter::parseNestedExpression(const WCHAR* pwStr, UINT& index, CCurrentGame* pGame, CCharacter* pNPC)
+//Parse and evaluate a nested expression.
+{
+	ASSERT(pwStr[index] == W_t('('));
+	++index; //pass left paren
+
+	int val = parseExpression(pwStr, index, pGame, pNPC, ')'); //recursive call
+	SKIP_WHITESPACE(pwStr, index);
+	if (pwStr[index] == W_t(')'))
+		++index;
+	else
+	{
+		//parse error -- return the current value
+		LogParseError(pwStr, "Parse error (missing close parenthesis)");
+	}
+	return val;
+}
+
+//*****************************************************************************
+int CCharacter::parseNumber(const WCHAR* pwStr, UINT& index)
+{
+	ASSERT(iswdigit(pwStr[index]));
+
+	const int val = _Wtoi(pwStr + index);
+
+	//Parse past digits.
+	++index;
+	while (iswdigit(pwStr[index]))
+		++index;
+
+	if (iswalpha(pwStr[index])) //i.e. of form <digits><alphas>
+	{
+		//Invalid var name -- skip to end of it and return zero value.
+		while (isVarCharValid(pwStr[index]))
+			++index;
+
+		LogParseError(pwStr, "Parse error (invalid var name)");
+
+		return 0;
+	}
+
+	return val;
+}
+
+//*****************************************************************************
 int CCharacter::parseFactor(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC)
 //Parse and evaluate a term in an expression.
 {
@@ -1064,49 +1175,11 @@ int CCharacter::parseFactor(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame
 
 	//A nested expression?
 	if (pwStr[index] == W_t('('))
-	{
-		++index;
-		int val = parseExpression(pwStr, index, pGame, pNPC, true); //recursive call
-		SKIP_WHITESPACE(pwStr, index);
-		if (pwStr[index] == W_t(')'))
-			++index;
-		else
-		{
-			//parse error -- return the current value
-			CFiles f;
-			string str = UnicodeToUTF8(pwStr);
-			str += ": Parse error (missing close parenthesis)";
-			f.AppendErrorLog(str.c_str());
-		}
-		return val;
-	}
+		return parseNestedExpression(pwStr, index, pGame, pNPC);
 
 	//Number?
 	if (iswdigit(pwStr[index]))
-	{
-		int val = _Wtoi(pwStr + index);
-
-		//Parse past digits.
-		++index;
-		while (iswdigit(pwStr[index]))
-			++index;
-
-		if (iswalpha(pwStr[index])) //i.e. of form <digits><alphas>
-		{
-			//Invalid var name -- skip to end of it and return zero value.
-			while (CDbHold::IsVarCharValid(pwStr[index]))
-				++index;
-
-			CFiles f;
-			string str = UnicodeToUTF8(pwStr);
-			str += ": Parse error (invalid var name)";
-			f.AppendErrorLog(str.c_str());
-
-			return 0;
-		}
-
-		return val;
-	}
+		return parseNumber(pwStr, index);
 
 	//Variable identifier?
 	if (pwStr[index] == W_t('_') || iswalpha(pwStr[index]) || pwStr[index] == W_t('.')) //valid first char
@@ -1139,24 +1212,72 @@ int CCharacter::parseFactor(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame
 			}
 		} else if (ScriptVars::IsCharacterLocalVar(wVarName)) {
 			val = pNPC ? pNPC->getLocalVarInt(wVarName) : 0;
-		} else {
+		} else if (pGame->pHold->GetVarID(wVarName.c_str())) {
 			//Is it a local hold var?
 			char *varName = pGame->pHold->getVarAccessToken(wVarName.c_str());
 			const UNPACKEDVARTYPE vType = pGame->stats.GetVarType(varName);
 			const bool bValidInt = vType == UVT_int || vType == UVT_uint || vType == UVT_unknown;
 			if (bValidInt)
 				val = pGame->stats.GetVar(varName, (int)0);
-			//else: unrecognized identifier -- just return a zero value
 		}
+
+		//Is it a function primitive?
+		ScriptVars::PrimitiveType ePrimitive = ScriptVars::parsePrimitive(wVarName);
+		if (ePrimitive != ScriptVars::NoPrimitive)
+			return parsePrimitive(ePrimitive, pwStr, index, pGame, pNPC);
+
+		//else: unrecognized identifier -- just return a zero value
 		return val;
 	}
 
 	//Invalid identifier
-	CFiles f;
-	string str = UnicodeToUTF8(pwStr + index);
-	str += ": Parse error (invalid var name)";
-	f.AppendErrorLog(str.c_str());
+	LogParseError(pwStr, "Parse error(invalid var name)");
 
+	return 0;
+}
+
+//*****************************************************************************
+//Parses and evaluates a primitive function call in the context of the game object.
+//
+//Returns: calculated value from call to primitive
+int CCharacter::parsePrimitive(
+	ScriptVars::PrimitiveType ePrimitive,
+	const WCHAR* pwStr, UINT& index, CCurrentGame* pGame, CCharacter* pNPC)
+{
+	SKIP_WHITESPACE(pwStr, index);
+
+	ASSERT(pwStr[index] == W_t('('));
+	++index; //pass left paren
+
+	SKIP_WHITESPACE(pwStr, index);
+
+	vector<int> params;
+
+	if (pwStr[index] != W_t(')')) {
+		UINT lookaheadIndex = index;
+		while (IsValidExpression(pwStr, lookaheadIndex, pGame->pHold, ',')) //recursive call
+		{
+			params.push_back(parseExpression(pwStr, index, pGame, pNPC, ',')); //recursive call
+			ASSERT(pwStr[index] == W_t(','));
+			++index;
+			lookaheadIndex = index;
+		}
+
+		//no more commas; parse final argument
+		params.push_back(parseExpression(pwStr, index, pGame, pNPC, ')')); //recursive call
+	}
+
+	if (pwStr[index] == W_t(')')) {
+		++index;
+	}
+	else {
+		LogParseError(pwStr, "Parse error in primitive parameter list (missing close parenthesis)");
+	}
+
+	if (params.size() == ScriptVars::getPrimitiveRequiredParameters(ePrimitive))
+		return pGame->EvalPrimitive(ePrimitive, params);
+
+	LogParseError(pwStr, "Parse error in primitive parameter list (incorrect argument count)");
 	return 0;
 }
 

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -833,7 +833,7 @@ bool CCharacter::IsValidExpression(
 //
 //Params:
 	const WCHAR *pwStr, UINT& index, CDbHold *pHold,
-	const char closingChar) ////[default=0] if set, indicates that the specified character (e.g., close paren) can mark the end of this (nested) expression
+	const char closingChar) //[default=0] if set, indicates that the specified character (e.g., close paren) can mark the end of this (nested) expression
 {
 	ASSERT(pwStr);
 	ASSERT(pHold);
@@ -851,7 +851,7 @@ bool CCharacter::IsValidExpression(
 		//Parse another term.
 		if (pwStr[index] == W_t('+') || pwStr[index] == W_t('-'))
 			++index;
-		else if (closingChar && pwStr[index] == closingChar) //closing nested expression
+		else if (closingChar && pwStr[index] == W_t(closingChar)) //closing nested expression
 			return true; //caller will parse the close paren
 		else
 			return false; //invalid symbol between terms
@@ -1054,7 +1054,7 @@ int CCharacter::parseExpression(
 			bAdd = false;
 			++index;
 		}
-		else if (closingChar && pwStr[index] == closingChar) //closing nested expression
+		else if (closingChar && pwStr[index] == W_t(closingChar)) //closing nested expression
 			return val; //caller will parse the closing char
 		else
 		{

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -169,9 +169,13 @@ public:
 	virtual bool   IsTarget() const { return (this->IsVisible() && this->IsMonsterTarget()) || CanBeNPCBeethro(); }
 	bool           IsTileAt(const CCharacterCommand& command) const;
 	virtual bool   IsTileObstacle(const UINT wTileNo) const;
-	static bool    IsValidExpression(const WCHAR *pwStr, UINT& index, CDbHold *pHold, const bool bExpectCloseParen=false);
+
+	static bool    IsValidExpression(const WCHAR *pwStr, UINT& index, CDbHold *pHold, const char closingChar=0);
 	static bool    IsValidTerm(const WCHAR *pwStr, UINT& index, CDbHold *pHold);
 	static bool    IsValidFactor(const WCHAR *pwStr, UINT& index, CDbHold *pHold);
+	static bool    IsValidPrimitiveParameters(ScriptVars::PrimitiveType ePrimitive,
+		const WCHAR* pwStr, UINT& index, CDbHold* pHold);
+
 	virtual bool   IsVisible() const {return this->bVisible;}
 	bool           JumpToCommandWithLabel(const WCHAR *pText);
 	bool           JumpToCommandWithLabel(const UINT num);
@@ -179,9 +183,15 @@ public:
 	static void    LoadCommands(CDbPackedVars& ExtraVars, COMMANDPTR_VECTOR& commands);
 	virtual bool   OnAnswer(int nCommand, CCueEvents &CueEvents);
 	virtual bool   OnStabbed(CCueEvents &CueEvents, const UINT /*wX*/=-1, const UINT /*wY*/=-1, WeaponType weaponType=WT_Sword);
-	static int     parseExpression(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC=NULL, const bool bExpectCloseParen=false);
+
+	static int     parseExpression(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC=NULL, const char closingChar=0);
+	static int     parseNestedExpression(const WCHAR* pwStr, UINT& index, CCurrentGame* pGame, CCharacter* pNPC);
+	static int     parseNumber(const WCHAR* pwStr, UINT& index);
 	static int     parseTerm(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC);
 	static int     parseFactor(const WCHAR *pwStr, UINT& index, CCurrentGame *pGame, CCharacter *pNPC);
+	static int     parsePrimitive(ScriptVars::PrimitiveType ePrimitive,
+		const WCHAR* pwStr, UINT& index, CCurrentGame* pGame, CCharacter* pNPC);
+
 	virtual void   Process(const int nLastCommand, CCueEvents &CueEvents);
 	virtual void   PushInDirection(int dx, int dy, bool bStun, CCueEvents &CueEvents);
 

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -565,6 +565,23 @@ int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vect
 			const UINT tile = this->pRoom->GetFSquare(params[0], params[1]);
 			return getForceArrowDirection(tile);
 		}
+		case ScriptVars::P_RoomTile:
+		{
+			switch (params[2]) {
+				case 0: return this->pRoom->GetOSquare(params[0], params[1]);
+				case 1: return this->pRoom->GetFSquare(params[0], params[1]);
+				case 2: return this->pRoom->GetTSquare(params[0], params[1]);
+				default: return 0;
+			}
+		}
+		case ScriptVars::P_MonsterType:
+		{
+			CMonster* pMonster = this->pRoom->GetMonsterAtSquare(params[0], params[1]);
+			if (pMonster) {
+				return pMonster->wType;
+			}
+			return -1;
+		}
 		break;
 	}
 

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -523,6 +523,19 @@ int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vect
 			const int dy = sgn(params[1]);
 			return nGetO(dx, dy);
 		}
+		case ScriptVars::P_Facing:
+		{
+			int dx = params[0];
+			int dy = params[1];
+			//If one of the four compass directions is more direct than a diagonal,
+			//snap to it.
+			const int absDx = abs(dx), absDy = abs(dy);
+			if (absDx > 2 * absDy)
+				dy = 0;
+			else if (absDy > 2 * absDx)
+				dx = 0;
+			return nGetO(sgn(dx), sgn(dy));
+		}
 		case ScriptVars::P_OrientX:
 		case ScriptVars::P_OrientY:
 		case ScriptVars::P_RotateCW:

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -508,6 +508,64 @@ UINT CCurrentGame::EndDemoRecording()
 }
 
 
+//***************************************************************************************
+//Evaluate a calculated function in context of the current game
+int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vector<int>& params)
+{
+	ASSERT(params.size() == ScriptVars::getPrimitiveRequiredParameters(ePrimitive));
+
+	switch (ePrimitive) {
+		case ScriptVars::P_Abs:
+			return abs(params[0]);
+		case ScriptVars::P_Orient:
+		{
+			const int dx = sgn(params[0]);
+			const int dy = sgn(params[1]);
+			return nGetO(dx, dy);
+		}
+		case ScriptVars::P_OrientX:
+		case ScriptVars::P_OrientY:
+		case ScriptVars::P_RotateCW:
+		case ScriptVars::P_RotateCCW:
+		{
+			const int o = params[0];
+			if (!IsValidOrientation(o))
+				return o;
+			switch (ePrimitive) {
+				case ScriptVars::P_OrientX: return nGetOX(o);
+				case ScriptVars::P_OrientY: return nGetOY(o);
+				case ScriptVars::P_RotateCW: return nNextCO(o);
+				case ScriptVars::P_RotateCCW: return nNextCCO(o);
+			}
+		}
+		case ScriptVars::P_Min:
+			return min(params[0], params[1]);
+		case ScriptVars::P_Max:
+			return max(params[0], params[1]);
+		case ScriptVars::P_Dist0: //L-infinity norm
+		{
+			const int deltaX = abs(params[2] - params[0]);
+			const int deltaY = abs(params[3] - params[1]);
+			return max(deltaX, deltaY);
+		}
+		case ScriptVars::P_Dist1: //L-1 norm (Manhattan distance)
+		{
+			const int deltaX = params[2] - params[0];
+			const int deltaY = params[3] - params[1];
+			return abs(deltaX) + abs(deltaY);
+		}
+		case ScriptVars::P_Dist2: //L-2 norm (Euclidean distance)
+		{
+			const int deltaX = params[2] - params[0];
+			const int deltaY = params[3] - params[1];
+			return int(sqrt(deltaX * deltaX + deltaY * deltaY));
+		}
+		break;
+	}
+
+	return 0;
+}
+
 //*****************************************************************************
 WSTRING CCurrentGame::ExpandText(const WCHAR* wText,
 	CCharacter *pCharacter) //character, to query its local vars [default=NULL]

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -538,6 +538,25 @@ int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vect
 				case ScriptVars::P_RotateCCW: return nNextCCO(o);
 			}
 		}
+		case ScriptVars::P_RotateDist:
+		{
+			UINT wO1 = params[0];
+			UINT wO2 = params[1];
+			UINT wTurns = 0;
+
+			if (!(IsValidOrientation(wO1) && IsValidOrientation(wO2)) ||
+				wO1 == NO_ORIENTATION || wO2 == NO_ORIENTATION) {
+				return 0;
+			}
+
+			while (wO1 != wO2) {
+				wO1 = nNextCO(wO1);
+				++wTurns;
+				ASSERT(wTurns < 8);
+			}
+
+			return wTurns <= 4 ? wTurns : 8 - wTurns;
+		}
 		case ScriptVars::P_Min:
 			return min(params[0], params[1]);
 		case ScriptVars::P_Max:

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -560,6 +560,11 @@ int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vect
 			const int deltaY = params[3] - params[1];
 			return int(sqrt(deltaX * deltaX + deltaY * deltaY));
 		}
+		case ScriptVars::P_ArrowDir:
+		{
+			const UINT tile = this->pRoom->GetFSquare(params[0], params[1]);
+			return getForceArrowDirection(tile);
+		}
 		break;
 	}
 

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -201,6 +201,7 @@ public:
 	static void DiffVarValues(const VARMAP& vars1, const VARMAP& vars2, set<VarNameType>& diff);
 	UINT     EndDemoRecording();
 	bool     ExecutingNoMoveCommands() const {return this->bExecuteNoMoveCommands;}
+	int EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vector<int>& params);
 	WSTRING  ExpandText(const WCHAR* wText, CCharacter *pCharacter=NULL);
 	WSTRING  getTextForInputCommandKey(InputCommands::DCMD id) const;
 	void     FegundoToAsh(CMonster *pMonster, CCueEvents &CueEvents);

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -25,6 +25,23 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call
 
 //*****************************************************************************
+// Values are not case sensitive; caps added here for readability
+const char ScriptVars::primitiveNames[PrimitiveCount][11] =
+{
+	"_abs",
+	"_min",
+	"_max",
+	"_orient",
+	"_ox",
+	"_oy",
+	"_rotateCW",
+	"_rotateCCW",
+	"_dist0",
+	"_dist1",
+	"_dist2"
+};
+
+//*****************************************************************************
 string ScriptVars::getVarName(const Predefined var)
 //Returns: pointer to the name of this pre-defined var, or empty string if no match
 {
@@ -47,6 +64,46 @@ WSTRING ScriptVars::getVarNameW(const Predefined var)
 	WSTRING wstr;
 	UTF8ToUnicode(varName.c_str(), wstr);
 	return wstr;
+}
+
+//*****************************************************************************
+PrimitiveType ScriptVars::parsePrimitive(const WSTRING& wstr)
+{
+	const string str = UnicodeToUTF8(wstr);
+	return parsePrimitive(str);
+}
+
+PrimitiveType ScriptVars::parsePrimitive(const string& str)
+{
+	for (int i = 0; i < PrimitiveCount; ++i) {
+		if (!_stricmp(str.c_str(), primitiveNames[i]))
+			return PrimitiveType(i);
+	}
+	return NoPrimitive;
+}
+
+//Returns: the number of parameter arguments each primitive function requires
+UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
+{
+	switch (eType)
+	{
+		case P_Abs:
+		case P_OrientX:
+		case P_OrientY:
+		case P_RotateCW:
+		case P_RotateCCW:
+			return 1;
+		case P_Min:
+		case P_Max:
+		case P_Orient:
+			return 2;
+			//return 3;
+		case P_Dist0:
+		case P_Dist1:
+		case P_Dist2:
+			return 4;
+	}
+	return 0;
 }
 
 //*****************************************************************************

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -26,7 +26,7 @@ string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call
 
 //*****************************************************************************
 // Values are not case sensitive; caps added here for readability
-const char ScriptVars::primitiveNames[PrimitiveCount][11] =
+const char ScriptVars::primitiveNames[PrimitiveCount][13] =
 {
 	"_abs",
 	"_min",
@@ -39,7 +39,9 @@ const char ScriptVars::primitiveNames[PrimitiveCount][11] =
 	"_dist0",
 	"_dist1",
 	"_dist2",
-	"_ArrowDir"
+	"_ArrowDir",
+	"_RoomTile",
+	"_MonsterType"
 };
 
 //*****************************************************************************
@@ -98,7 +100,10 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_Max:
 		case P_Orient:
 		case P_ArrowDir:
+		case P_MonsterType:
 			return 2;
+		case P_RoomTile:
+			return 3;
 		case P_Dist0:
 		case P_Dist1:
 		case P_Dist2:

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -32,6 +32,7 @@ const char ScriptVars::primitiveNames[PrimitiveCount][13] =
 	"_min",
 	"_max",
 	"_orient",
+	"_facing",
 	"_ox",
 	"_oy",
 	"_rotateCW",
@@ -100,6 +101,7 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_Min:
 		case P_Max:
 		case P_Orient:
+		case P_Facing:
 		case P_RotateDist:
 		case P_ArrowDir:
 		case P_MonsterType:

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -38,7 +38,8 @@ const char ScriptVars::primitiveNames[PrimitiveCount][11] =
 	"_rotateCCW",
 	"_dist0",
 	"_dist1",
-	"_dist2"
+	"_dist2",
+	"_ArrowDir"
 };
 
 //*****************************************************************************
@@ -96,8 +97,8 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_Min:
 		case P_Max:
 		case P_Orient:
+		case P_ArrowDir:
 			return 2;
-			//return 3;
 		case P_Dist0:
 		case P_Dist1:
 		case P_Dist2:

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -36,6 +36,7 @@ const char ScriptVars::primitiveNames[PrimitiveCount][13] =
 	"_oy",
 	"_rotateCW",
 	"_rotateCCW",
+	"_rotateDist",
 	"_dist0",
 	"_dist1",
 	"_dist2",
@@ -99,6 +100,7 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_Min:
 		case P_Max:
 		case P_Orient:
+		case P_RotateDist:
 		case P_ArrowDir:
 		case P_MonsterType:
 			return 2;

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -93,6 +93,7 @@ namespace ScriptVars
 		P_Dist0,     //L-infinity norm
 		P_Dist1,     //L-1 norm (Manhattan distance)
 		P_Dist2,     //L-2 norm (Euclidean distance)
+		P_ArrowDir,  //(x,y) --> direction of arrow at (x,y)
 		PrimitiveCount
 	};
 

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -86,6 +86,7 @@ namespace ScriptVars
 		P_Min,       //(x,y) --> min(x,y)
 		P_Max,       //(x,y) --> max(x,y)
 		P_Orient,    //(dx,dy) --> o
+		P_Facing,    //(dx,dy) --> o
 		P_OrientX,   //o --> dx
 		P_OrientY,   //o --> dy
 		P_RotateCW,  //o --> cw(o)

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -74,6 +74,28 @@ namespace ScriptVars
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 
+	//Predefined functions (that take a set of arguments to calculate a value)
+	//
+	//To add new primitives, add a new enumeration here and in the following locations:
+	// primitiveNames
+	// getPrimitiveRequiredParameters
+	// CCurrentGame::EvalPrimitive
+	enum PrimitiveType {
+		NoPrimitive = -1,
+		P_Abs,       //x --> abs(x)
+		P_Min,       //(x,y) --> min(x,y)
+		P_Max,       //(x,y) --> max(x,y)
+		P_Orient,    //(dx,dy) --> o
+		P_OrientX,   //o --> dx
+		P_OrientY,   //o --> dy
+		P_RotateCW,  //o --> cw(o)
+		P_RotateCCW, //o --> ccw(o)
+		P_Dist0,     //L-infinity norm
+		P_Dist1,     //L-1 norm (Manhattan distance)
+		P_Dist2,     //L-2 norm (Euclidean distance)
+		PrimitiveCount
+	};
+
 	void init();
 	string getVarName(const ScriptVars::Predefined var);
 	WSTRING getVarNameW(const ScriptVars::Predefined var);
@@ -81,12 +103,17 @@ namespace ScriptVars
 	Predefined parsePredefinedVar(const string& str);
 	Predefined parsePredefinedVar(const WSTRING& wstr);
 
+	PrimitiveType parsePrimitive(const string& str);
+	UINT getPrimitiveRequiredParameters(PrimitiveType eType);
+	PrimitiveType parsePrimitive(const WSTRING& wstr);
+
 	bool IsCharacterLocalVar(const WSTRING& wstr);
 	bool IsCharacterLocalVar(const WCHAR* wstr);
 
 	//All predefined vars.
 	extern const UINT predefinedVarMIDs[PredefinedVarCount];
 	extern string midTexts[PredefinedVarCount];
+	extern const char primitiveNames[PrimitiveCount][11]; //expand buffer size as needed
 };
 
 //Stats used for various tally operations.

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -94,6 +94,8 @@ namespace ScriptVars
 		P_Dist1,     //L-1 norm (Manhattan distance)
 		P_Dist2,     //L-2 norm (Euclidean distance)
 		P_ArrowDir,  //(x,y) --> direction of arrow at (x,y)
+		P_RoomTile,  //(x,y,z) --> id of room tile at (x,y) on layer z
+		P_MonsterType,//(x,y) --> type of monster at (x,y), or -1 if no monster is there
 		PrimitiveCount
 	};
 
@@ -114,7 +116,7 @@ namespace ScriptVars
 	//All predefined vars.
 	extern const UINT predefinedVarMIDs[PredefinedVarCount];
 	extern string midTexts[PredefinedVarCount];
-	extern const char primitiveNames[PrimitiveCount][11]; //expand buffer size as needed
+	extern const char primitiveNames[PrimitiveCount][13]; //expand buffer size as needed
 };
 
 //Stats used for various tally operations.

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -90,6 +90,7 @@ namespace ScriptVars
 		P_OrientY,   //o --> dy
 		P_RotateCW,  //o --> cw(o)
 		P_RotateCCW, //o --> ccw(o)
+		P_RotateDist,//(o1, o2) --> number of turns between the two
 		P_Dist0,     //L-infinity norm
 		P_Dist1,     //L-1 norm (Manhattan distance)
 		P_Dist2,     //L-2 norm (Euclidean distance)

--- a/DRODLib/TileConstants.h
+++ b/DRODLib/TileConstants.h
@@ -333,6 +333,21 @@ static inline UINT getToggledForceArrow(const UINT t) {
 	}
 }
 
+static inline UINT getForceArrowDirection(const UINT t) {
+	switch (t) {
+		case T_ARROW_NE: return NE;
+		case T_ARROW_E:  return E;
+		case T_ARROW_SE: return SE;
+		case T_ARROW_S:  return S;
+		case T_ARROW_SW: return SW;
+		case T_ARROW_W:  return W;
+		case T_ARROW_NW: return NW;
+		case T_ARROW_N:  return N;
+
+		default: return NO_ORIENTATION;
+	}
+}
+
 static inline bool bIsPotion(const UINT t) {
 	switch (t)
 	{

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -405,6 +405,7 @@
     <ClCompile Include="src\tests\Scripting\ImperativePushable\PushableByWeapon.cpp" />
     <ClCompile Include="src\tests\Scripting\Imperative_BrainPathmapObstacle.cpp" />
     <ClCompile Include="src\tests\Scripting\Imperative_Vulnerable_Invulnerable.cpp" />
+    <ClCompile Include="src\tests\Scripting\PrimitiveFunctions.cpp" />
     <ClCompile Include="src\tests\Scripting\PushTile.cpp" />
     <ClCompile Include="src\tests\Scripting\SetPlayerWeapon.cpp" />
     <ClCompile Include="src\tests\Scripting\SmartGotoLabels.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -243,6 +243,9 @@
     <ClCompile Include="src\tests\Scripting\Behavior\SetMovementType.cpp">
       <Filter>Tests\Scripting\Behavior</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Scripting\PrimitiveFunctions.cpp">
+      <Filter>Tests\Scripting\Behavior</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />

--- a/DRODLibTests/src/tests/Scripting/PrimitiveFunctions.cpp
+++ b/DRODLibTests/src/tests/Scripting/PrimitiveFunctions.cpp
@@ -130,6 +130,22 @@ TEST_CASE("Scripting: Primitive Functions", "[game][scripting][functions]") {
 		TestParsedValue(noOrientCW, NO_ORIENTATION, pGame, pCharacter);
 		TestParsedValue(noOrientCCW, NO_ORIENTATION, pGame, pCharacter);
 
+		// Facing
+		wstring facingExpression(L"_facing(2,2)");
+		wstring facingExpression2(L"_facing(0,-3)");
+		wstring facingExpression3(L"_facing(1,5)");
+		wstring facingExpression4(L"_facing(0,0)");
+
+		TestValidity(facingExpression, pHold);
+		TestValidity(facingExpression2, pHold);
+		TestValidity(facingExpression3, pHold);
+		TestValidity(facingExpression4, pHold);
+
+		TestParsedValue(facingExpression, SE, pGame, pCharacter);
+		TestParsedValue(facingExpression2, N, pGame, pCharacter);
+		TestParsedValue(facingExpression3, S, pGame, pCharacter);
+		TestParsedValue(facingExpression4, NO_ORIENTATION, pGame, pCharacter);
+
 		// Rotation distance
 		wstring rotationDist(L"_rotateDist(2,6)");
 		wstring rotationDist2(L"_rotateDist(1,3)");

--- a/DRODLibTests/src/tests/Scripting/PrimitiveFunctions.cpp
+++ b/DRODLibTests/src/tests/Scripting/PrimitiveFunctions.cpp
@@ -1,0 +1,224 @@
+#include "../../test-include.hpp"
+#include "../../CAssert.h"
+
+static void TestValidity(const wstring& expression, CDbHold* pHold, bool bValid = true) {
+	UINT index = 0;
+	CHECK(CCharacter::IsValidExpression(expression.c_str(), index, pHold) == bValid);
+}
+
+static void TestParsedValue(
+	wstring expression,
+	int expectedValue,
+	CCurrentGame* pGame,
+	CCharacter* pCharacter
+) {
+	UINT index = 0;
+	CHECK(CCharacter::parseExpression(expression.c_str(), index, pGame, pCharacter) == expectedValue);
+}
+
+TEST_CASE("Scripting: Primitive Functions", "[game][scripting][functions]") {
+	SECTION("Mathematical Functions") {
+		CCurrentGame* pGame = Runner::StartGame(10, 10);
+		CDbHold* pHold = pGame->pHold;
+		CCharacter* pCharacter = RoomBuilder::AddVisibleCharacter(10, 11);
+
+		// Absolute value
+		wstring absExpression(L"_abs(-5)");
+		wstring absExpression2(L"_abs(7)");
+		wstring absBad(L"_abs(-6");
+		
+		TestValidity(absExpression, pHold);
+		TestValidity(absExpression2, pHold);
+		TestValidity(absBad, pHold, false);
+
+		TestParsedValue(absExpression, 5, pGame, pCharacter);
+		TestParsedValue(absExpression2, 7, pGame, pCharacter);
+
+		// Minimum and maximum
+		wstring minExpression(L"_min(2,6)");
+		wstring maxExpression(L"_max(-7, -3)");
+		wstring nestedMin(L"_min(_min(-1, 3), _min(4, 22))");
+		wstring nestedMax(L"_max(_max(-1, 3), _max(4, 22))");
+		wstring nestedMinMax(L"_min(_max(-1, 3), _max(4, 22))");
+		wstring nestedMaxMin(L"_max(_min(-1, 3), _min(4, 22))");
+
+		TestValidity(minExpression, pHold);
+		TestValidity(maxExpression, pHold);
+		TestValidity(nestedMin, pHold);
+		TestValidity(nestedMax, pHold);
+		TestValidity(nestedMinMax, pHold);
+		TestValidity(nestedMaxMin, pHold);
+
+		TestParsedValue(minExpression, 2, pGame, pCharacter);
+		TestParsedValue(maxExpression, -3, pGame, pCharacter);
+		TestParsedValue(nestedMin, -1, pGame, pCharacter);
+		TestParsedValue(nestedMax, 22, pGame, pCharacter);
+		TestParsedValue(nestedMinMax, 3, pGame, pCharacter);
+		TestParsedValue(nestedMaxMin, 4, pGame, pCharacter);
+
+		// Distances
+		wstring distLInf(L"_dist0(5,5,7,12)");
+		wstring distL1(L"_dist1(2,2,4,5)");
+		wstring distL2(L"_dist2(1,2,4,6)");
+
+		TestValidity(distLInf, pHold);
+		TestValidity(distL1, pHold);
+		TestValidity(distL2, pHold);
+
+		TestParsedValue(distLInf, 7, pGame, pCharacter);
+		TestParsedValue(distL1, 5, pGame, pCharacter);
+		TestParsedValue(distL2, 5, pGame, pCharacter);
+	}
+
+	SECTION("DROD Math Functions") {
+		CCurrentGame* pGame = Runner::StartGame(10, 10);
+		CDbHold* pHold = pGame->pHold;
+		CCharacter* pCharacter = RoomBuilder::AddVisibleCharacter(10, 11);
+
+		// Orientations
+		TestValidity(L"_ox(3)", pHold);
+		TestValidity(L"_oy(7)", pHold);
+
+		for (int wO = 0; wO <= 8; wO++) {
+			if (wO == NO_ORIENTATION) {
+				continue;
+			}
+
+			TestParsedValue(
+				wstring(L"_rotateCW(") + std::to_wstring(wO) + wstring(L")"),
+				nNextCO(wO),
+				pGame,
+				pCharacter
+			);
+			TestParsedValue(
+				wstring(L"_rotateCCW(") + std::to_wstring(wO) + wstring(L")"),
+				nNextCCO(wO),
+				pGame,
+				pCharacter
+			);
+			TestParsedValue(
+				wstring(L"_ox(") + std::to_wstring(wO) + wstring(L")"),
+				nGetOX(wO),
+				pGame,
+				pCharacter
+			);
+			TestParsedValue(
+				wstring(L"_oy(") + std::to_wstring(wO) + wstring(L")"),
+				nGetOY(wO),
+				pGame,
+				pCharacter
+			);
+		}
+
+		wstring orientExpression(L"_orient(1,1)");
+		wstring orientExpression2(L"_orient(-5,7)");
+		wstring badOX(L"_ox(11)");
+		wstring badOY(L"_oy(-6)");
+
+		TestValidity(badOX, pHold);
+		TestValidity(badOY, pHold);
+		TestValidity(orientExpression, pHold);
+		TestValidity(orientExpression2, pHold);
+
+		TestParsedValue(orientExpression, SE, pGame, pCharacter);
+		TestParsedValue(orientExpression2, SW, pGame, pCharacter);
+		TestParsedValue(badOX, 11, pGame, pCharacter);
+		TestParsedValue(badOY, -6, pGame, pCharacter);
+
+		wstring noOrientCW(L"_rotateCW(4)");
+		wstring noOrientCCW(L"_rotateCCW(4)");
+		TestParsedValue(noOrientCW, NO_ORIENTATION, pGame, pCharacter);
+		TestParsedValue(noOrientCCW, NO_ORIENTATION, pGame, pCharacter);
+
+		// Rotation distance
+		wstring rotationDist(L"_rotateDist(2,6)");
+		wstring rotationDist2(L"_rotateDist(1,3)");
+		wstring rotationDist3(L"_rotateDist(7,5)");
+		wstring rotationDistSame(L"_rotateDist(1,1)");
+		wstring rotationDistNo(L"_rotateDist(4,7)");
+		wstring rotationDistBad(L"_rotateDist(12,1)");
+
+		TestValidity(rotationDist, pHold);
+		TestValidity(rotationDist2, pHold);
+		TestValidity(rotationDist3, pHold);
+		TestValidity(rotationDistSame, pHold);
+		TestValidity(rotationDistNo, pHold);
+		TestValidity(rotationDistBad, pHold);
+
+		TestParsedValue(rotationDist, 4, pGame, pCharacter);
+		TestParsedValue(rotationDist2, 2, pGame, pCharacter);
+		TestParsedValue(rotationDist3, 2, pGame, pCharacter);
+		TestParsedValue(rotationDistSame, 0, pGame, pCharacter);
+		TestParsedValue(rotationDistNo, 0, pGame, pCharacter);
+		TestParsedValue(rotationDistBad, 0, pGame, pCharacter);
+	}
+
+	SECTION("Room Information Functions") {
+		// Room setup
+		RoomBuilder::Plot(T_ARROW_N, 5, 15);
+		RoomBuilder::Plot(T_ARROW_S, 6, 15);
+		RoomBuilder::Plot(T_ARROW_NW, 7, 15);
+
+		RoomBuilder::Plot(T_FIRETRAP, 5, 16);
+		RoomBuilder::Plot(T_NODIAGONAL, 5, 16);
+		RoomBuilder::Plot(T_BOMB, 5, 16);
+
+		RoomBuilder::AddMonster(M_ROACH, 5, 17);
+		RoomBuilder::AddMonster(M_GELMOTHER, 6, 17);
+		CMonster* pSnake = RoomBuilder::AddMonster(M_SERPENT, 7, 17);
+		CSerpent* pSerpent = DYN_CAST(CSerpent*, CMonster*, pSnake);
+		RoomBuilder::AddSerpentPiece(pSerpent, 8, 17);
+
+		CCurrentGame* pGame = Runner::StartGame(10, 10);
+		CDbHold* pHold = pGame->pHold;
+		CCharacter* pCharacter = RoomBuilder::AddVisibleCharacter(10, 11);
+
+		// Arrow direction
+		wstring arrowDir(L"_ArrowDir(5,15)");
+		wstring arrowDir2(L"_ArrowDir(6,15)");
+		wstring arrowDir3(L"_ArrowDir(7,15)");
+		wstring arrowDirNone(L"_ArrowDir(8,15)");
+
+		TestValidity(arrowDir, pHold);
+		TestValidity(arrowDir2, pHold);
+		TestValidity(arrowDir3, pHold);
+		TestValidity(arrowDirNone, pHold);
+
+		TestParsedValue(arrowDir, N, pGame, pCharacter);
+		TestParsedValue(arrowDir2, S, pGame, pCharacter);
+		TestParsedValue(arrowDir3, NW, pGame, pCharacter);
+		TestParsedValue(arrowDirNone, NO_ORIENTATION, pGame, pCharacter);
+
+		// Room Tile
+		wstring roomTileO(L"_RoomTile(5,16,0)");
+		wstring roomTileF(L"_RoomTile(5,16,1)");
+		wstring roomTileT(L"_RoomTile(5,16,2)");
+		wstring roomTileInvalidLayer(L"_RoomTile(5,16,3)");
+
+		TestValidity(roomTileO, pHold);
+		TestValidity(roomTileF, pHold);
+		TestValidity(roomTileT, pHold);
+		TestValidity(roomTileInvalidLayer, pHold);
+
+		TestParsedValue(roomTileO, T_FIRETRAP, pGame, pCharacter);
+		TestParsedValue(roomTileF, T_NODIAGONAL, pGame, pCharacter);
+		TestParsedValue(roomTileT, T_BOMB, pGame, pCharacter);
+		TestParsedValue(roomTileInvalidLayer, 0, pGame, pCharacter);
+
+		// Monster Type
+		wstring monsterType(L"_MonsterType(5,17)");
+		wstring monsterType2(L"_MonsterType(6,17)");
+		wstring monsterType3(L"_MonsterType(7,17)");
+		wstring monsterTypeBig(L"_MonsterType(8,17)"); // snake piece
+
+		TestValidity(monsterType, pHold);
+		TestValidity(monsterType2, pHold);
+		TestValidity(monsterType3, pHold);
+		TestValidity(monsterTypeBig, pHold);
+
+		TestParsedValue(monsterType, M_ROACH, pGame, pCharacter);
+		TestParsedValue(monsterType2, M_GELMOTHER, pGame, pCharacter);
+		TestParsedValue(monsterType3, M_SERPENT, pGame, pCharacter);
+		TestParsedValue(monsterTypeBig, M_SERPENT, pGame, pCharacter);
+	}
+}

--- a/Data/Help/1/refindex.html
+++ b/Data/Help/1/refindex.html
@@ -270,6 +270,7 @@
 <a href="customizing.html#FullScoreUpload">FullScoreUpload</a> (customizing)<br />
 <a href="settings.html#fullscreen">Full screen</a> (settings)<br />
 <a href="keyboard.html#fullscreen">Full screen mode</a> (keys)<br />
+<a href="script.html#functions">Function primitives</a> (scripts)<br />
 </p>
 <p>
 <a href="#A">A</a>&nbsp;<a href="#B">B</a>&nbsp;<a href="#C">C</a>&nbsp;<a href="#D">D</a>&nbsp;<a href="#E">E</a>&nbsp;<a href="#F">F</a>&nbsp;<a href="#G">G</a>&nbsp;<a href="#H">H</a>&nbsp;<a href="#I">I</a>&nbsp;<a href="#J">J</a>&nbsp;<a href="#K">K</a>&nbsp;<a href="#L">L</a>&nbsp;<a href="#M">M</a>&nbsp;<a href="#N">N</a>&nbsp;<a href="#O">O</a>&nbsp;<a href="#P">P</a>&nbsp;<a href="#Q">Q</a>&nbsp;<a href="#R">R</a>&nbsp;<a href="#S">S</a>&nbsp;<a href="#T">T</a>&nbsp;<a href="#U">U</a>&nbsp;<a href="#V">V</a>&nbsp;<a href="#W">W</a>&nbsp;<a href="#X">X</a>&nbsp;<a href="#Y">Y</a>&nbsp;<a href="#Z">Z</a>
@@ -521,6 +522,7 @@
 <a href="editroom.html#playtesting">Playtesting</a> (room editor)<br />
 <a href="editroom.html#powertoken">Power/target token</a> (room editor)<br />
 <a href="editroom.html#pressureplates">Pressure plates</a> (room editor)<br />
+<a href="script.html#functions">Primitives</a> (scripts)<br />
 <a href="keyboard.html#lock">Prevent exiting</a> (keys)<br />
 <a href="script.html#dontrestart">Prevent script from restarting on reentry</a> (scripts)<br />
 <a href="caravelNet.html#privacy">Privacy notice</a> (CaravelNet)<br />

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -569,6 +569,7 @@ continue executing script commands from a different location in the script.</p>
 <p><a name="oy">* <b>_oy(o)</b></a> - Given an orientation id (0-8), returns its y component offset (-1, 0, 1).  Given an invalid orientation value, the same value is returned.</p>
 <p><a name="rotatecw">* <b>_rotateCW(o)</b></a> - Given an orientation id (0-8), returns the id of the orientation in a clockwise direction.  Given an invalid orientation value, the same value is returned.</p>
 <p><a name="rotateccw">* <b>_rotateCCW(o)</b></a> - Given an orientation id (0-8), returns the id of the orientation in a counter-clockwise direction.  Given an invalid orientation value, the same value is returned.</p>
+<p><a name="rotatedist">* <b>_rotateDist(o1, o2)</b></a> - Give two orientation ids (0-8), returns the number of rotations between them. If either value is invalid, or has a value of 4, returns a value of zero.</p>
 <p><a name="dist0">* <b>_dist0(x1,y1,x2,y2)</b></a> - Returns the L-infinity norm (max axial distance) between two 2-D coordinates.</p>
 <p><a name="dist1">* <b>_dist1(x1,y1,x2,y2)</b></a> - Returns the L-1 norm (Manhattan distance) between two 2-D coordinates.</p>
 <p><a name="dist2">* <b>_dist2(x1,y1,x2,y2)</b></a> - Returns the L-2 norm (Euclidean distance) between two 2-D coordinates.</p>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -19,6 +19,7 @@ designate.  There are four general classes of script commands, as follows:</p>
 <a href="#usagenotes">Notes about using NPC scripts</a><br />
 <a href="#imperativelist">Imperatives</a><br />
 <a href="#behaviorlist">Behaviors</a><br />
+<a href="#functions">Function Primitives</a><br />
 <a href="#branchingexamples">Examples of branching code structures</a><br />
 <a href="#commandkeyexample">Example of using the Special Command key</a><br />
 <a href="#world-map-command-ex">Example of using World Map commands</a><br />
@@ -572,6 +573,13 @@ continue executing script commands from a different location in the script.</p>
 <p><a name="dist1">* <b>_dist1(x1,y1,x2,y2)</b></a> - Returns the L-1 norm (Manhattan distance) between two 2-D coordinates.</p>
 <p><a name="dist2">* <b>_dist2(x1,y1,x2,y2)</b></a> - Returns the L-2 norm (Euclidean distance) between two 2-D coordinates.</p>
 <p><a name="arrowdir">* <b>_ArrowDir(x,y)</b></a> - Returns the the orientation id (0-8) for the arrow at the room location (x,y). If no arrow is present, returns a value of 4.</p>
+<p><a name="roomtile">* <b>_RoomTile(x,y,z)</b></a> - Returns the numeric id of the room tile at (x,y). Use the z parameter to select the tile layer.<br/>
+Supported layer values - 0 -> O Layer, 1 -> F Layer, 2 -> T Layer <br/>
+Hint: Each layer corresponds to a tab in the editor's tile selection dialog.
+</p>
+<p><a name="monstertype">* <b>_MonsterType(x,y)</b></a> - Returns the numeric monster type of the monster at (x,y). If no monster is present on the tile, -1 is returned.<br/>
+Hint: This can be used to compare the monsters in different tiles, or for providing a value for _MyScript injection.
+</p>
 
 <p><a name="branchingexamples"><b>Examples of branching code structures:</b></a></p>
 <ol>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -552,6 +552,26 @@ continue executing script commands from a different location in the script.</p>
 	<li><a name="beh-fatal-push-immune"><b>Push to Fall Immunity</b></a>: The NPC cannot be pushed onto pit or water tiles if this would kill them. The NPC can still be pushed into other potentially dangerous tiles, such as active fire traps.</li>
 </ol>
 
+<p><a name="functions"><b>Function primitives</b></a> - Predefined
+  functions may be inserted anywhere a variable is referenced. The function will
+  return a value based on the input parameters and current game context, where applicable.
+  Functions are useful to apply in variable expressions.
+  All inputs must either be integer values or an expression that resolves to an integer value.
+  All outputs are likewise integers.
+  Function names are case-insensitive.
+</p>
+<p><a name="abs">* <b>_abs(x)</b></a> - Returns the absolute value of x</p>
+<p><a name="min">* <b>_min(x,y)</b></a> - Returns the lesser of two values</p>
+<p><a name="max">* <b>_max(x,y)</b></a> - Returns the greater of two values</p>
+<p><a name="orient">* <b>_orient(dx,dy)</b></a> - Returns an orientation id (0-8), given x,y directional offsets</p>
+<p><a name="ox">* <b>_ox(o)</b></a> - Given an orientation id (0-8), returns its x component offset (-1, 0, 1).  Given an invalid orientation value, the same value is returned.</p>
+<p><a name="oy">* <b>_oy(o)</b></a> - Given an orientation id (0-8), returns its y component offset (-1, 0, 1).  Given an invalid orientation value, the same value is returned.</p>
+<p><a name="rotatecw">* <b>_rotateCW(o)</b></a> - Given an orientation id (0-8), returns the id of the orientation in a clockwise direction.  Given an invalid orientation value, the same value is returned.</p>
+<p><a name="rotateccw">* <b>_rotateCCW(o)</b></a> - Given an orientation id (0-8), returns the id of the orientation in a counter-clockwise direction.  Given an invalid orientation value, the same value is returned.</p>
+<p><a name="dist0">* <b>_dist0(x1,y1,x2,y2)</b></a> - Returns the L-infinity norm (max axial distance) between two 2-D coordinates.</p>
+<p><a name="dist1">* <b>_dist1(x1,y1,x2,y2)</b></a> - Returns the L-1 norm (Manhattan distance) between two 2-D coordinates.</p>
+<p><a name="dist2">* <b>_dist2(x1,y1,x2,y2)</b></a> - Returns the L-2 norm (Euclidean distance) between two 2-D coordinates.</p>
+
 <p><a name="branchingexamples"><b>Examples of branching code structures:</b></a></p>
 <ol>
   <li><a name="singlecodebranch">A single code branch:</a><br />

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -565,6 +565,7 @@ continue executing script commands from a different location in the script.</p>
 <p><a name="min">* <b>_min(x,y)</b></a> - Returns the lesser of two values</p>
 <p><a name="max">* <b>_max(x,y)</b></a> - Returns the greater of two values</p>
 <p><a name="orient">* <b>_orient(dx,dy)</b></a> - Returns an orientation id (0-8), given x,y directional offsets</p>
+<p><a name="facing">* <b>_facing(dx,dy)</b></a> - Returns the orientation id (0-8) most directly facing in the direction of the given x,y vector</p>
 <p><a name="ox">* <b>_ox(o)</b></a> - Given an orientation id (0-8), returns its x component offset (-1, 0, 1).  Given an invalid orientation value, the same value is returned.</p>
 <p><a name="oy">* <b>_oy(o)</b></a> - Given an orientation id (0-8), returns its y component offset (-1, 0, 1).  Given an invalid orientation value, the same value is returned.</p>
 <p><a name="rotatecw">* <b>_rotateCW(o)</b></a> - Given an orientation id (0-8), returns the id of the orientation in a clockwise direction.  Given an invalid orientation value, the same value is returned.</p>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -571,6 +571,7 @@ continue executing script commands from a different location in the script.</p>
 <p><a name="dist0">* <b>_dist0(x1,y1,x2,y2)</b></a> - Returns the L-infinity norm (max axial distance) between two 2-D coordinates.</p>
 <p><a name="dist1">* <b>_dist1(x1,y1,x2,y2)</b></a> - Returns the L-1 norm (Manhattan distance) between two 2-D coordinates.</p>
 <p><a name="dist2">* <b>_dist2(x1,y1,x2,y2)</b></a> - Returns the L-2 norm (Euclidean distance) between two 2-D coordinates.</p>
+<p><a name="arrowdir">* <b>_ArrowDir(x,y)</b></a> - Returns the the orientation id (0-8) for the arrow at the room location (x,y). If no arrow is present, returns a value of 4.</p>
 
 <p><a name="branchingexamples"><b>Examples of branching code structures:</b></a></p>
 <ol>


### PR DESCRIPTION
It's #354, but for mainline DROD. Adds functions that be used when setting variables. I consider the functions to exist in three categories.

## Mathematical
For the manipulation of numbers or calculation of values.

`_abs(x)` - Returns the absolute value of x
`min(x,y)` and `max(x,y)` - Returns the lesser and greater value, respectively.
`_dist0(x1,y1,x2,y2)` - Distance between two points using L-infinity metric
`_dist1(x1,y1,x2,y2)` - Distance between two points using L1 metric
`_dist2(x1,y1,x2,y2)` - Distance between two points using L2 metric

## DROD Maths
Number crunching, in specific DROD contexts

`_ox(o)` and `_oy(o)` - Returns x and y components of the given orientation. Invalid orientations return themselves
`_orient(x,y)` - Returns the orientation based on the given x and y component
`_facing(dx,dy)` - Returns the orientation closest to the direction of the given vector.
`_rotateCW(o)` and `_rotateCCW(o)` - Returns next clockwise or counterclockwise direction
`_rotationDist(o1, o2)` - How many rotations between the two orientations. If either value is invalid, returns zero.

## Room Information
Finds information about the room.

`_ArrowDir(x,y)` - Direction of arrow at (x,y). Arrowless tiles return 4, for NO_ORIENTATION
`_MonsterType(x,y)` - The type of monster at (x,y). Monsterless tile returns -1, because Roaches are monster zero.
`_RoomTile(x,y,z)` - The tile id of the tile at (x,y). z parameter chooses the layer to inspect.