### PR TITLE
Add support for token build markers

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -4428,24 +4428,7 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget *pListBox,
 		pListBox->AddItem(T_SCROLL, g_pTheDB->GetMessageText(MID_Scroll));
 		pListBox->AddItem(T_STAIRS, g_pTheDB->GetMessageText(MID_Stairs));
 		pListBox->AddItem(T_STAIRS_UP, g_pTheDB->GetMessageText(MID_StairsUp));
-		pListBox->AddItem(T_TOKEN_CONQUER, g_pTheDB->GetMessageText(MID_TokenConquer));
-		pListBox->AddItem(T_TOKEN_DISARM, g_pTheDB->GetMessageText(MID_TokenSwordDisarm));
-		pListBox->AddItem(T_TOKEN_PERSISTENTMOVE, g_pTheDB->GetMessageText(MID_TokenCitizen));
-		pListBox->AddItem(T_TOKEN_POWER, g_pTheDB->GetMessageText(MID_TokenPowerTarget));
-		pListBox->AddItem(T_TOKEN_ROTATECCW, g_pTheDB->GetMessageText(MID_TokenRotateCCW));
-		pListBox->AddItem(T_TOKEN_ROTATECW, g_pTheDB->GetMessageText(MID_Token));
-		pListBox->AddItem(T_TOKEN_SWITCH_GELMUD, g_pTheDB->GetMessageText(MID_TokenGelMud));
-		pListBox->AddItem(T_TOKEN_SWITCH_TARGEL, g_pTheDB->GetMessageText(MID_TokenTarGel));
-		pListBox->AddItem(T_TOKEN_SWITCH_TARMUD, g_pTheDB->GetMessageText(MID_TokenTarMud));
-		pListBox->AddItem(T_TOKEN_TSPLIT, g_pTheDB->GetMessageText(MID_TemporalSplitToken));
 		pListBox->AddItem(T_TOKEN_TSPLIT_USED, g_pTheDB->GetMessageText(MID_TemporalSplitUsed));
-		pListBox->AddItem(T_TOKEN_VISION, g_pTheDB->GetMessageText(MID_TokenTranslucentTar));
-		pListBox->AddItem(T_TOKEN_WPCABER, g_pTheDB->GetMessageText(MID_TokenCaber));
-		pListBox->AddItem(T_TOKEN_WPDAGGER, g_pTheDB->GetMessageText(MID_TokenDagger));
-		pListBox->AddItem(T_TOKEN_WPPICKAXE, g_pTheDB->GetMessageText(MID_TokenPickaxe));
-		pListBox->AddItem(T_TOKEN_WPSPEAR, g_pTheDB->GetMessageText(MID_TokenSpear));
-		pListBox->AddItem(T_TOKEN_WPSTAFF, g_pTheDB->GetMessageText(MID_TokenStaff));
-		pListBox->AddItem(T_TOKEN_WPSWORD, g_pTheDB->GetMessageText(MID_TokenSword));
 		pListBox->AddItem(T_WALLLIGHT, g_pTheDB->GetMessageText(MID_WallLight));
 	}
 
@@ -4523,6 +4506,23 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget *pListBox,
 	pListBox->AddItem(T_TAR, g_pTheDB->GetMessageText(MID_Tar));
 	pListBox->AddItem(T_THINICE, g_pTheDB->GetMessageText(MID_ThinIce));
 	pListBox->AddItem(T_THINICE_SH, g_pTheDB->GetMessageText(MID_ThinIce2));
