### PR TITLE
Correctly connect briar edges when building new briar roots

### DIFF
--- a/DRODLib/Briar.cpp
+++ b/DRODLib/Briar.cpp
@@ -522,10 +522,13 @@ void CBriars::initLiveTiles()
 }
 
 //*****************************************************************************
-void CBriars::insert(const UINT wX, const UINT wY)
+void CBriars::insert(const UINT wX, const UINT wY, bool bConstructed)
 //Add a briar root at (x,y)
+//If bConstructed if true, it is being added after the room has been initialized
 {
-	ASSERT(!this->briarIndices.Exists(wX,wY)); //this root should not have been processed yet
+	//this root should not have been processed yet
+	//but a root built via scripting can be placed on existing briar
+	ASSERT(!this->briarIndices.Exists(wX, wY) || bConstructed);
 
 	//Each briar root starts with its own separate connected component of briar tiles.
 	this->briarComponents.push_back(CCoordSet(wX, wY));
@@ -570,9 +573,13 @@ void CBriars::insert(const UINT wX, const UINT wY)
 		for (list<CBriar*>::iterator briar = this->briars.begin(); briar != this->briars.end(); ++briar)
 			if ((*briar)->wComponentIndex == wAdjIndex)
 				(*briar)->wComponentIndex = wIndex;
-		//Combine connected components.  Edges are still empty and can be ignored.
+		//Combine connected components. Edges can be ignored if empty.
 		this->briarComponents[wIndex-1] += this->briarComponents[wAdjIndex-1];
 		this->briarComponents[wAdjIndex-1].clear();
+		if (!this->briarEdge.empty()) {
+			this->briarEdge[wIndex - 1] += this->briarEdge[wAdjIndex - 1];
+			this->briarEdge[wAdjIndex - 1].clear();
+		}
 	}
 }
 

--- a/DRODLib/Briar.h
+++ b/DRODLib/Briar.h
@@ -73,7 +73,7 @@ public:
 	UINT getIndexAt(const UINT wX, const UINT wY) const;
 	UINT getNumSourcesWithIndex(const UINT index) const;
 	void initLiveTiles();
-	void insert(const UINT wX, const UINT wY);
+	void insert(const UINT wX, const UINT wY, bool bConstructed = false);
 	void plotted(const UINT wX, const UINT wY, const UINT wTileNo);
 	void process(CCueEvents &CueEvents);
 	void removeSource(const UINT wX, const UINT wY);

--- a/DRODLib/BuildUtil.cpp
+++ b/DRODLib/BuildUtil.cpp
@@ -348,7 +348,7 @@ bool BuildUtil::BuildNormalTile(CDbRoom& room, const UINT baseTile, const UINT t
 		} else if (wOldTTile == T_FLUFF && baseTile != wOldTTile) {
 			room.DestroyFluff(x, y, CueEvents);
 		} else if (baseTile == T_BRIAR_SOURCE && baseTile != wOldTTile) {
-			room.briars.insert(x, y);
+			room.briars.insert(x, y, true);
 			room.briars.forceRecalc();
 		} else if (wOldTTile == T_BRIAR_SOURCE && baseTile != wOldTTile) {
 			room.briars.removeSource(x, y);


### PR DESCRIPTION
Construction of briar roots didn't actually work right. `CBriars::insert()` was designed to run before briar edges are calculated, so when briar components are transferred to a newly constructed root, the edges are left disconnected. A small change was added so that if `briarEdge` contains edge data when a new root is insert, the edge data will be updated correctly.
Previously, roots would connect "correctly" due the issue fixed in #87, which was allowing briar components to connect through non-component and edge briar tiles.

The function now also takes an argument to indicate if the root is being inserted via building, so that the assert doesn't fire if roots are built onto existing briar.