### PR TITLE
Additional Image Overlay commands

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -6416,7 +6416,8 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 			this->pCommand->label = pText->GetText();
 
 			CImageOverlay tempImage(this->pCommand->label, 0, 0);
-			if (tempImage.clearsImageOverlays() != ImageOverlayCommand::NO_LAYERS) {
+			if (tempImage.clearsImageOverlays() != ImageOverlayCommand::NO_LAYERS ||
+					tempImage.clearsImageOverlayGroup() != ImageOverlayCommand::NO_GROUP) {
 				//No image required.
 				this->pCommand->w = 0;
 			} else {

--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -952,11 +952,18 @@ void CDrodScreen::ProcessImageEvents(
 
 		//Don't wait for additional images to be added to the room widget before clearing effects.
 		const int clearsLayer = pImageOverlay->clearsImageOverlays();
-		if (clearsLayer == ImageOverlayCommand::NO_LAYERS) {
+		const int clearsGroup = pImageOverlay->clearsImageOverlayGroup();
+		if (clearsLayer == ImageOverlayCommand::NO_LAYERS &&
+				clearsGroup == ImageOverlayCommand::NO_GROUP) {
 			CImageOverlayEffect *pEffect = new CImageOverlayEffect(pRoomWidget, pImageOverlay, currentTurn, dwNow);
 			pRoomWidget->AddLayerEffect(pEffect, pImageOverlay->getLayer());
 		} else {
-			pRoomWidget->RemoveLayerEffects(EIMAGEOVERLAY, clearsLayer);
+			if (clearsLayer != ImageOverlayCommand::NO_LAYERS) {
+				pRoomWidget->RemoveLayerEffects(EIMAGEOVERLAY, clearsLayer);
+			}
+			if (clearsGroup != ImageOverlayCommand::NO_GROUP) {
+				pRoomWidget->RemoveGroupEffects(clearsGroup);
+			}
 		}
 
 		//Don't reprocess these events if this method is called again.

--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -469,6 +469,12 @@ void CImageOverlayEffect::StartNextCommand()
 		this->sourceClipRect.h = min(max(0, command.val[3]), this->pImageSurface->h);
 		break;
 
+	case ImageOverlayCommand::DisplayRectModify:
+		this->sourceClipRect.x = max(0, this->sourceClipRect.x + val);
+		this->sourceClipRect.y = max(0, this->sourceClipRect.y + command.val[1]);
+		this->sourceClipRect.w = min(max(0, this->sourceClipRect.w + command.val[2]), this->pImageSurface->w);
+		this->sourceClipRect.h = min(max(0, this->sourceClipRect.h + command.val[3]), this->pImageSurface->h);
+
 	case ImageOverlayCommand::DisplaySize:
 		this->sourceClipRect.w = min(max(0, val), this->pImageSurface->w);
 		this->sourceClipRect.h = min(max(0, command.val[1]), this->pImageSurface->h);
@@ -746,6 +752,7 @@ bool CImageOverlayEffect::IsInstantCommand(const ImageOverlayCommand::IOC comman
 		case ImageOverlayCommand::CancelLayer:
 		case ImageOverlayCommand::Center:
 		case ImageOverlayCommand::DisplayRect:
+		case ImageOverlayCommand::DisplayRectModify:
 		case ImageOverlayCommand::DisplaySize:
 		case ImageOverlayCommand::Rotate:
 		case ImageOverlayCommand::Scale:

--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -143,6 +143,19 @@ void CImageOverlayEffect::InitParams()
 	this->parallelCommands.clear();
 }
 
+int CImageOverlayEffect::getGroup() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::Group)
+			return c.val[0];
+	}
+
+	return ImageOverlayCommand::DEFAULT_GROUP;
+}
+
 bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 {
 	if (!this->pImageSurface)
@@ -441,7 +454,9 @@ void CImageOverlayEffect::StartNextCommand()
 	int val = command.val[0];
 	switch (curCommand) {
 	case ImageOverlayCommand::CancelAll:
+	case ImageOverlayCommand::CancelGroup:
 	case ImageOverlayCommand::CancelLayer:
+	case ImageOverlayCommand::Group:
 	case ImageOverlayCommand::Layer:
 		// Do nothing, these are handled externally
 		return;
@@ -749,6 +764,7 @@ bool CImageOverlayEffect::IsInstantCommand(const ImageOverlayCommand::IOC comman
 		case ImageOverlayCommand::AddX:
 		case ImageOverlayCommand::AddY:
 		case ImageOverlayCommand::CancelAll:
+		case ImageOverlayCommand::CancelGroup:
 		case ImageOverlayCommand::CancelLayer:
 		case ImageOverlayCommand::Center:
 		case ImageOverlayCommand::DisplayRect:

--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -446,6 +446,13 @@ void CImageOverlayEffect::StartNextCommand()
 		// Do nothing, these are handled externally
 		return;
 
+	case ImageOverlayCommand::AddX:
+		this->x += val;
+		break;
+	case ImageOverlayCommand::AddY:
+		this->y += val;
+		break;
+
 	case ImageOverlayCommand::Center:
 		this->x = (int(this->pRoomWidget->GetW()) - int(this->pImageSurface->w)) / 2;
 		this->y = (int(this->pRoomWidget->GetH()) - int(this->pImageSurface->h)) / 2;
@@ -733,6 +740,8 @@ bool CImageOverlayEffect::IsTurnBasedCommand(const ImageOverlayCommand::IOC comm
 
 bool CImageOverlayEffect::IsInstantCommand(const ImageOverlayCommand::IOC commandType) const {
 	switch (commandType) {
+		case ImageOverlayCommand::AddX:
+		case ImageOverlayCommand::AddY:
 		case ImageOverlayCommand::CancelAll:
 		case ImageOverlayCommand::CancelLayer:
 		case ImageOverlayCommand::Center:

--- a/DROD/ImageOverlayEffect.h
+++ b/DROD/ImageOverlayEffect.h
@@ -72,6 +72,8 @@ public:
 	UINT getInstanceID() const { return instanceID; }
 	UINT getStartTurn() const { return turnNo; }
 
+	int getGroup() const;
+
 protected:
 	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
 	virtual void Draw(SDL_Surface& destSurface);

--- a/DROD/RoomEffectList.cpp
+++ b/DROD/RoomEffectList.cpp
@@ -25,6 +25,7 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
+#include "ImageOverlayEffect.h"
 #include "RoomEffectList.h"
 #include "RoomWidget.h"
 #include <BackEndLib/Assert.h>
@@ -160,6 +161,42 @@ void CRoomEffectList::RemoveEffectsOfType(
 			++iSeek;
 			this->Effects.remove(pDelete);
 			delete pDelete;
+		}
+		else
+			++iSeek;
+	}
+}
+
+void CRoomEffectList::RemoveOverlayEffectsInGroup(
+//Removes all image overlay effects in the given group from the list.
+//
+//Params:
+	const int clearGroup,//(in) Overlay group to remove
+	const bool bForceClearAll) //if set [default=true], delete all effects,
+	                     //including those that request to be retained
+{
+	list<CEffect*>::const_iterator iSeek = this->Effects.begin();
+	while (iSeek != this->Effects.end())
+	{
+		if ((*iSeek)->GetEffectType() == EIMAGEOVERLAY)
+		{
+			//Remove from list.
+			CEffect* pDelete = *iSeek;
+			ASSERT(pDelete);
+			if (pDelete->RequestsRetainOnClear() && !bForceClearAll)
+			{
+				++iSeek;
+				continue;
+			}
+
+			CImageOverlayEffect* pDeleteOverlay = DYN_CAST(CImageOverlayEffect*, CEffect*, pDelete);
+
+			if (pDeleteOverlay->getGroup() == clearGroup) {
+				DirtyTilesForRects(pDelete->dirtyRects);  //touch up area before deleting
+				++iSeek;
+				this->Effects.remove(pDelete);
+				delete pDelete;
+			}
 		}
 		else
 			++iSeek;

--- a/DROD/RoomEffectList.h
+++ b/DROD/RoomEffectList.h
@@ -44,6 +44,7 @@ public:
 	void           DirtyTilesInRect(const UINT xStart, const UINT yStart,
 			const UINT xEnd, const UINT yEnd) const;
 	virtual void   RemoveEffectsOfType(const UINT eEffectType, const bool bForceClearAll=true);
+	virtual void   RemoveOverlayEffectsInGroup(const int clearGroup, const bool bForceClearAll=true);
 
 protected:
 	CRoomWidget *pOwnerWidget;

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -2319,13 +2319,23 @@ void CRoomWidget::DisplayPersistingImageOverlays(CCueEvents& CueEvents)
 		}
 
 		//Don't wait for additional images to be added to the room widget before clearing effects.
+		bool bClearedEffect = false;
 		const int clearsLayer = pImageOverlay->clearsImageOverlays();
 		if (clearsLayer != ImageOverlayCommand::NO_LAYERS) {
 			RemoveLayerEffects(EIMAGEOVERLAY, clearsLayer);
 			CueEvents.Remove(cid, pObj);
 			pObj = CueEvents.GetFirstPrivateData(cid);
-			continue;
+			bClearedEffect = true;
 		}
+
+		const int clearsGroup = pImageOverlay->clearsImageOverlayGroup();
+		if (clearsGroup != ImageOverlayCommand::NO_GROUP) {
+			RemoveGroupEffects(clearsGroup);
+			bClearedEffect = true;
+		}
+
+		if (bClearedEffect)
+			continue;
 
 		pObj = CueEvents.GetNextPrivateData();
 	}
@@ -4796,6 +4806,18 @@ void CRoomWidget::RemoveEffectsQueuedForRemoval()
 	}
 
 	this->queued_layer_effect_type_removal.clear();
+}
+
+void CRoomWidget::RemoveGroupEffects(int clearGroup)
+{
+	ASSERT(this->pOLayerEffects);
+	this->pOLayerEffects->RemoveOverlayEffectsInGroup(clearGroup);
+	ASSERT(this->pTLayerEffects);
+	this->pTLayerEffects->RemoveOverlayEffectsInGroup(clearGroup);
+	ASSERT(this->pMLayerEffects);
+	this->pMLayerEffects->RemoveOverlayEffectsInGroup(clearGroup);
+	ASSERT(this->pLastLayerEffects);
+	this->pLastLayerEffects->RemoveOverlayEffectsInGroup(clearGroup);
 }
 
 //*****************************************************************************

--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -320,6 +320,7 @@ public:
 		queued_layer_effect_type_removal.insert(make_pair(eEffectType, layer)); }
 
 	void           RedrawMonsters(SDL_Surface* pDestSurface);
+	void           RemoveGroupEffects(int clearGroup);
 	void           RemoveLayerEffects(const EffectType eEffectType, int layer);
 	void           RemoveLastLayerEffectsOfType(const EffectType eEffectType, const bool bForceClearAll=true);
 	void           RemoveMLayerEffectsOfType(const EffectType eEffectType);

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -219,6 +219,7 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("display ")] = ImageOverlayCommand::DisplayDuration;
 		commandMap[string("displayms")] = ImageOverlayCommand::DisplayDuration; //deprecated
 		commandMap[string("displayrect")] = ImageOverlayCommand::DisplayRect;
+		commandMap[string("displayrectmodify")] = ImageOverlayCommand::DisplayRectModify;
 		commandMap[string("displaysize")] = ImageOverlayCommand::DisplaySize;
 		commandMap[string("displayturns")] = ImageOverlayCommand::TurnDuration;
 		commandMap[string("fadetoalpha")] = ImageOverlayCommand::FadeToAlpha;
@@ -312,6 +313,7 @@ bool CImageOverlay::parse(const WSTRING& wtext, ImageOverlayCommands& commands)
 		int arg_index=0;
 		switch (eCommand) {
 			case ImageOverlayCommand::DisplayRect:
+			case ImageOverlayCommand::DisplayRectModify:
 				//four arguments
 				if (!parseNumber(pText, textLength, pos, val[arg_index++]))
 					return false;

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -211,6 +211,8 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 	ASSERT(pText);
 
 	if (commandMap.empty()) {
+		commandMap[string("addx")] = ImageOverlayCommand::AddX;
+		commandMap[string("addy")] = ImageOverlayCommand::AddY;
 		commandMap[string("cancelall")] = ImageOverlayCommand::CancelAll;
 		commandMap[string("cancellayer")] = ImageOverlayCommand::CancelLayer;
 		commandMap[string("center")] = ImageOverlayCommand::Center;

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -11,6 +11,8 @@ const int ImageOverlayCommand::NO_LOOP_MAX = -1;
 const int ImageOverlayCommand::DEFAULT_LAYER = 3; //last layer
 const int ImageOverlayCommand::ALL_LAYERS = -2;
 const int ImageOverlayCommand::NO_LAYERS = -3;
+const int ImageOverlayCommand::DEFAULT_GROUP = 0;
+const int ImageOverlayCommand::NO_GROUP = -1;
 
 //*****************************************************************************
 CColorText::~CColorText() { delete pText; }
@@ -214,6 +216,7 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("addx")] = ImageOverlayCommand::AddX;
 		commandMap[string("addy")] = ImageOverlayCommand::AddY;
 		commandMap[string("cancelall")] = ImageOverlayCommand::CancelAll;
+		commandMap[string("cancelgroup")] = ImageOverlayCommand::CancelGroup;
 		commandMap[string("cancellayer")] = ImageOverlayCommand::CancelLayer;
 		commandMap[string("center")] = ImageOverlayCommand::Center;
 		commandMap[string("display ")] = ImageOverlayCommand::DisplayDuration;
@@ -223,6 +226,7 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("displaysize")] = ImageOverlayCommand::DisplaySize;
 		commandMap[string("displayturns")] = ImageOverlayCommand::TurnDuration;
 		commandMap[string("fadetoalpha")] = ImageOverlayCommand::FadeToAlpha;
+		commandMap[string("group")] = ImageOverlayCommand::Group;
 		commandMap[string("grow")] = ImageOverlayCommand::Grow;
 		commandMap[string("jitter")] = ImageOverlayCommand::Jitter;
 		commandMap[string("layer")] = ImageOverlayCommand::Layer;
@@ -373,6 +377,19 @@ int CImageOverlay::clearsImageOverlays() const
 	return ImageOverlayCommand::NO_LAYERS;
 }
 
