### PR TITLE
Make alternate player role Clones consistent with other player-like entities

### DIFF
--- a/DRODLib/Clone.cpp
+++ b/DRODLib/Clone.cpp
@@ -69,6 +69,14 @@ bool CClone::CanDropTrapdoor(const UINT oTile) const
 	return false;
 }
 
+//*****************************************************************************
+bool CClone::CanWadeInShallowWater() const
+//Returns: if the clone can wade. Clones wade if the player wade
+{
+	const CSwordsman& player = this->pCurrentGame->swordsman;
+	return player.CanWadeInShallowWater();
+}
+
 //*****************************************************************************************
 UINT CClone::GetIdentity() const
 //Returns: what the clone looks like
@@ -110,6 +118,14 @@ bool CClone::IsMonsterTarget() const
 
 	//Otherwise, clones are only targets if the player is
 	return player.IsTarget();
+}
+
+//*****************************************************************************
+bool CClone::IsSwimming() const
+//Returns: if the clone can swim. Clones swim if the player swims
+{
+	const CSwordsman& player = this->pCurrentGame->swordsman;
+	return player.GetMovementType() == MovementType::WATER;
 }
 
 //*****************************************************************************

--- a/DRODLib/Clone.cpp
+++ b/DRODLib/Clone.cpp
@@ -174,6 +174,28 @@ bool CClone::KillIfOnDeadlyTile(CCueEvents& CueEvents)
 	return false;
 }
 
+//*****************************************************************************
+bool CClone::OnStabbed(CCueEvents& CueEvents, const UINT wX, const UINT wY, WeaponType weaponType)
+// Override for Clone, as some player roles can survive stabs.
+{
+	const UINT identity = GetIdentity();
+
+	if ((identity == M_WUBBA || identity == M_FLUFFBABY)
+		&& weaponType != WT_Firetrap) {
+		// Wubbas and Puffs can only be killed by Firetrap stabs.
+		return false;
+	}
+
+	if (identity == M_FEGUNDO) {
+		// Fegundoes are immune to all weapon types.
+		return false;
+	}
+
+	//Monster dies.
+	CueEvents.Add(CID_MonsterDiedFromStab, this);
+	return true;
+}
+
 //*****************************************************************************************
 void CClone::Process(
 //Process a clone for movement.

--- a/DRODLib/Clone.h
+++ b/DRODLib/Clone.h
@@ -42,9 +42,11 @@ public:
 	IMPLEMENT_CLONE_REPLICATE(CMonster, CClone);
 
 	virtual bool CanDropTrapdoor(const UINT oTile) const;
+  virtual bool CanWadeInShallowWater() const;
 	virtual UINT GetIdentity() const;
 	virtual bool IsFlying() const;
 	virtual bool IsMonsterTarget() const;
+  virtual bool IsSwimming() const;
 	virtual bool IsHiding() const;
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 

--- a/DRODLib/Clone.h
+++ b/DRODLib/Clone.h
@@ -48,6 +48,7 @@ public:
 	virtual bool IsMonsterTarget() const;
   virtual bool IsSwimming() const;
 	virtual bool IsHiding() const;
+  bool KillIfOnDeadlyTile(CCueEvents& CueEvents);
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 
 	virtual bool SetWeaponSheathed();

--- a/DRODLib/Clone.h
+++ b/DRODLib/Clone.h
@@ -49,6 +49,8 @@ public:
   virtual bool IsSwimming() const;
 	virtual bool IsHiding() const;
   bool KillIfOnDeadlyTile(CCueEvents& CueEvents);
+  virtual bool OnStabbed(CCueEvents &CueEvents, const UINT wX = (UINT)-1, const UINT wY = (UINT)-1,
+		WeaponType weaponType = WT_Sword);
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 
 	virtual bool SetWeaponSheathed();

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3099,6 +3099,12 @@ void CDbRoom::KillMonstersOnHazard(CCueEvents &CueEvents)
 				pConstruct->KillIfOnOremites(CueEvents);
 			}
 			break;
+			case M_CLONE:
+			{
+				CClone* pClone = DYN_CAST(CClone*, CMonster*, pMonster);
+				pClone->KillIfOnDeadlyTile(CueEvents);
+			}
+			break;
 			case M_TEMPORALCLONE:
 			{
 				CTemporalClone *pTemporalClone = DYN_CAST(CTemporalClone*, CMonster*, pMonster);

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -376,6 +376,7 @@
     <ClCompile Include="src\tests\PlayerRoles\ConstructPlayerRole.cpp" />
     <ClCompile Include="src\tests\PlayerRoles\FegundoPlayerRole.cpp" />
     <ClCompile Include="src\tests\PlayerRoles\PuffPlayerRole.cpp" />
+    <ClCompile Include="src\tests\PlayerRoles\WaterskipperPlayerRole.cpp" />
     <ClCompile Include="src\tests\PlayerRoles\WraithwingPlayerRole.cpp" />
     <ClCompile Include="src\tests\Player\Basic\BeethroVsPressurePlate.cpp" />
     <ClCompile Include="src\tests\Player\Basic\MoveBeethroInEmptyRoom.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -216,6 +216,9 @@
     <ClCompile Include="src\tests\Monsters\Guard\GuardPuffObstacle.cpp">
       <Filter>Tests\Monsters\Guard</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\PlayerRoles\WaterskipperPlayerRole.cpp">
+      <Filter>Tests\PlayerRoles</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />

--- a/DRODLibTests/src/test-include.hpp
+++ b/DRODLibTests/src/test-include.hpp
@@ -1,4 +1,5 @@
 #include "./catch.hpp"
+#include "./CAssert.h"
 #include "./CTestDb.h"
 #include "./Runner.h"
 #include "./RoomBuilder.h"

--- a/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/ConstructPlayerRole.cpp
@@ -37,4 +37,16 @@ TEST_CASE("Construct player role", "[game][construct][player][player role]") {
 
 		REQUIRE(game->GetDyingEntity() == &(game->swordsman));
 	}
+
+	SECTION("Construct clone pushed onto oremites should be killed"){
+		RoomBuilder::Plot(T_GOO, 10, 9);
+		RoomBuilder::AddMonster(M_CLONE, 10, 10, N);
+		RoomBuilder::AddMonsterWithWeapon(M_MIMIC, WT_Staff, 10, 12, N);
+
+		CCurrentGame* game = Runner::StartGame(15, 15, N);
+
+		Runner::ExecuteCommand(CMD_N);
+
+		REQUIRE(game->GetDyingEntity() == game->pRoom->GetMonsterAtSquare(10,9));
+	}
 }

