### PR TITLE
RPG: Fix orientation of spawned eggs

### DIFF
--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1056,7 +1056,8 @@ void CMonster::SpawnEgg(CCueEvents& CueEvents)
 	{
 		CMonster* m = const_cast<CCurrentGame*>(this->pCurrentGame)->AddNewEntity(
 			CueEvents, spawnID, egg->wX, egg->wY, S, true);
-		if (!bMonsterHasDirection(m->GetIdentity())) {
+		UINT wType = m->GetIdentity();
+		if (wType != M_REGG && !bMonsterHasDirection(wType)) {
 			m->wO = NO_ORIENTATION;
 		}
 	}


### PR DESCRIPTION
The changes in #373 to support NPC egg spawning include a change to egg spawning code to handle monsters without an orientation. This had the side effect of causing roach eggs to spawn fully grown, as they don't have an orientation, but their orientation value is used to decide how the egg is drawn. To fix this, eggs are exempt from the orientation fixing, which they do not require.

Reporting post: http://forum.caravelgames.com/viewtopic.php?TopicID=44943&page=0#441141