### PR TITLE
Fix drag and drop functionallity in script editor

### DIFF
--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -1338,6 +1338,7 @@ void CListBoxWidget::HandleDrag(
 		this->Items[this->wDraggingLineNo] = this->Items[this->wCursorLine];
 		this->Items[this->wCursorLine] = pItem;
 		this->wDraggingLineNo = this->wCursorLine;
+		this->filteredItems = this->Items;
 
 		SelectLine(this->wCursorLine);
 


### PR DESCRIPTION
Fixes the issues described in #378. An additional line is needed so that the change to the item order is also applied to the filter items which are shown to the user.