### PR TITLE
"Smart" monsters treat puffs as pathing obstacles

### DIFF
--- a/DRODLib/Citizen.cpp
+++ b/DRODLib/Citizen.cpp
@@ -99,7 +99,7 @@ const
 
 	//No monsters can ever be stepped on.
 	CMonster *pMonster = room.GetMonsterAtSquare(wCol, wRow);
-	if (pMonster && pMonster->wType != M_FLUFFBABY)
+	if (pMonster)
 		return true;
 
 	//Some layer objects are obstacles.  Check for these.

--- a/DRODLib/Halph.cpp
+++ b/DRODLib/Halph.cpp
@@ -476,7 +476,7 @@ const
 
 	//No monsters can ever be stepped on.
 	CMonster *pMonster = room.GetMonsterAtSquare(wCol, wRow);
-	if (pMonster && pMonster->wType != M_FLUFFBABY)
+	if (pMonster)
 		return true;
 
 	//Some layer objects are obstacles.  Check for these.

--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -373,7 +373,9 @@ const
 		if (pMonster)
 		{
 			//Don't step-kill guards or other slayers
-			if (pMonster->wType == M_SLAYER || pMonster->wType == M_SLAYER2 || pMonster->wType == M_GUARD)
+			//Stepping on puffs is also bad
+			if (pMonster->wType == M_SLAYER || pMonster->wType == M_SLAYER2 || pMonster->wType == M_GUARD ||
+					pMonster->wType == M_FLUFFBABY)
 				return true;
 		}
 
@@ -415,7 +417,7 @@ const
 		//stop the wisp from advancing.
 		if (pMonster->IsLongMonster() || pMonster->IsPiece() ||
 				bIsRockGolemType(pMonster->wType) || pMonster->wType == M_GUARD ||
-				pMonster->wType == M_CHARACTER ||
+				pMonster->wType == M_CHARACTER || pMonster->wType == M_FLUFFBABY ||
 				pMonster->wType == M_FEGUNDO || pMonster->wType == M_FEGUNDOASHES)
 			return true;
 	}

--- a/DRODLib/Stalwart.cpp
+++ b/DRODLib/Stalwart.cpp
@@ -95,7 +95,7 @@ const
 
 	//No monsters can ever be stepped on unless you have a dagger
 	CMonster *pMonster = room.GetMonsterAtSquare(wCol, wRow);
