### PR TITLE
Make Slayer abandon broken or missing orb or plate.

### DIFF
--- a/BackEndLib/CoordStack.h
+++ b/BackEndLib/CoordStack.h
@@ -131,6 +131,18 @@ public:
 
 		return true;
 	}
+	bool Bottom(UINT& wX, UINT& wY) const
+	//Return value in bottom of stack w/o removing it.
+	{
+		if (IsEmpty())
+			return false;
+
+		const ROOMCOORD& first = this->data.front();
+		wX = first.wX;
+		wY = first.wY;
+
+		return true;
+	}
 	bool GetAt(const UINT wIndex, UINT &wX, UINT &wY) const
 	//Return values in indexth element w/o removing it.
 	{

--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -651,10 +651,10 @@ bool CSlayer::ConfirmGoal()
 
 	CDbRoom& room = *(this->pCurrentGame->pRoom);
 
-	if (room.GetOSquare(wGoalX, wGoalY) == T_PRESSPLATE && platesToDepress.has(CCoord(wGoalX, wGoalY))) {
+	if (platesToDepress.has(CCoord(wGoalX, wGoalY))) {
 		COrbData* pOrb = room.GetPressurePlateAtCoords(wGoalX, wGoalY);
-		//Reject activated one-use plate and remove from platesToDepress
-		if (pOrb->eType == OT_BROKEN) {
+		//Reject activated one-use or missing plate and remove from platesToDepress
+		if (!pOrb || pOrb->eType == OT_BROKEN) {
 			platesToDepress.erase(CCoord(wGoalX, wGoalY));
 			return false;
 		}

--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -651,7 +651,7 @@ bool CSlayer::ConfirmGoal()
 
 	CDbRoom& room = *(this->pCurrentGame->pRoom);
 
-	if (room.GetOSquare(wGoalX, wGoalY) == T_PRESSPLATE) {
+	if (room.GetOSquare(wGoalX, wGoalY) == T_PRESSPLATE && platesToDepress.has(CCoord(wGoalX, wGoalY))) {
 		COrbData* pOrb = room.GetPressurePlateAtCoords(wGoalX, wGoalY);
 		//Reject activated one-use plate and remove from platesToDepress
 		if (pOrb->eType == OT_BROKEN) {

--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -987,7 +987,7 @@ void CSlayer::MoveToOpenDoor(CCueEvents &CueEvents)     //(in/out)
 	}
 
 	//Confirm path to goal is still open.
-	if (!(ConfirmGoal() &&ConfirmPath()))
+	if (!(ConfirmGoal() && ConfirmPath()))
 	{
 		//If it's not, search for a new path to the goal.
 		bool bOrbPathFound = FindOptimalPathTo(this->wX, this->wY, this->orbsToHit, true);

--- a/DRODLib/Slayer.h
+++ b/DRODLib/Slayer.h
@@ -59,6 +59,7 @@ private:
 
 	void AdvanceAlongWisp(CCueEvents &CueEvents);
 	bool CheckWispIntegrity();
+	bool ConfirmGoal();
 	bool ExtendWisp(CCueEvents &CueEvents, const bool bMoveAllowed=true);
 	WISP GetWispAt(const UINT wX, const UINT wY);
 	const_WISP GetWispAt(const UINT wX, const UINT wY) const {


### PR DESCRIPTION
When in the door opening state, Slayers will continue to move towards broken orbs, activated one-use plates, and places that used to have something that could open a door, but now do not. This behavior is inconsistent with Halph, who will abandon missing or unusable goals. It's also doesn't make any sense.

Slayers moving to door-openers will now run `CSlayer::ConfirmGoal()`, which checks if there's something at the goal which will be useful for opening a door. If there's nothing there, the current path will be rejected.

This requires one extra function in `CCoordStack` to learn the end of the queue without removing it.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45542