### PR TITLE
Allow timeclones to step kill Golem/Construct players

### DIFF
--- a/DRODLib/Mimic.cpp
+++ b/DRODLib/Mimic.cpp
@@ -49,6 +49,27 @@ CMimic::CMimic(const UINT wSetType, CCurrentGame *pSetCurrentGame, UINT processi
 	: CPlayerDouble(wSetType, pSetCurrentGame, GROUND_AND_SHALLOW_WATER, processingSequence)
 { }
 
+//*****************************************************************************************
+//Can this Mimic step onto (and thus kill) the player?
+bool CMimic::CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const
+{
+	if (!((HasSword() && GetWeaponType() == WT_Dagger) || bStepAttack))
+		return false;
+
+	//Check if player is invulnerable to "dagger stepping".
+	switch (player.wAppearance)
+	{
+		case M_WUBBA: case M_FEGUNDO:
+		case M_ROCKGOLEM: case M_CONSTRUCT:
+			return false;
+		case M_CITIZEN: case M_ARCHITECT:
+			if (!bStepAttack)
+				return false;
+		default:
+			return true;
+	}
+}
+
 //******************************************************************************************
 bool CMimic::DoesSquareContainObstacle(
 //Override for mimics.  Parts copied from CMonster::DoesSquareContainObstacle.
@@ -162,23 +183,8 @@ const
 	const CSwordsman& player = this->pCurrentGame->swordsman;
 	if (player.IsInRoom() && player.wX == wCol && player.wY == wRow)
 	{
-		if ((HasSword() && GetWeaponType() == WT_Dagger) || bStepAttack)
-		{
-			//Check if player is invulnerable to "dagger stepping".
-			switch(player.wAppearance)
-			{
-				case M_WUBBA: case M_FEGUNDO:
-				case M_ROCKGOLEM: case M_CONSTRUCT:
-					return true;
-				case M_CITIZEN: case M_ARCHITECT:
-					if (!bStepAttack)
-						return true;
-					break;
-				default: break;
-			}
-		} else {
+		if (!CanStepAttackPlayer(player, bStepAttack))
 			return true;
-		}
 	}
 	
 	//Check for player's sword at square.

--- a/DRODLib/Mimic.h
+++ b/DRODLib/Mimic.h
@@ -33,6 +33,9 @@
 
 #include "PlayerDouble.h"
 
+//Pre-declare class to avoid includes
+class CSwordsman;
+
 class CMimic : public CPlayerDouble
 {
 public:
@@ -40,6 +43,7 @@ public:
 	CMimic(const UINT wSetType, CCurrentGame *pSetCurrentGame = NULL, UINT processingSequence=SPD_PDOUBLE);
 	IMPLEMENT_CLONE_REPLICATE(CMonster, CMimic);
 
+  virtual bool CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const;
 	virtual bool DoesSquareContainObstacle(const UINT wCol, const UINT wRow) const;
 	virtual bool IsTarget() const { return true; }
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -58,6 +58,26 @@ bool CTemporalClone::CanDropTrapdoor(const UINT oTile) const
 	return false;
 }
 
+//*****************************************************************************************
+//Can this projection step onto (and thus kill) the player?
+bool CTemporalClone::CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const
+{
+	if (!((HasSword() && GetWeaponType() == WT_Dagger) || bStepAttack))
+		return false;
+
+	//Check if player is invulnerable to "dagger stepping".
+	switch (player.wAppearance)
+	{
+	case M_WUBBA: case M_FEGUNDO:
+		return false;
+	case M_CITIZEN: case M_ARCHITECT:
+		if (!bStepAttack)
+			return false;
+	default:
+		return true;
+	}
+}
+
 //*****************************************************************************
 bool CTemporalClone::CanLightFuses() const
 {

--- a/DRODLib/TemporalClone.h
+++ b/DRODLib/TemporalClone.h
@@ -37,6 +37,7 @@ public:
 	IMPLEMENT_CLONE_REPLICATE(CMonster, CTemporalClone);
 
 	virtual bool CanDropTrapdoor(const UINT oTile) const;
+	virtual bool CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const;
 	virtual UINT GetIdentity() const;
 	virtual bool IsAttackableTarget() const;
 	virtual bool IsFlying() const;


### PR DESCRIPTION
Timeclones can't step onto players that are Golems or Constructs, but they can step onto other timeclones of those roles. Since monsters can generally step on Golem and Construct players, so should timeclones, if they have a step attack.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45534