--- a/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/FegundoPlayerRole.cpp
@@ -1,6 +1,6 @@
 #include "../../test-include.hpp"
 
-TEST_CASE("Fegundo player role", "[game]") {
+TEST_CASE("Fegundo player role", "[game][fegundo][player][player role]") {
 	RoomBuilder::ClearRoom();
 
 	CCharacter* character = RoomBuilder::AddVisibleCharacter(1, 1);
@@ -56,6 +56,17 @@ TEST_CASE("Fegundo player role", "[game]") {
 		Runner::ExecuteCommand(CMD_S, 2);
 		Runner::ExecuteCommand(CMD_CLONE);
 		Runner::ExecuteCommand(CMD_N);
+
+		REQUIRE(game->GetDyingEntity() == NULL);
+	}
+
+	SECTION("Fegundo clone should not be killed by fire trap") {
+		RoomBuilder::Plot(T_FIRETRAP_ON, 10, 12);
+		RoomBuilder::AddMonster(M_CLONE, 10, 12);
+
+		CCurrentGame* game = Runner::StartGame(10, 10, N);
+
+		Runner::ExecuteCommand(CMD_WAIT);
 
 		REQUIRE(game->GetDyingEntity() == NULL);
 	}

--- a/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/PuffPlayerRole.cpp
@@ -1,6 +1,6 @@
 #include "../../test-include.hpp"
 
-TEST_CASE("Puff player role", "[game]") {
+TEST_CASE("Puff player role", "[game][puff][player][player role]") {
 	RoomBuilder::ClearRoom();
 
 	CCharacter* character = RoomBuilder::AddVisibleCharacter(1, 1);
@@ -70,5 +70,17 @@ TEST_CASE("Puff player role", "[game]") {
 		Runner::ExecuteCommand(CMD_S, 1);
 
 		REQUIRE(game->GetDyingEntity() == &(game->swordsman));
+	}
+
+	SECTION("Puff clone pushed onto hot tile should be killed") {
+		RoomBuilder::Plot(T_HOT, 10, 9);
+		RoomBuilder::AddMonster(M_CLONE, 10, 10, N);
+		RoomBuilder::AddMonsterWithWeapon(M_MIMIC, WT_Staff, 10, 12, N);
+
+		CCurrentGame* game = Runner::StartGame(15, 15, N);
+
+		Runner::ExecuteCommand(CMD_N);
+
+		REQUIRE(game->GetDyingEntity() == game->pRoom->GetMonsterAtSquare(10, 9));
 	}
 }

--- a/DRODLibTests/src/tests/PlayerRoles/WaterskipperPlayerRole.cpp
+++ b/DRODLibTests/src/tests/PlayerRoles/WaterskipperPlayerRole.cpp
@@ -1,0 +1,23 @@
+#include "../../test-include.hpp"
+
+TEST_CASE("Waterskipper player role", "[game][waterskipper][player][player role]") {
+	RoomBuilder::ClearRoom();
+
+	CCharacter* character = RoomBuilder::AddVisibleCharacter(1, 1);
+	RoomBuilder::AddCommand(character, CCharacterCommand::CC_SetPlayerAppearance, M_WATERSKIPPER);
+	RoomBuilder::AddCommand(character, CCharacterCommand::CC_ActivateItemAt, 11, 11);
+
+	SECTION("Waterskipper clone pushed onto oremites should be live") {
+		RoomBuilder::Plot(T_WATER, 10, 9);
+		RoomBuilder::PlotRect(T_WATER, 15, 5, 15, 20);
+		RoomBuilder::AddMonster(M_CLONE, 10, 10, N);
+		RoomBuilder::AddMonsterWithWeapon(M_MIMIC, WT_Staff, 10, 12, N);
+
+		CCurrentGame* game = Runner::StartGame(15, 15, N);
+
+		Runner::ExecuteCommand(CMD_N);
+
+		AssertMonsterType(10, 9, M_CLONE);
+		REQUIRE(game->GetDyingEntity() == NULL);
+	}
+}


### PR DESCRIPTION
The final push to make player roles work consistently between the different things that are based on players. Clones managed to slip through with a few quirks which are now corrected:

- Water dwelling clones can no longer drown
- Clones now respect the player's shallow water traversal state
- Construct and Puff clones die instantly when on Oremites or Hot Tiles respectively
- Wubba, Puff and Fegundo clones are protected from various stabs

The weird exception here is Seep, as player and player-like Seep can survive outside of walls. I'm leaving that as-is because changing it would break any rooms that use a Seep player role. It's also not a particularly difficult restriction to script if an architect wants to have it.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45431