### PR TITLE
RPG: Support moods for custom portraits

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -5084,9 +5084,8 @@ void CCharacterDialogWidget::SetCharacterWidgetStates()
 		static const UINT CY_TILES = 4 * CDrodBitmapManager::CY_TILE;
 
 		pCharGraphicList->SelectItem(pChar->wType);
-		pFace->SetCharacter(getSpeakerType(MONSTERTYPE(pChar->wType)), false);
+		pFace->SetCharacter(PlayerRole, getSpeakerType(MONSTERTYPE(pChar->wType)), pChar);
 		pDefaultAvatar->Enable(pChar->dwDataID_Avatar != 0);
-		pFace->SetImage(pChar->dwDataID_Avatar);
 
 		const bool bHasTiles = pChar->dwDataID_Tiles != 0;
 		pDefaultTiles->Enable(bHasTiles);
@@ -5112,8 +5111,8 @@ void CCharacterDialogWidget::SetCharacterWidgetStates()
 		IDtext += _itoW(pChar->dwCharID, temp, 10);
 		pIDLabel->SetText(IDtext.c_str());
 	} else {
-		pFace->SetCharacter(getSpeakerType(
-				MONSTERTYPE(pCharGraphicList->GetSelectedItem())), false);
+		pFace->SetCharacter(PlayerRole, getSpeakerType(
+			MONSTERTYPE(pCharGraphicList->GetSelectedItem())), NULL);
 		pDefaultAvatar->Disable();
 		pDefaultTiles->Disable();
 		pAnimateSpeed->SetText(wszEmpty);

--- a/drodrpg/DROD/CreditsScreen.cpp
+++ b/drodrpg/DROD/CreditsScreen.cpp
@@ -123,7 +123,7 @@ bool CCreditsScreen::SetForActivate()
 #	define A_FACEIMAGE(eSpeaker) { \
 	SDL_Surface *pFaceSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, CX_FACE, CY_FACE, g_pTheBM->BITS_PER_PIXEL, 0, 0, 0, 0); \
 	pFaceWidget->SetDestSurface(pFaceSurface); \
-	pFaceWidget->SetCharacter(eSpeaker, false); \
+	pFaceWidget->SetCharacter(PlayerRole, eSpeaker, NULL); \
 	pFaceWidget->Paint(); \
 	CImageWidget *pImage = new CImageWidget(0, (this->pScrollingText->GetW()-CX_FACE)/2, 0, pFaceSurface); \
 	this->pScrollingText->Add(pImage); }