+int CImageOverlay::clearsImageOverlayGroup() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::CancelGroup)
+			return c.val[0];
+	}
+
+	return ImageOverlayCommand::NO_GROUP;
+}
+
 int CImageOverlay::getLayer() const
 {
 	for (ImageOverlayCommands::const_iterator it=commands.begin();
@@ -384,6 +401,19 @@ int CImageOverlay::getLayer() const
 	}
 
 	return ImageOverlayCommand::DEFAULT_LAYER;
+}
+
+int CImageOverlay::getGroup() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::Group)
+			return c.val[0];
+	}
+
+	return ImageOverlayCommand::DEFAULT_GROUP;
 }
 
 bool CImageOverlay::loopsForever() const

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -369,6 +369,8 @@ struct ImageOverlayCommand
 	static const int NO_LAYERS;
 
 	enum IOC {
+		AddX,
+		AddY,
 		CancelAll,
 		CancelLayer,
 		Center,

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -367,11 +367,14 @@ struct ImageOverlayCommand
 	static const int DEFAULT_LAYER;
 	static const int ALL_LAYERS;
 	static const int NO_LAYERS;
+	static const int DEFAULT_GROUP;
+	static const int NO_GROUP;
 
 	enum IOC {
 		AddX,
 		AddY,
 		CancelAll,
+		CancelGroup,
 		CancelLayer,
 		Center,
 		DisplayDuration,
@@ -379,6 +382,7 @@ struct ImageOverlayCommand
 		DisplayRectModify,
 		DisplaySize,
 		FadeToAlpha,
+		Group,
 		Grow,
 		Jitter,
 		Layer,
@@ -428,7 +432,9 @@ public:
 	static bool parse(const WSTRING& wtext, ImageOverlayCommands& commands);
 
 	int getLayer() const;
+	int getGroup() const;
 	int clearsImageOverlays() const;
+	int clearsImageOverlayGroup() const;
 	bool loopsForever() const;
 
 	ImageOverlayCommands commands;

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -376,6 +376,7 @@ struct ImageOverlayCommand
 		Center,
 		DisplayDuration,
 		DisplayRect,
+		DisplayRectModify,
 		DisplaySize,
 		FadeToAlpha,
 		Grow,

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -7326,16 +7326,18 @@ void CCurrentGame::StashPersistingEvents(CCueEvents& CueEvents)
 		if (pImageOverlay->loopsForever())
 			this->persistingImageOverlays.push_back(*pImageOverlay);
 		const int clearLayer = pImageOverlay->clearsImageOverlays();
-		RemoveClearedImageOverlays(clearLayer);
+		const int clearGroup = pImageOverlay->clearsImageOverlayGroup();
+		RemoveClearedImageOverlays(clearLayer, clearGroup);
 
 		pObj = CueEvents.GetNextPrivateData();
 	}
 }
 
 //*****************************************************************************
