### PR TITLE
Allow Squad Horn to work for Wall-based player roles

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3643,7 +3643,8 @@ bool CDbRoom::GetNearestEntranceTo(const UINT wX, const UINT wY, const MovementT
 	ASSERT(eMovement == GROUND_FORCE
 		|| eMovement == GROUND_AND_SHALLOW_WATER_FORCE
 		|| eMovement == AIR_FORCE
-		|| eMovement == WATER_FORCE);
+		|| eMovement == WATER_FORCE
+		|| eMovement == WALL_FORCE);
 
 	if (!this->pPathMap[eMovement])
 		CreatePathMap(wX, wY, eMovement);
@@ -7263,6 +7264,7 @@ const
 				}
 			break;
 		case WALL:
+		case WALL_FORCE:
 			if (!(bIsWall(wOSquare) || bIsCrumblyWall(wOSquare) || bIsDoor(wOSquare)))
 				return DMASK_ALL;
 			break;

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -102,6 +102,7 @@ enum MovementType {
 	GROUND_AND_SHALLOW_WATER_FORCE,
 	AIR_FORCE,
 	WATER_FORCE,
+	WALL_FORCE,
 	NumMovementTypes
 };
 
@@ -136,7 +137,8 @@ static inline bool bMovementSupportsPartialObstacles (MovementType movement)
 	return movement == GROUND_FORCE
 		|| movement == GROUND_AND_SHALLOW_WATER_FORCE
 		|| movement == AIR_FORCE
-		|| movement == WATER_FORCE;
+		|| movement == WATER_FORCE
+		|| movement == WALL_FORCE;
 }
 
 static inline MovementType GetHornMovementType(MovementType movement)
@@ -144,6 +146,9 @@ static inline MovementType GetHornMovementType(MovementType movement)
 	switch (movement) {
 		case AIR:
 			return AIR_FORCE;
+
+		case WALL:
+			return WALL_FORCE;
 
 		case WATER:
 			return WATER_FORCE;

--- a/DRODLibTests/src/tests/Elements/SquadHorn.cpp
+++ b/DRODLibTests/src/tests/Elements/SquadHorn.cpp
@@ -97,4 +97,24 @@ TEST_CASE("Squad Horn", "[game][elements]") {
 		RunTestCase(T_PIT, T_WATER, M_WATERSKIPPER, false);
 	}
 	
+	// Wall Entity
+	SECTION("Clone will not appear across floor for Seep") {
+		RunTestCase(T_FLOOR, T_WALL, M_SEEP, false);
+	}
+
+	SECTION("Clone will not appear across deep water for Seep") {
+		RunTestCase(T_WATER, T_WALL, M_SEEP, false);
+	}
+
+	SECTION("Clone will appear across walls for Seep") {
+		RunTestCase(T_WALL, T_WALL, M_SEEP, true);
+	}
+
+	SECTION("Clone will appear across closed yellow door for Seep") {
+		RunTestCase(T_DOOR_Y, T_WALL, M_SEEP, true);
+	}
+
+	SECTION("Clone will not appear across pits for Seep") {
+		RunTestCase(T_PIT, T_WALL, M_SEEP, false);
+	}
 }


### PR DESCRIPTION
Since Squad Horns can show up on walls and closed doors, the case exists where a Seep player can toot one. Fairly simple change.