--- a/drodrpg/DROD/FaceWidget.cpp
+++ b/drodrpg/DROD/FaceWidget.cpp
@@ -674,7 +674,12 @@ void CFaceWidget::Paint(
 		//Draw special image, if set.
 		if (this->pImage)
 		{
-			SDL_Rect Src = MAKE_SDL_RECT(0, 0, this->w, this->h);
+			int srcX = 0;
+
+			if (this->pImage->w >= this->w * (this->eMood + 1))
+				srcX = this->w * this->eMood;
+
+			SDL_Rect Src = MAKE_SDL_RECT(srcX, 0, this->w, this->h);
 			SDL_BlitSurface(this->pImage, &Src, pDestSurface, &Dest);
 		} else {
 			//Bounds check -- just revert to default if this face frame is not loaded.

--- a/drodrpg/DROD/FaceWidget.h
+++ b/drodrpg/DROD/FaceWidget.h
@@ -1,4 +1,4 @@
-// $Id: FaceWidget.h 9131 2008-08-05 04:22:02Z mrimer $
+// $Id$
 
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1
@@ -17,7 +17,7 @@
  *
  * The Initial Developer of the Original Code is
  * Caravel Software.
- * Portions created by the Initial Developer are Copyright (C) 2002, 2005, 2007
+ * Portions created by the Initial Developer are Copyright (C) 2002, 2005
  * Caravel Software. All Rights Reserved.
  *
  * Contributor(s):
@@ -32,9 +32,16 @@
 #include "DrodSound.h"
 #include "../DRODLib/MonsterFactory.h"
 #include "../DRODLib/Character.h"
+#include "../DRODLib/HoldRecords.h"
 
 static const UINT CX_FACE = 130;
 static const UINT CY_FACE = 164;
+
+enum FaceWidgetLayer {
+	PlayerRole = 0,
+	Speaker,
+	Death
+};
 
 //Moods the swordsman can be in that affect his facial expression.
 enum MOOD
@@ -126,6 +133,32 @@ enum FACE_FRAME
 
 typedef std::map<UINT, SDL_Surface*> SurfaceMap;
 
+struct Face {
+	Face(FaceWidgetLayer eLayer) :
+		eLayer(eLayer),
+		pHoldCharacter(NULL), eCharacter(Speaker_Beethro), dwImageID(0), eMoodSEID(SEID_NONE),
+		eMood(Mood_Normal), ePrevMood(Mood_Normal), dwMoodUntil(0),
+		bIsActive(false), bIsReading(false), bIsSleeping(false), bIsBlinking(false),
+		bIsDrawn(false)
+	{}
+
+	FaceWidgetLayer eLayer;
+	const HoldCharacter* pHoldCharacter;
+	SPEAKER         eCharacter;
+	Uint32          dwImageID;
+	MOOD            eMood;
+	MOOD            ePrevMood;
+
+	Uint32          dwMoodUntil;
+	SEID            eMoodSEID; // Show current mood until this sound ends
+
+	bool            bIsActive;
+	bool            bIsReading;
+	bool            bIsSleeping;
+	bool            bIsBlinking;
+	bool            bIsDrawn;
+};
+
 //******************************************************************************
 class CFaceWidget : public CWidget
 {
@@ -134,55 +167,64 @@ public:
 			const UINT wSetW, const UINT wSetH);
 	~CFaceWidget();
 
-	void           PaintFull(const bool bVal=true) {this->bAlwaysPaintFull = bVal;}
-	inline SPEAKER GetCharacter() const {return this->eSpeaker;}
-	inline UINT   GetImageID() const {return this->dwImageID;}
-	inline bool    IsMoodLocked() const {return this->bMoodLocked;}
-	bool           IsSpeakerAnimated() const;
-	void           MovePupils(const UINT wLookAtX=(UINT)-1, const UINT wLookAtY=(UINT)-1);
+	void            PaintFull(const bool bVal=true) {this->bAlwaysPaintFull = bVal;}
+	void            MovePupils(const UINT wLookAtX=(UINT)-1, const UINT wLookAtY=(UINT)-1);
 	virtual void      Paint(bool bUpdateRect = true);
 	virtual void      PaintClipped(const int nX, const int nY, const UINT wW,
 			const UINT wH, const bool bUpdateRect = true);
-	void           ResetForPaint() {this->bMoodDrawn = false;}
-	FACE_FRAME     ResolveFace();
-	void           SetCharacter(const SPEAKER eSpeaker, const bool bLockMood);
-	void           SetImage(const UINT dwDataID);
-	void           SetMood(const MOOD eSetMood, const Uint32 lDelay=0,
-		const bool bOverrideLock=false);
-	void           SetMoodToSoundEffect(MOOD eSetMood, SEID eUntilSEID);
-	void           SetReading(const bool bReading);
-	void           SetSleeping();
+	void            ResetForPaint() { GetActiveFace()->bIsDrawn = false; }
+	void            SetCharacter(const FaceWidgetLayer eLayer, const SPEAKER eSpeaker, const HoldCharacter* pHoldCharacter);
+	void            SetMood(const FaceWidgetLayer eLayer, const MOOD eSetMood, const Uint32 lDelay=0);
+	void            SetMoodToSoundEffect(const FaceWidgetLayer eLayer, MOOD eSetMood, SEID eUntilSEID);
+	void            SetReading(const bool bReading);
+	void            SetDying(const bool bIsDying, MOOD eDyingMood = Mood_Normal);
+	void            SetSpeaker(const bool bIsSpeaking,
+			const SPEAKER eSpeaker = Speaker_None, const HoldCharacter* pHoldCharacter = NULL, MOOD eDyingMood = Mood_Normal);
+	void            SetSleeping(const bool bIsSleeping);
+
+	Face           facePlayer;
+	Face           faceSpeaker;
+	Face           faceDying;
+
+struct POINT
+{
+	 long  x;
+	 long  y;
+};
 
 protected:
 	virtual void   HandleAnimate();
+	void           HandleAnimateFace(Face *face);
 	virtual void   HandleMouseUp(const SDL_MouseButtonEvent &Button);
 	virtual bool   IsAnimated() const {return true;}
 
 private:
+	void           PaintFace(Face* face);
 	void           DrawPupils();
-	inline void       DrawPupils_DrawOnePupil(
+	inline void    DrawPupils_DrawOnePupil(
 			SDL_Surface *pDestSurface, const int nDestX, const int nDestY,
-			const int nMaskX, const int nMaskY) const;
-	bool           bHasMoodDelayPassed() const {return SDL_GetTicks()-this->dwStartDelayMood > this->dwDelayMood;}
-	void           SetMoodDelay(const Uint32 dwDelay);
+			const int nMaskX, const int nMaskY);
 
-	SPEAKER        eSpeaker;         //character face being displayed
-	MOOD           eMood, ePrevMood; //face's mood
-	Uint32         dwDelayMood, dwStartDelayMood;        //how long to show face (0 means indefinitely)
-	bool           bMoodDrawn, bIsReading, bIsBlinking, bIsSleeping;  //whether face is reading, etc.
+	SDL_Rect*      getEyeMask();
+	const POINT*   getEyeMaskOffset();
+	UINT           getBetweenPupils();
+	FACE_FRAME     ResolveFaceFrame(Face* face);
+
+	bool            IsSpeakerAnimated(const Face* face) const;
+	Face*           GetFace(const FaceWidgetLayer layer);
+	Face*           GetActiveFace();
+	const FaceWidgetLayer GetActiveLayer() const;
+
 	bool           bDoBlink;      //when set, do a blink at next possible time
-	SEID           eMoodSEID;
-	bool           bMoodLocked;   //can't change mood w/o explicit flag
 
 	//Eye movement.
 	int               nPupilX, nPupilY;
 	int               nPupilTargetX, nPupilTargetY;
 
 	Uint32			dwLastFrame;
-	bool           bAlwaysPaintFull;
+	bool            bAlwaysPaintFull;
 
 	SDL_Surface *pImage;   //custom image currently being shown
-	UINT dwImageID;       //ID of image being shown
 	SurfaceMap faceImages; //loaded custom images
 };
 

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -181,7 +181,8 @@ private:
 	virtual void   ShowChatHistory(CEntranceSelectDialogWidget* pBox);
 	void           showStat(const UINT eType, const int delta, CEntity *pEntity, UINT& count);
 //	void           ShowLockIcon(const bool bShow=true);
-	void           ShowPlayerFace(const bool bOverrideLock=false);
+	void           UpdatePlayerFace();
+	void           ResolvePlayerFace(SPEAKER& pSpeaker, HoldCharacter** playerHoldCharacter);
 	UINT           ShowRoom(CDbRoom *pRoom);
 	void           ShowRoomCoords(CDbRoom *pRoom);
 	void           ShowRoomTemporarily(UINT roomID);

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -5085,7 +5085,7 @@ void CRoomWidget::SetFrameVars(const bool bMoveMade)
 					{
 						CGameScreen *pGameScreen = DYN_CAST(CGameScreen*, CScreen*, pScreen);
 						ASSERT(pGameScreen);
-						pGameScreen->GetFaceWidget()->SetSleeping();
+						pGameScreen->GetFaceWidget()->SetSleeping(true);
 					}
 				}
 			}

