### PR TITLE
Fatalize puff player role moving on to hot tiles

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -2728,7 +2728,10 @@ bool CCurrentGame::PushPlayerInDirection(int dx, int dy, CCueEvents &CueEvents)
 		if (this->swordsman.wAppearance == M_CONSTRUCT && pRoom->GetOSquare(this->swordsman.wX, this->swordsman.wY) == T_GOO && this->wTurnNo > 0){
 			SetDyingEntity(&this->swordsman);
 			CueEvents.Add(CID_PlayerEatenByOremites);
-		} else {
+		}	else if (this->swordsman.wAppearance == M_FLUFFBABY && pRoom->GetOSquare(this->swordsman.wX, this->swordsman.wY) == T_HOT && this->wTurnNo > 0) {
+			SetDyingEntity(&this->swordsman);
+			CueEvents.Add(CID_PlayerBurned);
+		}	else {
 			QueryCheckpoint(CueEvents, wDestX, wDestY);
 		}
 	}
@@ -6139,7 +6142,10 @@ MakeMove:
 			ProcessPlayer_HandleLeaveLevel(CueEvents);
 		break;
 		case T_HOT:
-			if (bStayedOnHotFloor && this->swordsman.wX == wStartingX && this->swordsman.wY == wStartingY)
+			if (this->wTurnNo > 0 && this->swordsman.wAppearance == M_FLUFFBABY) {
+				SetDyingEntity(&this->swordsman);
+				CueEvents.Add(CID_PlayerBurned);
+			}	else if (bStayedOnHotFloor && this->swordsman.wX == wStartingX && this->swordsman.wY == wStartingY)
 			{
 				//Player dies if on same hot tile two (non-hasted) turns in a row.
 				if ((!this->swordsman.bIsHasted || this->bWaitedOnHotFloorLastTurn) &&

--- a/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
@@ -61,4 +61,14 @@ TEST_CASE("Puff player role", "[game]") {
 
 		REQUIRE(game->GetDyingEntity() == &(game->swordsman));
 	}
+
+	SECTION("Should die when moving onto hot tile") {
+		RoomBuilder::Plot(T_HOT, 10, 11);
+		CCurrentGame* game = Runner::StartGame(10, 10, N);
+
+		CCueEvents CueEvents;
+		Runner::ExecuteCommand(CMD_S, 1);
+
+		REQUIRE(game->GetDyingEntity() == &(game->swordsman));
+	}
 }


### PR DESCRIPTION
At some point Temporal Projections were changed so that if they had Puff appearance, they would die instantly when stepping on hot tiles. Until now, this was not implemented for the player as a puff.