### PR TITLE
RPG: Enable support for cross-hold character copying

### DIFF
--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -4332,8 +4332,16 @@ void CEditRoomScreen::PasteRegion(
 		const UINT wStartY = yInc > 0 ? this->wCopyY1 : this->wCopyY2;
 		const UINT wEndY = yInc < 0 ? this->wCopyY1 : this->wCopyY2;
 
+		CDbRoom* pSrcRoom = this->pRoom;
+		CDbHold* pSrcHold = NULL;
+		if (this->pCopyRoom) {
+			pSrcRoom = this->pCopyRoom;
+			const UINT srcHoldID = g_pTheDB->Levels.GetHoldIDForLevel(pSrcRoom->dwLevelID);
+			if (srcHoldID != g_pTheDB->Levels.GetHoldIDForLevel(this->pRoom->dwLevelID))
+				pSrcHold = g_pTheDB->Holds.GetByID(srcHoldID);
+		}
+
 		//Copy tiles, one at a time.
-		CDbRoom *pSrcRoom = this->pCopyRoom ? this->pCopyRoom : this->pRoom;
 		UINT xSrc, ySrc;         //square copied from
 		UINT xDest, yDest; //square being copied to
 		UINT wSrcTile, wDestTile;
@@ -4677,7 +4685,7 @@ void CEditRoomScreen::PasteRegion(
 							pNewMonster->wX = xDest;
 							pNewMonster->wY = yDest;
 							CCharacter *pNewCharacter = DYN_CAST(CCharacter*, CMonster*, pNewMonster);
-							pNewCharacter->ChangeHold(NULL, this->pHold, info);
+							pNewCharacter->ChangeHold(pSrcHold, this->pHold, info);
 							room.LinkMonster(pNewCharacter);
 						}
 						break;
@@ -4745,6 +4753,8 @@ void CEditRoomScreen::PasteRegion(
 					VERIFY(pOrb->DeleteAgent(pAgent));
 			}
 		}
+
+		delete pSrcHold;
 	}
 
 DonePasting:


### PR DESCRIPTION
Wires up the bits so that copying a character from one hold to another causes its default script and assets to get copied over.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45238