--- a/drodrpg/Data/Help/1/customchar.html
+++ b/drodrpg/Data/Help/1/customchar.html
@@ -23,7 +23,9 @@ scripts to define new monster types and game elements, where each instance
 should share a common behavior.</p>
 <p><a name="avatar"><b>Custom avatar</b></a> - Import a custom face from an
 image file on disk into your hold. When an NPC of this custom type speaks,
-this image will be shown in the game screen's face box (130x164 pixels).</p>
+this image will be shown in the game screen's face box (130x164 pixels).
+The custom face may be extended to the right to provide protraits for speaking moods, with each additional portrait being 130 pixels wide.
+The supported moods, in the order they should appear in the image are <b>Normal</b>, <b>Aggressive</b>, <b>Nervous</b>, <b>Striking</b>, <b>Happy</b>, <b>Dying</b>, and <b>Talking</b>.</p>
 <p><a name="tiles"><b>Custom tiles</b></a> - Click to import a custom tileset
 for this character.
 The tileset may be a grid of from one to nine columns of 44x44 pixel tiles.


### PR DESCRIPTION
Updates the face management code in DROD RPG to the newer DROD 5.0 face management. This makes faces better, I assume.

Also includes the small change to face drawing code to support moods for custom portraits. The face's mood value is used to offset the source rectangle (provided the image is wide enough), allowing a custom portrait to provide graphics for moods other than normal.