### PR TITLE
Support moods for custom portraits

### DIFF
--- a/DROD/FaceWidget.cpp
+++ b/DROD/FaceWidget.cpp
@@ -845,8 +845,14 @@ void CFaceWidget::PaintFace(
 		//Draw special image, if set.
 		if (face->dwImageID)
 		{
-			SDL_Rect Src = MAKE_SDL_RECT(0, 0, this->w, this->h);
-			SDL_BlitSurface(this->faceImages[face->dwImageID], &Src, pDestSurface, &Dest);
+			SDL_Surface* faceImage = this->faceImages[face->dwImageID];
+			int srcX = 0;
+
+			if (faceImage->w >= this->w * (face->eMood + 1))
+				srcX = this->w * face->eMood;
+
+			SDL_Rect Src = MAKE_SDL_RECT(srcX, 0, this->w, this->h);
+			SDL_BlitSurface(faceImage, &Src, pDestSurface, &Dest);
 		}
 		else {
 			//Bounds check -- just revert to default if this face frame is not loaded.

--- a/Data/Help/1/character.html
+++ b/Data/Help/1/character.html
@@ -31,6 +31,8 @@ to create a script that runs in each room instead of just one particular room.
 Click <b>"Custom avatar"</b> to import a custom face from an image file (130x164 pixels)
 on disk into your hold.
 When this actor speaks, this image will be shown in the game screen's face box.
+The custom face may be extended to the right to provide protraits for speaking moods, with each additional portrait being 130 pixels wide.
+The supported moods, in the order they should appear in the image are <b>Normal</b>, <b>Aggressive</b>, <b>Nervous</b>, <b>Striking</b>, <b>Happy</b>, <b>Dying</b>, and <b>Talking</b>.
 Click <a name="customtiles">"Custom Tiles"</a> to import a custom tileset for this
 character.<br />
 <br />


### PR DESCRIPTION
A small change to face drawing code to support moods for custom portraits. The face's mood value is used to offset the source rectangle (provided the image is wide enough), allowing a custom portrait to provide graphics for moods other than normal.  In additional to speaking moods, it also means that a custom dying mood can be provided for custom player roles.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=41611