### PR TITLE
Don't increment command index after default script replacement

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -2896,7 +2896,7 @@ void CCharacter::Process(
 					wTurnCount = 0;
 					++wVarSets; //Count as setting a variable for loop avoidence
 					LoadCommands(this->pCustomChar->ExtraVars, this->commands);
-				}	else {
+				} else {
 					// Index does not automatically increment after this command is executed
 					++this->wCurrentCommandIndex;
 				}

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -2896,6 +2896,9 @@ void CCharacter::Process(
 					wTurnCount = 0;
 					++wVarSets; //Count as setting a variable for loop avoidence
 					LoadCommands(this->pCustomChar->ExtraVars, this->commands);
+				}	else {
+					// Index does not automatically increment after this command is executed
+					++this->wCurrentCommandIndex;
 				}
 				bProcessNextCommand = true;
 			break;
@@ -3438,7 +3441,8 @@ void CCharacter::Process(
 			default: ASSERT(!"Bad CCharacter command"); break;
 		}
 
-		++this->wCurrentCommandIndex;
+		if (command.command != CCharacterCommand::CC_ReplaceWithDefault)
+			++this->wCurrentCommandIndex;
 
 		//If MoveRel command was used as an If condition, then reset the relative
 		//movement destination for the next relative movement command.


### PR DESCRIPTION
Fix for minor problem in #387, where the first command in a default script will be skipped due to the command index incrementing after the script is replaced with the default script. Automatic increment is supressed for the command. If the replacement fails, the index is manually incremental to prevent the script runner getting stuck.