### PR TITLE
RPG: Disable surface blending for tile images

### DIFF
--- a/drodrpg/DROD/DrodBitmapManager.cpp
+++ b/drodrpg/DROD/DrodBitmapManager.cpp
@@ -609,6 +609,7 @@ bool CDrodBitmapManager::LoadTileImages(
 	if (!pSrcSurface) return false;
 	ASSERT(pSrcSurface->w % CX_TILE == 0);
 	ASSERT(pSrcSurface->h % CY_TILE == 0);
+	DisableSurfaceBlending(pSrcSurface);
 	wCols = (pSrcSurface->w / CX_TILE);
 	wRows = (pSrcSurface->h / CY_TILE);
 	


### PR DESCRIPTION
It's #408 but for DROD RPG. Arguably more important since the transparency colour in RPG is eye-searing magenta.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45514