-	if (pMonster && pMonster->wType != M_FLUFFBABY){
+	if (pMonster){
 		if (!CStalwart::typesToAttack.has(pMonster->wType))
 			return true;
 		else if (!this->CanDaggerStep(pMonster->wType))

--- a/DRODLib/Station.cpp
+++ b/DRODLib/Station.cpp
@@ -78,7 +78,7 @@ UINT CStation::GetDirectionFrom(const UINT wX, const UINT wY) const
 		wDist = this->distance.GetAt(wXDest, wYDest);
 		bool bMonsterObstacle = false;
 		CMonster *pMonster = this->pRoom->GetMonsterAtSquare(wXDest, wYDest);
-		if (pMonster && pMonster->wType != M_FLUFFBABY)
+		if (pMonster)
 			bMonsterObstacle = true;
 		if (this->pRoom->DoesGentryiiPreventDiagonal(wX, wY, wXDest, wYDest))
 			bMonsterObstacle = true;

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -368,6 +368,7 @@
     <ClCompile Include="src\tests\Monsters\Seep\SeepVsPit.cpp" />
     <ClCompile Include="src\tests\Monsters\Slayer\SlayerBodyKillBlocked.cpp" />
     <ClCompile Include="src\tests\Monsters\Slayer\SlayerPuffObstacle.cpp" />
+    <ClCompile Include="src\tests\Monsters\Stalwart\StalwartPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Waterskipper\SkipperAttackWeaponBlock.cpp" />
     <ClCompile Include="src\tests\PlayerRoles\ConstructPlayerRole.cpp" />
     <ClCompile Include="src\tests\PlayerRoles\FegundoPlayerRole.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -357,6 +357,7 @@
     <ClCompile Include="src\tests\Monsters\Aumtlich\CrackedOrbs.cpp" />
     <ClCompile Include="src\tests\Monsters\Aumtlich\DoubleGaze.cpp" />
     <ClCompile Include="src\tests\Monsters\Aumtlich\GenericAumtlich.cpp" />
+    <ClCompile Include="src\tests\Monsters\Citizen\CitizenPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Clone.cpp" />
     <ClCompile Include="src\tests\Monsters\Fegundo.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PuffPushingArrowsOrthosquares.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -367,6 +367,7 @@
     <ClCompile Include="src\tests\Monsters\Seep\SeepAttackWeaponBlock.cpp" />
     <ClCompile Include="src\tests\Monsters\Seep\SeepVsPit.cpp" />
     <ClCompile Include="src\tests\Monsters\Slayer\SlayerBodyKillBlocked.cpp" />
+    <ClCompile Include="src\tests\Monsters\Slayer\SlayerPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Waterskipper\SkipperAttackWeaponBlock.cpp" />
     <ClCompile Include="src\tests\PlayerRoles\ConstructPlayerRole.cpp" />
     <ClCompile Include="src\tests\PlayerRoles\FegundoPlayerRole.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -360,6 +360,7 @@
     <ClCompile Include="src\tests\Monsters\Citizen\CitizenPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Clone.cpp" />
     <ClCompile Include="src\tests\Monsters\Fegundo.cpp" />
+    <ClCompile Include="src\tests\Monsters\Halph\HalphPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PuffPushingArrowsOrthosquares.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PuffTargetsVisibleClone.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PushFluffOntoTarstuffMother.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -201,6 +201,9 @@
     <ClCompile Include="src\tests\Scripting\Imperative_Vulnerable_Invulnerable.cpp">
       <Filter>Tests\Scripting</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Monsters\Slayer\SlayerPuffObstacle.cpp">
+      <Filter>Tests\Monsters\Slayer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -210,6 +210,9 @@
     <ClCompile Include="src\tests\Monsters\Citizen\CitizenPuffObstacle.cpp">
       <Filter>Tests\Monsters\Citizen</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Monsters\Halph\HalphPuffObstacle.cpp">
+      <Filter>Tests\Monsters\Halph</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />
@@ -302,6 +305,9 @@
     </Filter>
     <Filter Include="Tests\Monsters\Citizen">
       <UniqueIdentifier>{a00dd17e-8a89-4284-9021-3658d01bf3ac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Monsters\Halph">
+      <UniqueIdentifier>{681440c9-dd10-4eb7-b280-0365d7a976f5}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -204,6 +204,9 @@
     <ClCompile Include="src\tests\Monsters\Slayer\SlayerPuffObstacle.cpp">
       <Filter>Tests\Monsters\Slayer</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Monsters\Stalwart\StalwartPuffObstacle.cpp">
+      <Filter>Tests\Monsters\Stalwart</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />
@@ -290,6 +293,9 @@
     </Filter>
     <Filter Include="Tests\Player\TurnZero">
       <UniqueIdentifier>{2d45dc5d-441e-4fb0-93b4-569dc83b1979}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Monsters\Stalwart">
+      <UniqueIdentifier>{5f0faa9f-73ce-4137-9df8-b762d2cf44c0}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -207,6 +207,9 @@
     <ClCompile Include="src\tests\Monsters\Stalwart\StalwartPuffObstacle.cpp">
       <Filter>Tests\Monsters\Stalwart</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Monsters\Citizen\CitizenPuffObstacle.cpp">
+      <Filter>Tests\Monsters\Citizen</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />
@@ -296,6 +299,9 @@
     </Filter>
     <Filter Include="Tests\Monsters\Stalwart">
       <UniqueIdentifier>{5f0faa9f-73ce-4137-9df8-b762d2cf44c0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Monsters\Citizen">
+      <UniqueIdentifier>{a00dd17e-8a89-4284-9021-3658d01bf3ac}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/DRODLibTests/src/tests/Monsters/Citizen/CitizenPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Citizen/CitizenPuffObstacle.cpp
@@ -1,0 +1,47 @@
+#include "../../../test-include.hpp"
+#include "../../../CAssert.h"
+
+TEST_CASE("Citizen interaction with puffs", "[game][citizen][puff]") {
+	RoomBuilder::ClearRoom();
+
+	SECTION("Puff hides build marker from Citizen") {
+		RoomBuilder::PlotRect(T_WALL, 9, 9, 11, 11);
+		RoomBuilder::PlotRect(T_FLOOR, 10, 10, 10, 11);
+
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
+		RoomBuilder::AddMonster(M_CITIZEN, 10, 13);
+		RoomBuilder::PlotStation(10, 14, 0);
+
+		CCharacter* pScript = RoomBuilder::AddCharacter(0, 0);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_BuildMarker, 10, 10, 0, 0, T_BOMB);
+
+		Runner::StartGame(5, 5, S);
+		Runner::ExecuteCommand(CMD_WAIT, 2);
+
+		//Citizen should not have moved
+		AssertMonsterType(10, 13, M_CITIZEN);
+	}
+
+	SECTION("Puff does not hide station from Citizen") {
+		RoomBuilder::PlotRect(T_WALL, 9, 9, 11, 11);
+		RoomBuilder::PlotRect(T_FLOOR, 10, 10, 10, 11);
+
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
+		RoomBuilder::AddMonster(M_CITIZEN, 10, 13);
+
+		RoomBuilder::PlotStation(10, 10, 1);
+		RoomBuilder::PlotStation(10, 14, 1);
+
+		Runner::StartGame(5, 5, S);
+		Runner::ExecuteCommand(CMD_WAIT, 2);
+
+		//Citizen should have made a move towards the station
+		AssertMonsterType(10, 12, M_CITIZEN);
+
+		Runner::ExecuteCommand(CMD_WAIT);
+
+		//Citizen should get stuck on puff
+		AssertMonsterType(10, 12, M_CITIZEN);
+		AssertMonsterType(10, 11, M_FLUFFBABY);
+	}
+}

--- a/DRODLibTests/src/tests/Monsters/Halph/HalphPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Halph/HalphPuffObstacle.cpp
@@ -1,0 +1,45 @@
+#include "../../../test-include.hpp"
+#include "../../../CAssert.h"
+
+TEST_CASE("Halph interaction with puffs", "[game][Halph][puff]") {
+	RoomBuilder::ClearRoom();
+
+	SECTION("Puff hides orb from Halph") {
+		RoomBuilder::PlotRect(T_WALL, 9, 9, 11, 11);
+		RoomBuilder::PlotRect(T_FLOOR, 10, 10, 10, 11);
+
+		RoomBuilder::Plot(T_ORB, 10, 10);
+		RoomBuilder::Plot(T_DOOR_Y, 10, 15);
+		RoomBuilder::AddOrbDataToTile(10, 10, OrbType::OT_NORMAL);
+		RoomBuilder::LinkOrb(10, 10, 10, 15, OrbAgentType::OA_OPEN);
+
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
+		RoomBuilder::AddMonster(M_HALPH, 10, 13);
+		
+		CCueEvents CueEvents;
+		Runner::StartGame(10, 14, S);
+		Runner::ExecuteCommand(CMD_S, CueEvents);
+
+		//Halph should not move
+		AssertMonsterType(10, 13, M_HALPH);
+		CHECK(CueEvents.HasOccurred(CID_HalphCantOpen));
+	}
+
+	SECTION("Puff hides pressure plate from Halph") {
+		RoomBuilder::Plot(T_PRESSPLATE, 10, 10);
+		RoomBuilder::Plot(T_DOOR_Y, 10, 15);
+		RoomBuilder::AddOrbDataToTile(10, 10, OrbType::OT_NORMAL);
+		RoomBuilder::LinkOrb(10, 10, 10, 15, OrbAgentType::OA_OPEN);
+
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 10);
+		RoomBuilder::AddMonster(M_HALPH, 10, 13);
+
+		CCueEvents CueEvents;
+		Runner::StartGame(10, 14, S);
+		Runner::ExecuteCommand(CMD_S, CueEvents);
+
+		//Halph should not move
+		AssertMonsterType(10, 13, M_HALPH);
+		CHECK(CueEvents.HasOccurred(CID_HalphCantOpen));
+	}
+}

--- a/DRODLibTests/src/tests/Monsters/Slayer/SlayerPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Slayer/SlayerPuffObstacle.cpp
@@ -1,0 +1,39 @@
+#include "../../../test-include.hpp"
+#include "../../../CAssert.h"
+#include <DRODLib/Slayer.h>
+
+TEST_CASE("Slayer interaction with puffs", "[game][Slayer][puff]") {
+	RoomBuilder::ClearRoom();
+
+	SECTION("Slayer does not step on puff to kill player") {
+		RoomBuilder::PlotRect(T_WALL, 9, 9, 11, 11);
+		RoomBuilder::PlotRect(T_FLOOR, 10, 10, 10, 11);
+
+		RoomBuilder::AddMonster(M_SLAYER, 10, 10, S);
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
+
+		CCueEvents CueEvents;
+		Runner::StartGame(10, 12, S);
+		Runner::ExecuteCommand(CMD_WAIT, CueEvents);
+
+		//Puff should prevent Slayer moving south and killing player
+		CHECK(!CueEvents.HasOccurred(CID_MonsterKilledPlayer));
+		AssertMonsterType(10, 10, M_SLAYER);
+		AssertMonsterType(10, 11, M_FLUFFBABY);
+	}
+
+	SECTION("Puff blocks Slayer pathing") {
+		RoomBuilder::PlotRect(T_WALL, 9, 9, 11, 12);
+		RoomBuilder::PlotRect(T_FLOOR, 10, 10, 10, 12);
+
+		RoomBuilder::AddMonster(M_SLAYER, 10, 10, S);
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 12);
+
+		CCueEvents CueEvents;
+		Runner::StartGame(10, 14, S);
+		Runner::ExecuteCommand(CMD_WAIT, CueEvents);
+
+		//As the path is blocked, the slayer should move south
+		AssertMonsterType(10, 11, M_SLAYER);
+	}
+}

--- a/DRODLibTests/src/tests/Monsters/Slayer/SlayerPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Slayer/SlayerPuffObstacle.cpp
@@ -12,9 +12,8 @@ TEST_CASE("Slayer interaction with puffs", "[game][Slayer][puff]") {
 		RoomBuilder::AddMonster(M_SLAYER, 10, 10, S);
 		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
 
-		CCueEvents CueEvents;
 		Runner::StartGame(10, 12, S);
-		Runner::ExecuteCommand(CMD_WAIT, CueEvents);
+		Runner::ExecuteCommand(CMD_WAIT);
 
 		//Puff should prevent Slayer moving south and killing player
 		CHECK(!CueEvents.HasOccurred(CID_MonsterKilledPlayer));
@@ -29,9 +28,8 @@ TEST_CASE("Slayer interaction with puffs", "[game][Slayer][puff]") {
 		RoomBuilder::AddMonster(M_SLAYER, 10, 10, S);
 		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 12);
 
-		CCueEvents CueEvents;
 		Runner::StartGame(10, 14, S);
-		Runner::ExecuteCommand(CMD_WAIT, CueEvents);
+		Runner::ExecuteCommand(CMD_WAIT);
 
 		//As the path is blocked, the slayer should move south
 		AssertMonsterType(10, 11, M_SLAYER);

--- a/DRODLibTests/src/tests/Monsters/Stalwart/StalwartPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Stalwart/StalwartPuffObstacle.cpp
@@ -1,0 +1,25 @@
+#include "../../../test-include.hpp"
+#include "../../../CAssert.h"
+
+TEST_CASE("Stalwart interaction with puffs", "[game][stalwart][puff]") {
+	RoomBuilder::ClearRoom();
+	CDbRoom* pRoom;
+
+	SECTION("Puff hides monster from Stalwart") {
+		RoomBuilder::PlotRect(T_WALL, 9, 9, 11, 11);
+		RoomBuilder::PlotRect(T_FLOOR, 10, 10, 10, 11);
+
+		RoomBuilder::AddMonster(M_BRAIN, 10, 10);
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
+		RoomBuilder::AddMonster(M_STALWART, 10, 15, N);
+
+		CCueEvents CueEvents;
+		Runner::StartGame(5, 5, S);
+		Runner::ExecuteCommand(CMD_WAIT, CueEvents);
+
+		//Stalwart should not move, and should not have a path to a monster
+		pRoom = Runner::GetCurrentGame()->GetRoom();
+		AssertMonsterType(10, 15, M_STALWART);
+		CHECK(!pRoom->GetMonsterAtSquare(10,15)->ConfirmPath());
+	}
+}

--- a/DRODLibTests/src/tests/Monsters/Stalwart/StalwartPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Stalwart/StalwartPuffObstacle.cpp
@@ -13,9 +13,8 @@ TEST_CASE("Stalwart interaction with puffs", "[game][stalwart][puff]") {
 		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
 		RoomBuilder::AddMonster(M_STALWART, 10, 15, N);
 
-		CCueEvents CueEvents;
 		Runner::StartGame(5, 5, S);
-		Runner::ExecuteCommand(CMD_WAIT, CueEvents);
+		Runner::ExecuteCommand(CMD_WAIT);
 
 		//Stalwart should not move, and should not have a path to a monster
 		pRoom = Runner::GetCurrentGame()->GetRoom();


### PR DESCRIPTION
Citizens, Engineers, Halphs, Stalwarts, Soldiers and Slayers will now treat Puffs as obstacles, and pathfind around them. Relay Stations will also consider Puffs as obstacles when directing Citizen movement, but not when constructing pathmaps.

Some unit tests have been added to validate basic expectations of this behavior change.

Reporting thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45266