### PR TITLE
Additional object selection highlighting

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1041,10 +1041,11 @@ void CRoomWidget::HighlightSelectedTile()
 				UINT wDestX, wDestY;
 				if (pCitizen->GetGoal(wDestX, wDestY)) {
 					AddShadeEffect(wDestX, wDestY, PaleYellow);
-					for (UINT wPathIndex = 0; wPathIndex < pCitizen->GetStoredPath().GetSize(); ++wPathIndex)
+					CCoordStack citizenPath = pCitizen->GetStoredPath();
+					for (UINT wPathIndex = 0; wPathIndex < citizenPath.GetSize(); ++wPathIndex)
 					{
 						UINT wX, wY;
-						pCitizen->GetStoredPath().GetAt(wPathIndex, wX, wY);
+						citizenPath.GetAt(wPathIndex, wX, wY);
 						ASSERT(this->pRoom->IsValidColRow(wX, wY));
 						AddShadeEffect(wX, wY, PaleYellow);
 					}
@@ -1059,10 +1060,11 @@ void CRoomWidget::HighlightSelectedTile()
 				CStalwart *pStalwart = DYN_CAST(CStalwart*, CMonster*, const_cast<CMonster*>(pMonster));
 				UINT wDestX, wDestY;
 				if (!pStalwart->bFrozen && pStalwart->GetGoal(wDestX, wDestY)) {
-					for (UINT wPathIndex = 0; wPathIndex < pStalwart->GetStoredPath().GetSize(); ++wPathIndex)
+					CCoordStack stalwartPath = pStalwart->GetStoredPath();
+					for (UINT wPathIndex = 0; wPathIndex < stalwartPath.GetSize(); ++wPathIndex)
 					{
 						UINT wX, wY;
-						pStalwart->GetStoredPath().GetAt(wPathIndex, wX, wY);
+						stalwartPath.GetAt(wPathIndex, wX, wY);
 						ASSERT(this->pRoom->IsValidColRow(wX, wY));
 						AddShadeEffect(wX, wY, PaleYellow);
 					}
@@ -1101,10 +1103,11 @@ void CRoomWidget::HighlightSelectedTile()
 				static const SURFACECOLOR Orange = { 255, 165, 0 };
 				//Show Halph's stored path
 				const CHalph* pHalph = DYN_CAST(const CHalph*, const CMonster*, pMonster);
-				for (UINT wPathIndex = 0; wPathIndex < pHalph->GetStoredPath().GetSize(); ++wPathIndex)
+				CCoordStack halphPath = pHalph->GetStoredPath();
+				for (UINT wPathIndex = 0; wPathIndex < halphPath.GetSize(); ++wPathIndex)
 				{
 					UINT wX, wY;
-					pHalph->GetStoredPath().GetAt(wPathIndex, wX, wY);
+					halphPath.GetAt(wPathIndex, wX, wY);
 					ASSERT(this->pRoom->IsValidColRow(wX, wY));
 					AddShadeEffect(wX, wY, Orange);
 				}

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1039,8 +1039,16 @@ void CRoomWidget::HighlightSelectedTile()
 				//Show citizen's current destination.
 				const CCitizen *pCitizen = DYN_CAST(const CCitizen*, const CMonster*, pMonster);
 				UINT wDestX, wDestY;
-				if (pCitizen->GetGoal(wDestX,wDestY))
+				if (pCitizen->GetGoal(wDestX, wDestY)) {
 					AddShadeEffect(wDestX, wDestY, PaleYellow);
+					for (UINT wPathIndex = 0; wPathIndex < pCitizen->GetStoredPath().GetSize(); ++wPathIndex)
+					{
+						UINT wX, wY;
+						pCitizen->GetStoredPath().GetAt(wPathIndex, wX, wY);
+						ASSERT(this->pRoom->IsValidColRow(wX, wY));
+						AddShadeEffect(wX, wY, PaleYellow);
+					}
+				}
 				bRemoveHighlightNextTurn = false;
 			}
 			break;
@@ -1050,8 +1058,15 @@ void CRoomWidget::HighlightSelectedTile()
 				//Show stalwart's current target.
 				CStalwart *pStalwart = DYN_CAST(CStalwart*, CMonster*, const_cast<CMonster*>(pMonster));
 				UINT wDestX, wDestY;
-				if (!pStalwart->bFrozen && pStalwart->GetGoal(wDestX,wDestY))
-					AddShadeEffect(wDestX, wDestY, PaleYellow);
+				if (!pStalwart->bFrozen && pStalwart->GetGoal(wDestX, wDestY)) {
+					for (UINT wPathIndex = 0; wPathIndex < pStalwart->GetStoredPath().GetSize(); ++wPathIndex)
+					{
+						UINT wX, wY;
+						pStalwart->GetStoredPath().GetAt(wPathIndex, wX, wY);
+						ASSERT(this->pRoom->IsValidColRow(wX, wY));
+						AddShadeEffect(wX, wY, PaleYellow);
+					}
+				}
 				bRemoveHighlightNextTurn = false;
 			}
 			break;

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1175,9 +1175,8 @@ void CRoomWidget::HighlightSelectedTile()
 		break;
 		case T_HORN_SQUAD:
 		{
-			MovementType eMovement = GetHornMovementType(this->pCurrentGame->swordsman.GetMovementType());
 			UINT goalX, goalY;
-			if (this->pRoom->GetNearestEntranceTo(wX, wY, eMovement, goalX, goalY)) {
+			if (this->pCurrentGame->GetNearestEntranceForHorn(wX, wY, M_CLONE, goalX, goalY)) {
 				AddShadeEffect(goalX, goalY, PaleYellow);
 				bRemoveHighlightNextTurn = false;
 			}
@@ -1186,7 +1185,7 @@ void CRoomWidget::HighlightSelectedTile()
 		case T_HORN_SOLDIER:
 		{
 			UINT goalX, goalY;
-			if (this->pRoom->GetNearestEntranceTo(wX, wY, GROUND_AND_SHALLOW_WATER_FORCE, goalX, goalY)) {
+			if (this->pCurrentGame->GetNearestEntranceForHorn(wX, wY, M_STALWART2, goalX, goalY)) {
 				SURFACECOLOR Blue = { 120, 120, 255 };
 				AddShadeEffect(goalX, goalY, Blue);
 				bRemoveHighlightNextTurn = false;

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1170,6 +1170,26 @@ void CRoomWidget::HighlightSelectedTile()
 			bRemoveHighlightNextTurn = false;
 		}
 		break;
+		case T_HORN_SQUAD:
+		{
+			MovementType eMovement = GetHornMovementType(this->pCurrentGame->swordsman.GetMovementType());
+			UINT goalX, goalY;
+			if (this->pRoom->GetNearestEntranceTo(wX, wY, eMovement, goalX, goalY)) {
+				AddShadeEffect(goalX, goalY, PaleYellow);
+				bRemoveHighlightNextTurn = false;
+			}
+		}
+		break;
+		case T_HORN_SOLDIER:
+		{
+			UINT goalX, goalY;
+			if (this->pRoom->GetNearestEntranceTo(wX, wY, GROUND_AND_SHALLOW_WATER_FORCE, goalX, goalY)) {
+				SURFACECOLOR Blue = { 120, 120, 255 };
+				AddShadeEffect(goalX, goalY, Blue);
+				bRemoveHighlightNextTurn = false;
+			}
+		}
+		break;
 		default: break;
 	}
 

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -605,6 +605,21 @@ WSTRING CCurrentGame::ExpandText(const WCHAR* wText,
 }
 
 //*****************************************************************************
+bool CCurrentGame::GetNearestEntranceForHorn(
+	UINT wHornX, UINT wHornY, UINT wSummonType, UINT& wX, UINT& wY
+)
+// Find the nearest room edge tile for horn-summoned entity.
+// Returns true if an edge is found, and outputs the location to (wX, wY).
+// If no room edge can be reached from the horn tile, return false.
+{
+	MovementType eMovement = GROUND_AND_SHALLOW_WATER_FORCE;
+	if (wSummonType == M_CLONE)
+		eMovement = GetHornMovementType(this->swordsman.GetMovementType());
+
+	return this->pRoom->GetNearestEntranceTo(wHornX, wHornY, eMovement, wX, wY);
+}
+
+//*****************************************************************************
 UINT CCurrentGame::GetNextImageOverlayID()
 {
 	return imageOverlayNextID++;
@@ -4748,10 +4763,7 @@ void CCurrentGame::BlowHorn(CCueEvents &CueEvents, const UINT wSummonType,
 
 	ResetPendingTemporalSplit(CueEvents);
 
-	MovementType eMovement = GetHornMovementType(this->swordsman.GetMovementType());
-	if (wSummonType != M_CLONE)
-		eMovement = GROUND_AND_SHALLOW_WATER_FORCE;
-	if (!this->pRoom->GetNearestEntranceTo(wHornX, wHornY, eMovement, wX, wY))
+	if (!GetNearestEntranceForHorn(wHornX, wHornY, wSummonType, wX, wY))
 	{
 		CueEvents.Add(CID_HornFail);
 	} else {

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -198,6 +198,7 @@ public:
 	const CEntity* GetKillingEntity() const {return this->pKillingEntity;}
 	void     GetLevelStats(CDbLevel *pLevel);
 	MusicData GetMusic() const { return music; }
+	bool     GetNearestEntranceForHorn(UINT wHornX, UINT wHornY, UINT wSummonType, UINT& wX, UINT& wY);
 	UINT     GetNextImageOverlayID();
 	UINT     GetRoomExitDirection(const UINT wMoveO) const;
 	WSTRING  GetScrollTextAt(const UINT wX, const UINT wY);

--- a/DRODLib/Halph.h
+++ b/DRODLib/Halph.h
@@ -48,7 +48,6 @@ public:
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 
 	bool GetPathTo(CCueEvents &CueEvents, const CCoordSet &adjDests, const CCoordSet *pDirectDests=NULL);
-	virtual CCoordStack GetStoredPath() const { return this->pathToDest; }
 	virtual bool IsAggressive() const {return false;}
 	virtual bool IsFriendly() const {return true;}
 	bool IsOpeningDoorAt(const CCoordSet& doorSquares) const;

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -272,6 +272,7 @@ public:
 	virtual UINT  GetProcessSequence() const;
 	virtual UINT  GetResolvedIdentity() const {return GetIdentity();}
 	UINT          GetOrientationFacingTarget(const UINT wX, const UINT wY) const;
+	virtual CCoordStack GetStoredPath() const { return this->pathToDest; }
 	bool          GetSwordCoords(UINT& wX, UINT& wY) const;
 	virtual WeaponType GetWeaponType() const { return WT_Sword; }
 	bool          GetTarget(UINT &wX, UINT &wY, const bool bConsiderDecoys=true);


### PR DESCRIPTION
Stalwart, Soldier and Citizen pathfinding is weird and confusing to many players. So there is a desire to visualize it. It would also be nice if clicking on horns showed where the spawn will occur.

Monster path visuals extend the implementation of #359, allowing paths to be viewed for Stalwarts, Soldiers, Citizens and Engineers.