+	pListBox->AddItem(T_TOKEN_CONQUER, g_pTheDB->GetMessageText(MID_TokenConquer));
+	pListBox->AddItem(T_TOKEN_DISARM, g_pTheDB->GetMessageText(MID_TokenSwordDisarm));
+	pListBox->AddItem(T_TOKEN_PERSISTENTMOVE, g_pTheDB->GetMessageText(MID_TokenCitizen));
+	pListBox->AddItem(T_TOKEN_POWER, g_pTheDB->GetMessageText(MID_TokenPowerTarget));
+	pListBox->AddItem(T_TOKEN_ROTATECCW, g_pTheDB->GetMessageText(MID_TokenRotateCCW));
+	pListBox->AddItem(T_TOKEN_ROTATECW, g_pTheDB->GetMessageText(MID_Token));
+	pListBox->AddItem(T_TOKEN_SWITCH_GELMUD, g_pTheDB->GetMessageText(MID_TokenGelMud));
+	pListBox->AddItem(T_TOKEN_SWITCH_TARGEL, g_pTheDB->GetMessageText(MID_TokenTarGel));
+	pListBox->AddItem(T_TOKEN_SWITCH_TARMUD, g_pTheDB->GetMessageText(MID_TokenTarMud));
+	pListBox->AddItem(T_TOKEN_TSPLIT, g_pTheDB->GetMessageText(MID_TemporalSplitToken));
+	pListBox->AddItem(T_TOKEN_VISION, g_pTheDB->GetMessageText(MID_TokenTranslucentTar));
+	pListBox->AddItem(T_TOKEN_WPCABER, g_pTheDB->GetMessageText(MID_TokenCaber));
+	pListBox->AddItem(T_TOKEN_WPDAGGER, g_pTheDB->GetMessageText(MID_TokenDagger));
+	pListBox->AddItem(T_TOKEN_WPPICKAXE, g_pTheDB->GetMessageText(MID_TokenPickaxe));
+	pListBox->AddItem(T_TOKEN_WPSPEAR, g_pTheDB->GetMessageText(MID_TokenSpear));
+	pListBox->AddItem(T_TOKEN_WPSTAFF, g_pTheDB->GetMessageText(MID_TokenStaff));
+	pListBox->AddItem(T_TOKEN_WPSWORD, g_pTheDB->GetMessageText(MID_TokenSword));
 	pListBox->AddItem(T_TRAPDOOR, g_pTheDB->GetMessageText(MID_Trapdoor));
 	pListBox->AddItem(T_TRAPDOOR2, g_pTheDB->GetMessageText(MID_Trapdoor2));
 	pListBox->AddItem(T_TUNNEL_E, g_pTheDB->GetMessageText(MID_Tunnel_E));

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1625,7 +1625,14 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 	//Build marker.
 	if (this->pRoom->building.get(wX,wY))
 	{
-		mid = getBuildMarkerTileMID(this->pRoom->building.get(wX,wY) - 1);
+		UINT wBuildTile = this->pRoom->building.get(wX, wY) - 1;
+
+		if (bIsFakeTokenType(wBuildTile)) {
+			mid = GetTokenMID(ConvertFakeTokenType(wBuildTile));
+		}	else {
+			mid = getBuildMarkerTileMID(wBuildTile);
+		}
+
 		if (mid)
 		{
 			wstr += wszCRLF;

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -4800,6 +4800,8 @@ void CRoomWidget::PopulateBuildMarkerEffects(const CDbRoom& room)
 						case T_BRIAR_SOURCE: wTileNo = TI_BRIARROOT; break;
 						default: wTileNo = GetTileImageForTileNo(wTile); break;
 					}
+					if (bIsFakeTokenType(wTile))
+						wTileNo = CalcTileImageForToken(ConvertFakeTokenType(wTile));
 					if (wTileNo == CALC_NEEDED)
 						wTileNo = CalcTileImageFor(&room, wTile, wX, wY);
 					if (wTileNo != CALC_NEEDED)

--- a/DRODLib/Building.cpp
+++ b/DRODLib/Building.cpp
@@ -57,9 +57,6 @@ UINT CBuilding::get(const UINT wX, const UINT wY) const
 void CBuilding::plot(const UINT wX, const UINT wY, const UINT wTile)
 //Set build tile at (x,y) to specified tile.
 {
-	//Only supported in immediate building at this time
-	if (bIsFakeTokenType(wTile)) return;
-
 	switch (wTile) {
 		case T_REMOVE_BUILD_MARKER:
 			remove(wX,wY);


### PR DESCRIPTION
Allows token build markers to be plotted and to appear correctly. Also adds all token types other than the used temporal split to the list of buildable objects in the script editor.

Minor changes have been done in `RoomWidget` so that tooltips and effects for token build markers work.

See thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45196