-void CCurrentGame::RemoveClearedImageOverlays(const int clearLayers)
+void CCurrentGame::RemoveClearedImageOverlays(const int clearLayers, const int clearGroup)
 {
-	if (clearLayers == ImageOverlayCommand::NO_LAYERS)
+	if (clearLayers == ImageOverlayCommand::NO_LAYERS && 
+			clearGroup == ImageOverlayCommand::NO_GROUP)
 		return;
 
 	if (clearLayers == ImageOverlayCommand::ALL_LAYERS) {
@@ -7349,7 +7351,7 @@ void CCurrentGame::RemoveClearedImageOverlays(const int clearLayers)
 			imageIt!=this->persistingImageOverlays.end(); ++imageIt)
 	{
 		const CImageOverlay& image = *imageIt;
-		if (clearLayers != image.getLayer())
+		if (clearLayers != image.getLayer() && clearGroup != image.getGroup())
 			keptImages.push_back(image);
 	}
 

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -423,7 +423,7 @@ private:
 			const OrbActivationType eActivationType, CCueEvents &CueEvents, CArmedMonster *pArmedMonster = NULL);
 	bool     PushPlayerInDirection(int dx, int dy, CCueEvents &CueEvents);
 	bool     RemoveInvalidCommand(const CCueEvents& CueEvents);
