### PR TITLE
Add missing breaks in CDbRoom::CanPushMonster()

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2581,11 +2581,13 @@ const
 			if (!(CanPushOntoOTile(wToX, wToY) && tile != T_HOT))
 				return false;
 		}
+		break;
 		case M_CHARACTER: {
 			const CCharacter* pCharacter = DYN_CAST(const CCharacter*, const CMonster*, pMonster);
 			if (!pCharacter->CanPushOntoOTileAt(wToX, wToY))
 				return false;
 		}
+		break;
 		default:
 			if (!CanPushOntoOTile(wToX, wToY))
 				return false;


### PR DESCRIPTION
There is a break statement missing in `CDbRoom::CanPushMonster()` which leads to crashing when a puff is pushed. As this is undesirable, I have added some more break statements to make sure the code isn't dropping into cases when it shouldn't be.