### PR TITLE
Change Guards to not step on Puffs

### DIFF
--- a/DRODLib/Guard.cpp
+++ b/DRODLib/Guard.cpp
@@ -61,12 +61,13 @@ const
 	if (CMonster::DoesSquareContainObstacle(wCol, wRow))
 		return true;
 
-	//Can't move onto monsters except Fluff Babies -- even target ones.
+	//Can't move onto monsters -- even target ones.
 	CMonster *pMonster = this->pCurrentGame->pRoom->GetMonsterAtSquare(wCol, wRow);
 	if (pMonster){
-		if (pMonster->wType != M_FLUFFBABY && !CanDaggerStep(pMonster->wType))
+		if (!CanDaggerStep(pMonster->wType))
 			return true;
-		if (pMonster->wType == M_GUARD || pMonster->wType == M_SLAYER || pMonster->wType == M_SLAYER2)
+		if (pMonster->wType == M_GUARD || pMonster->wType == M_SLAYER || pMonster->wType == M_SLAYER2 ||
+			  pMonster->wType == M_FLUFFBABY)
 			return true;
 		if (pMonster->wType == M_CHARACTER) {
 			CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -360,6 +360,7 @@
     <ClCompile Include="src\tests\Monsters\Citizen\CitizenPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Clone.cpp" />
     <ClCompile Include="src\tests\Monsters\Fegundo.cpp" />
+    <ClCompile Include="src\tests\Monsters\Guard\GuardPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Halph\HalphPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PuffPushingArrowsOrthosquares.cpp" />
     <ClCompile Include="src\tests\Monsters\Puff\PuffTargetsVisibleClone.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -213,6 +213,9 @@
     <ClCompile Include="src\tests\Monsters\Halph\HalphPuffObstacle.cpp">
       <Filter>Tests\Monsters\Halph</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Monsters\Guard\GuardPuffObstacle.cpp">
+      <Filter>Tests\Monsters\Guard</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />
@@ -308,6 +311,9 @@
     </Filter>
     <Filter Include="Tests\Monsters\Halph">
       <UniqueIdentifier>{681440c9-dd10-4eb7-b280-0365d7a976f5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Monsters\Guard">
+      <UniqueIdentifier>{8693b0a4-8e13-462a-9adc-740ac9ecad17}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/DRODLibTests/src/tests/Monsters/ArmedMonsters/MovingIntoPuffs.cpp
+++ b/DRODLibTests/src/tests/Monsters/ArmedMonsters/MovingIntoPuffs.cpp
@@ -23,27 +23,8 @@ static void DoPushingTest(const UINT type, const char* title){
 	}
 }
 
-static void DoSteppingTest(const UINT type, const char* title){
-	SECTION(title){
-		RoomBuilder::Plot(T_ORB, 10, 10);
-		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11, NO_ORIENTATION);
-		RoomBuilder::AddMonster(M_BRAIN, 10, 6, NO_ORIENTATION);
-		RoomBuilder::AddMonster(type, 10, 12, N);
-
-		CCueEvents CueEvents;
-		Runner::StartGame(10, 5, N);
-		Runner::ExecuteCommand(CMD_WAIT, CueEvents);
-		REQUIRE(CueEvents.HasOccurred(CID_OrbActivatedByDouble));
-	}
-}
-
 TEST_CASE("Armed monsters entering puff tile", "[game]") {
 	RoomBuilder::ClearRoom();
-
-	
-	DoSteppingTest(M_GUARD, "Guard stepping into puff should stab the tile beyond it");
-	DoSteppingTest(M_STALWART, "Stalwart stepping into puff should stab the tile beyond it");
-	DoSteppingTest(M_STALWART2, "Soldier stepping into puff should stab the tile beyond it");
 
 	DoPushingTest(M_GUARD, "Guard pushed into puff should stab the tile beyond it");
 	DoPushingTest(M_SLAYER, "39th Slayer pushed into puff should stab the tile beyond it");

--- a/DRODLibTests/src/tests/Monsters/Guard/GuardPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Guard/GuardPuffObstacle.cpp
@@ -1,0 +1,46 @@
+#include "../../../test-include.hpp"
+#include "../../../CAssert.h"
+
+TEST_CASE("Guard interaction with puffs", "[game][guard][puff]") {
+	RoomBuilder::ClearRoom();
+	CDbRoom* pRoom;
+
+	SECTION("Guard paths around puff") {
+		RoomBuilder::AddMonster(M_GUARD, 10, 10, S);
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
+		RoomBuilder::Plot(T_WALL, 11, 11);
+
+		Runner::StartGame(10, 14, S);
+		Runner::ExecuteCommand(CMD_WAIT);
+
+		// Guard should move around puff
+		AssertMonsterType(9, 11, M_GUARD);
+	}
+
+	SECTION("Dagger Guard paths around puff") {
+		RoomBuilder::AddMonsterWithWeapon(M_GUARD, WT_Dagger, 10, 10, S);
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 11);
+		RoomBuilder::Plot(T_WALL, 11, 11);
+
+
+		Runner::StartGame(10, 14, S);
+		Runner::ExecuteCommand(CMD_WAIT);
+
+		// Guard should move around puff
+		AssertMonsterType(9, 11, M_GUARD);
+	}
+
+	SECTION("Pathmap ignores puff") {
+		RoomBuilder::AddMonster(M_GUARD, 10, 10, S);
+		RoomBuilder::AddMonster(M_FLUFFBABY, 10, 12);
+
+		RoomBuilder::PlotRect(T_WALL, 9, 9, 9, 12);
+		RoomBuilder::PlotRect(T_WALL, 11, 9, 11, 12);
+
+		Runner::StartGame(10, 14, S);
+		Runner::ExecuteCommand(CMD_WAIT);
+
+		// Guard should step south
+		AssertMonsterType(10, 11, M_GUARD);
+	}
+}

--- a/DRODLibTests/src/tests/Monsters/Slayer/SlayerPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Slayer/SlayerPuffObstacle.cpp
@@ -14,6 +14,7 @@ TEST_CASE("Slayer interaction with puffs", "[game][Slayer][puff]") {
 
 		Runner::StartGame(10, 12, S);
 		Runner::ExecuteCommand(CMD_WAIT);
+		CCueEvents CueEvents;
 
 		//Puff should prevent Slayer moving south and killing player
 		CHECK(!CueEvents.HasOccurred(CID_MonsterKilledPlayer));


### PR DESCRIPTION
To perhaps make things more consistent between human elements, Guards will now consider Puffs an obstacle. Therefore, they will not step on them, no matter what.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45266