### PR TITLE
Fix CMonster::ConfirmPath() for when monster is on its own path

### DIFF
--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -699,14 +699,13 @@ bool CMonster::ConfirmPath()
 	{
 		this->pathToDest.GetAt(wIndex, wX, wY);
 
-		// Backwards compatibility hack: if a path resides on monster's current position it should
-		// theorethically regenerate the path, but that could potentially break too many demos
-		// at this point. We can't run DoesSquareContainObstacle() either, because it will (correctly)
-		// ASSERT if given monster's current coords. So we just skip that one specific check.
+		// Backwards compatibility hack: if a path resides on monster's current position,
+		// regenerate the path. Previously, it would run DoesSquareContainObstacle() at the monster's
+		// position, which would assert, then return that an obstacle was found.
 
 		const bool bIsCurrentMonsterTile = wX == this->wX && wY == this->wY;
 
-		if (!bIsCurrentMonsterTile && DoesSquareContainObstacle(wX, wY))
+		if (bIsCurrentMonsterTile || DoesSquareContainObstacle(wX, wY))
 		{
 			bPathOpen = false;
 			break;


### PR DESCRIPTION
#329 includes a fix to `CMonster::ConfirmPath()` to prevent assertion beeps when the monster is on the path. It does so by skipping the check for the tile containing the monster, preventing the path from being regenerated in this case. A comment claims this is to prevent demo breakage. The given fix is wrong for two reasons:

1. Prior to this change, a monster on it's own path would cause the path to regenerate. If any of the monsters that use `ConfirmPath()` call `DoesSquareContainObstacle()` on their own tile, it will return true, as the tile contains a monster, which is an obstacle. This then invalidates the path. Therefore, not invaliding the path changes the current behavior, and could cause demo breaks.
2. Allowing a monster's path to contain the tile it is on means that the monster may make a "move" onto itself. This causes the monster to attack itself and die, after firing several asserts due to a monster attacking itself being an invalid situation.

The correct fix is to invalidate a path that contains the monster's current tile, without checking the tile for obstacles.

This fix is targetted to the master branch as I think it would be best not to release 5.1.1 without fixing this issue, as it is a fairly nasty regression.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=44987