### PR TITLE
Fix improved script editor to work with default script editing

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -1988,8 +1988,8 @@ void CCharacterDialogWidget::AddScriptDialog()
 
 	this->pScriptDialog->AddWidget(new CLabelWidget(0, X_COMMANDSLABEL, Y_COMMANDSLABEL,
 			CX_COMMANDSLABEL, CY_COMMANDSLABEL, F_Small, g_pTheDB->GetMessageText(MID_Commands)));
-	this->pDefaultScriptCommandsListBox = new CListBoxWidget(TAG_DEFAULTCOMMANDSLISTBOX, X_COMMANDS, Y_COMMANDS,
-			CX_COMMANDS, CY_COMMANDS, false, true, true);
+	this->pDefaultScriptCommandsListBox = new CCommandListBoxWidget(TAG_DEFAULTCOMMANDSLISTBOX, X_COMMANDS, Y_COMMANDS,
+			CX_COMMANDS, CY_COMMANDS);
 	this->pScriptDialog->AddWidget(this->pDefaultScriptCommandsListBox);
 
 	//OK button.
@@ -2483,7 +2483,7 @@ void CCharacterDialogWidget::OnKeyDown(
 						line!=selectedLines.end(); ++line)
 				{
 					if (*line < pCommands->size())
-						wstrCommandsText += toText(*pCommands, (*pCommands)[*line], *line);
+						wstrCommandsText += toText(*pCommands, (*pCommands)[*line], pActiveCommandList, *line);
 				}
 				if (!wstrCommandsText.empty())
 					g_pTheSound->PlaySoundEffect(SEID_POTION);
@@ -4089,10 +4089,12 @@ WSTRING CCharacterDialogWidget::GetDataName(const UINT dwID) const
 }
 
 //*****************************************************************************
-UINT CCharacterDialogWidget::ExtractCommandIndent(const UINT wCommandIndex) const
+UINT CCharacterDialogWidget::ExtractCommandIndent(
+	const CListBoxWidget* pCommandList,
+	const UINT wCommandIndex) const
 //Extracts command's indent size from the command listbox text
 {
-	WSTRING wstr = this->pCommandsListBox->GetTextAtLine(wCommandIndex);
+	WSTRING wstr = pCommandList->GetTextAtLine(wCommandIndex);
 
 	UINT i = 0;
 	for (; i < wstr.size(); ++i)
@@ -4105,7 +4107,7 @@ UINT CCharacterDialogWidget::ExtractCommandIndent(const UINT wCommandIndex) cons
 }
 
 //*****************************************************************************
-void CCharacterDialogWidget::PrettyPrintCommands(const COMMANDPTR_VECTOR &commands)
+void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, const COMMANDPTR_VECTOR &commands)
 {
 	WSTRING wstr;
 
@@ -4254,8 +4256,8 @@ void CCharacterDialogWidget::PrettyPrintCommands(const COMMANDPTR_VECTOR &comman
 
 		wstr.insert(wstr.begin(), bIsLabel ? wIndent - 2 : wIndent, W_t(' '));
 		wstr.insert(wstr.end(), wFinalIndent, W_t(' '));
-		wstr += this->pCommandsListBox->GetTextAtLine(index);
-		this->pCommandsListBox->SetItemTextAtLine(index, wstr.c_str());
+		wstr += pCommandList->GetTextAtLine(index);
+		pCommandList->SetItemTextAtLine(index, wstr.c_str());
 
 		bLastWasIfCondition = bIsIfCondition;
 	}
@@ -4776,7 +4778,7 @@ void CCharacterDialogWidget::PopulateCommandDescriptions(
 		SetCommandColor(pCommandList, insertedIndex, pCommand->command);
 	}
 	
-	PrettyPrintCommands(commands);
+	PrettyPrintCommands(pCommandList, commands);
 
 	if (commands.size())
 		pCommandList->SelectLine(0);
@@ -7811,6 +7813,7 @@ WSTRING CCharacterDialogWidget::toText(
 //Params:
 	const COMMANDPTR_VECTOR& commands,
 	CCharacterCommand* pCommand,       //Command to parse
+	const CListBoxWidget* pCommandList, //Command list to get string from
 	const UINT wCommandIndex)          //Index of the command
 {
 #define concatNum(n) wstr += _itoW(n,temp,10)
@@ -7825,7 +7828,7 @@ WSTRING CCharacterDialogWidget::toText(
 	if (wstrCommandName.empty())
 		return wstr;
 
-	UINT indent = ExtractCommandIndent(wCommandIndex);
+	UINT indent = ExtractCommandIndent(pCommandList, wCommandIndex);
 	wstr.insert(wstr.end(), indent - INDENT_PREFIX_SIZE + 2, W_t(' '));
 	wstr += wstrCommandName;
 	wstr += wszSpace;

--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -112,8 +112,8 @@ private:
 			const WCHAR* pText) const;
 	HoldCharacter* GetCustomCharacter();
 	WSTRING GetDataName(const UINT dwID) const;
-	UINT ExtractCommandIndent(const UINT wCommandIndex) const;
-	void    PrettyPrintCommands(const COMMANDPTR_VECTOR &commands);
+	UINT ExtractCommandIndent(const CListBoxWidget* pCommandList, const UINT wCommandIndex) const;
+	void    PrettyPrintCommands(CListBoxWidget* pCommandList, const COMMANDPTR_VECTOR &commands);
 	WSTRING GetEntranceName(CEditRoomScreen *pEditRoomScreen, UINT entranceID) const;
 	void AppendGotoDestination(WSTRING& wstr, const COMMANDPTR_VECTOR& commands,
 		const CCharacterCommand& pCommand) const;
@@ -171,7 +171,11 @@ private:
 
 	//For text editing of script commands.
 	CCharacterCommand* fromText(WSTRING text);
-	WSTRING toText(const COMMANDPTR_VECTOR& commands, CCharacterCommand* pCommand, const UINT wCommandIndex);
+	WSTRING toText(
+		const COMMANDPTR_VECTOR& commands,
+		CCharacterCommand* pCommand,
+		const CListBoxWidget* pCommandList,
+		const UINT wCommandIndex);
 
 	CListBoxWidget *pGraphicListBox, *pPlayerGraphicListBox, *pAddCommandGraphicListBox;
 	COptionButtonWidget *pIsVisibleButton;


### PR DESCRIPTION
#357 adds a number of visual improvements to script editing. However, it was overlooked that `CCharacterDialogWidget` actually has _two_ lists of commands - one for the character's script, and one for editing default scripts. The changes for #357 only apply to the main editor's listbox, meaning that it will be incorrectly referenced while editing default scripts. This crashes DROD due to out-of-bounds errors if the default script being edited is longer than the character script.

I've gone through and fixed that, and also updated the default script editor's list to be a `CCommandListBoxWidget`