### PR TITLE
Disable surface blending for tile images

### DIFF
--- a/DROD/DrodBitmapManager.cpp
+++ b/DROD/DrodBitmapManager.cpp
@@ -856,6 +856,7 @@ bool CDrodBitmapManager::LoadTileImages(
 	if (!pSrcSurface) return false;
 	ASSERT(pSrcSurface->w % CX_TILE == 0);
 	ASSERT(pSrcSurface->h % CY_TILE == 0);
+	DisableSurfaceBlending(pSrcSurface);
 	wCols = (pSrcSurface->w / CX_TILE);
 	wRows = (pSrcSurface->h / CY_TILE);
 


### PR DESCRIPTION
Disable surface blending on images that are used for room tiles.

See thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45004