### PR TITLE
Mark monster attached to CFiredCharacterCommand unsafe for deletion

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -5603,6 +5603,7 @@ void CGameScreen::PrepCustomSpeaker(CFiredCharacterCommand *pCmd)
 		{
 			//Attach speech to monster at this tile.
 			pCmd->pSpeakingEntity = pMonster;
+			pMonster->bSafeToDelete = false;
 		} else {
 			//No monster there -- create temporary pseudo-monster to attach to.
 			CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pCmd->pExecutingNPC);


### PR DESCRIPTION
#156 removes dead monsters that are no longer used by anything. However, `CFiredCharacterCommand` may hold onto a reference to a monster that gets deleted, which can cause a crash. To fix this, monsters that get attached to these commands by `CGameScreen::PrepCustomSpeaker` should be marked as unsafe for deletion.

Related thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45552