### PR TITLE
Add additional restrictions to Halph/Slayer room entry

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -5485,7 +5485,8 @@ void CCurrentGame::PreprocessMonsters(
 	this->swordsman.wAppearance = M_BEETHRO; //this type of player
 	bool bIgnored;
 	const bool bClosed = room.DoesSquareContainPlayerObstacle(wX, wY, wO, bIgnored) ||
-			IsPlayerAt(wX, wY) || IsPlayerWeaponAt(wX, wY);
+		room.DoesOrthoSquarePreventDiagonal(wX, wY, nOX, nOY) || room.GetOSquare(wX, wY) == T_FIRETRAP_ON ||
+		room.IsMonsterOfTypeAt(M_FLUFFBABY, wX, wY) || IsPlayerAt(wX, wY) || IsPlayerWeaponAt(wX, wY);
 	this->swordsman.wAppearance = wAppearance;
 	if (bClosed)
 		return;  //No.


### PR DESCRIPTION
In a few cases, Halph and Slayers can entry a on from a room edge tile in a weird way:

1. When entering at a corner, they are treated as moving diagonally by arrows, but not by orthosquares. This has been corrected so that a corner entry is blocked by an orthosquare. If the orthosquare is later removed, they will then be able to enter.
2. They can enter the room on an active fire trap, which is instantly lethal and inconsistent with how both elements avoid active traps. This has been corrected so that active traps block them from entering the room.
3. They can enter the room on a puff. This leads to two monsters sharing a tile, which is not good. This has been corrected so that puffs also block them from entering the room.

Related thread with discussion: http://forum.caravelgames.com/viewtopic.php?TopicID=44968