### PR TITLE
RPG: Fix crash when clicking bomb in editor

### DIFF
--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -7243,9 +7243,8 @@ void CDbRoom::ConvertUnstableTar(
 	CCueEvents &CueEvents,        //(out) May receive cue events.
 	const bool bDelayBabyMoves)   //(in)  Whether babies can move immediately when processed [default=false]
 {
-	ASSERT(this->pCurrentGame);
-	const UINT wSX = this->pCurrentGame->pPlayer->wX;
-	const UINT wSY = this->pCurrentGame->pPlayer->wY;
+	const UINT wSX = this->pCurrentGame ? this->pCurrentGame->pPlayer->wX : (UINT)-1;
+	const UINT wSY = this->pCurrentGame ? this->pCurrentGame->pPlayer->wY : (UINT)-1;
 	CCoordIndex swordCoords;
 	GetSwordCoords(swordCoords);
 


### PR DESCRIPTION
Preview bomb explosion calls CDbRoom::ConvertUnstableTar(). This function needs an active game to work, so a crash happens. Confusingly, it only crashs in the alpha. Anyhow, I updated the function to match the mainline version for getting player co-ordinates to avoid a crash.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45237