-	void     RemoveClearedImageOverlays(const int clearLayers);
+	void     RemoveClearedImageOverlays(const int clearLayers, const int clearGroup = ImageOverlayCommand::NO_GROUP);
 	void     ResetCutSceneStartTurn() { cutSceneStartTurn = -1; }
 	void     ResetPendingTemporalSplit(CCueEvents& CueEvents);
 	void     ResetTemporalSplitQueuingIfInvalid(CCueEvents& CueEvents);

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -706,14 +706,19 @@ Variables prefixed with "_My" are connected to the state of the NPC, the "_*Imag
 <p><a name="image-overlay-commands"><b>Image overlay commands</b></a></p>
   In addition to selecting an image for display with the "Image overlay" command, you must provide a simple set of commands to define how the image will be displayed in-game.  The list of supported (case-insensitive) commands for use in an Image Overlay script is as follows:<br />
 <br />
+<b>AddX (pixels)</b> -- shifts the image's X coordinate. Positive values shift to the right, negative values shift to the left.<br />
+<b>AddY (pixels)</b> -- shifts the image's Y coordinate. Positive values shift downwards, negative values shift upwards.<br />
 <b>CancelAll</b> -- remove all currently displaying image overlay effects. This command is typically run singly.<br />
+<b>CancelGroup (group #)</b> -- remove image overlay effects in the specified display group (0 or greater)<br />
 <b>CancelLayer (layer #)</b> -- remove image overlay effects on the specified display layer (0 through 3)<br />
 <b>Center</b> -- center the image within the room area<br />
 <b>Display (ms)</b> -- display the image in its current form for the specified duration<br />
 <b>DisplayRect (x) (y) (w) (h)</b> -- show this region of the source image<br />
+<b>DisplayRectModify (delta x) (delta y) (delta w) (delta h)</b> -- modifies the display region for the source image<br />
 <b>DisplaySize (w) (h)</b> -- show this amount of the source image, in pixels<br />
 <b>DisplayTurns (# turns)</b> -- display the image in its current form for the indicated number of game turns<br />
 <b>(p)FadeToAlpha (alpha) (ms)</b> -- transition the image from its current alpha value to the indicated value over the specified time interval<br />
+<b>Group (group #)</b> -- assign the effect to the given display group (0 or greater). Overlays without a Group command are assigned to Group #0. Only the first instance of this command in a script is executed.<br />
 <b>(p)Grow (percent of original) (ms)</b> -- scale the image by the indicated amount over the specified time interval<br />
 <b>(p)Jitter (pixels) (ms)</b> -- randomly shake the image off-center up to the indicated range for the specified time interval<br />
 <b>Layer (layer)</b> -- place the effect on the indicated display layer (0 through 3, generally corresponding to the menu tabs used for placing game elements in the room editor). Only the first instance of this command in a script is executed.<br />


### PR DESCRIPTION
Implements most of the Image Overlay commands requested in #71:

`AddX` and `AddY` move the the image by the given amount in the given axis.
`DisplayRectModify` allows the source region of the image to be altered
`Group` and `CancelGroup` allows images to be assigned to a group that can be cleared at a later point.