### PR TITLE
Make Lightpost, Relay Station and Fluff block room entry

### DIFF
--- a/DROD/EditRoomScreen.cpp
+++ b/DROD/EditRoomScreen.cpp
@@ -7346,7 +7346,7 @@ TERRAIN_TYPE terrainType(const UINT tile[4])
 	if (bIsWater(tile[0]))
 		return TT_WATER;
 
-	if (tile[1] == T_OBSTACLE || tile[1] == T_STATION || tile[1] == T_ORB ||
+	if (tile[1] == T_OBSTACLE || tile[1] == T_STATION || tile[1] == T_ORB || tile[1] == T_LIGHT ||
 			bIsBeacon(tile[1]) || bIsTarOrFluff(tile[1]) || bIsSerpentOrGentryii(tile[2]))
 		return TT_OBSTACLE;
 

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -6309,10 +6309,12 @@ const
 	switch (t)
 	{
 		case T_ORB:
-		case T_TAR:	case T_MUD: case T_GEL:
+		case T_TAR:	case T_MUD: case T_GEL: case T_FLUFF:
 		case T_BOMB:
 		case T_BRIAR_SOURCE: case T_BRIAR_DEAD: case T_BRIAR_LIVE:
 		case T_OBSTACLE:
+		case T_LIGHT:
+		case T_STATION:
 		case T_BEACON: case T_BEACON_OFF:
 			return false;
 		default:


### PR DESCRIPTION
The player shouldn't be able to enter rooms on tiles that contain Lightposts, Relay Stations or Fluff, as those are all non-open objects.

Since Lightposts are obstacles, the editor should treat them as such for the purpose of marking room edge errors.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45437