### PR TITLE
RPG: Fix crash when showing level or hold stats in editor

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -547,7 +547,10 @@ float CCurrentGame::GetTotalStatModifier(ScriptVars::StatModifiers statType) con
 //It is the product of the global, NPC and equipment modifiers
 {
 	float fMult = GetGlobalStatModifier(statType);
-	fMult *= pRoom->GetStatModifierFromCharacters(statType);
+
+	if (pRoom) {
+		fMult *= pRoom->GetStatModifierFromCharacters(statType);
+	}
 
 	const CCharacter* pWeapon = getCustomEquipment(ScriptFlag::Weapon);
 	if (pWeapon) {


### PR DESCRIPTION
Attempting to show a hold or level's statistics in the editor using F3 or F4 causes DROD to crash. This occurs in `CCurrentGame::GetGlobalStatModifier()`, as it attempts to acquire the room modifier for the HP stat. This fails, as there is no active room.

Adding a check that `pRoom` is not null before calling `CDbRoom::GetStatModifierFromCharacters()` prevents this crash from occuring.

Reporting thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45323