### PR TITLE
Add setting to enable window resizing

### DIFF
--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -2640,6 +2640,9 @@ void CDrodScreen::EnablePlayerSettings(
 #else
 	SetFullScreen(pPlayer->Settings.GetVar(Settings::Fullscreen, false));
 #endif
+
+	SetResizableScreen(pPlayer->Settings.GetVar(Settings::ResizableWindow, CScreen::bAllowWindowResizing));
+
 	g_pTheBM->bAlpha = pPlayer->Settings.GetVar(Settings::Alpha, true);
 	g_pTheDBM->SetGamma(pPlayer->Settings.GetVar(Settings::Gamma, (BYTE)CDrodBitmapManager::GetGammaOne()));
 	g_pTheBM->eyeCandy = pPlayer->Settings.GetVar(Settings::EyeCandy, BYTE(Metadata::GetInt(MetaKey::MAX_EYE_CANDY)));

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -552,7 +552,7 @@ void CSettingsScreen::SetupMediaTab(CTabbedMenuWidget* pTabbedMenu)
 
 	pOptionButton = new COptionButtonWidget(TAG_RESIZABLE_SCREEN, X_USEFULLSCREEN,
 		Y_USEFULLSCREEN + 32, CX_USEFULLSCREEN, CY_USEFULLSCREEN,
-		L"Resizable Window", false);
+		g_pTheDB->GetMessageText(MID_ResizableWindow), false);
 	pGraphicsFrame->AddWidget(pOptionButton);
 	if (!CScreen::bAllowWindowed)
 		pOptionButton->Disable();

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -113,6 +113,8 @@ const UINT TAG_HELP = 1092;
 
 const UINT TAG_MENU = 1093;
 
+const UINT TAG_RESIZABLE_SCREEN = 1094;
+
 static const UINT CX_SPACE = 10;
 static const UINT CY_SPACE = 10;
 
@@ -546,6 +548,13 @@ void CSettingsScreen::SetupMediaTab(CTabbedMenuWidget* pTabbedMenu)
 		g_pTheDB->GetMessageText(MID_UseFullScreen), false);
 	pGraphicsFrame->AddWidget(pOptionButton);
 	if (!CScreen::bAllowFullScreen || !CScreen::bAllowWindowed)
+		pOptionButton->Disable();
+
+	pOptionButton = new COptionButtonWidget(TAG_RESIZABLE_SCREEN, X_USEFULLSCREEN,
+		Y_USEFULLSCREEN + 32, CX_USEFULLSCREEN, CY_USEFULLSCREEN,
+		L"Resizable Window", false);
+	pGraphicsFrame->AddWidget(pOptionButton);
+	if (!CScreen::bAllowWindowed)
 		pOptionButton->Disable();
 
 	pOptionButton = new COptionButtonWidget(TAG_ALPHA, X_ALPHA, Y_ALPHA,
@@ -1355,6 +1364,7 @@ void CSettingsScreen::SetUnspecifiedPlayerSettings(
 	SETMISSING(Settings::Language, Language::English);
 	
 	SETMISSING(Settings::Fullscreen, IsFullScreen());
+	SETMISSING(Settings::ResizableWindow, CScreen::bAllowWindowResizing);
 	SETMISSING(Settings::Alpha, true);
 	SETMISSING(Settings::Gamma, (BYTE)CDrodBitmapManager::GetGammaOne());
 	SETMISSING(Settings::EyeCandy, BYTE(Metadata::GetInt(MetaKey::MAX_EYE_CANDY)));
@@ -1494,6 +1504,10 @@ void CSettingsScreen::UpdateWidgetsFromPlayerData(
 	pOptionButton->SetChecked((CScreen::bAllowFullScreen && CScreen::bAllowWindowed) ?
 			settings.GetVar(Settings::Fullscreen, IsFullScreen()) :
 			IsFullScreen());
+
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*, GetWidget(TAG_RESIZABLE_SCREEN));
+	pOptionButton->SetChecked(settings.GetVar(Settings::ResizableWindow, CScreen::bAllowWindowResizing));
+	pOptionButton->Enable(!IsFullScreen());
 
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*, GetWidget(TAG_ALPHA));
 	pOptionButton->SetChecked(settings.GetVar(Settings::Alpha, g_pTheBM->bAlpha));
@@ -1635,6 +1649,11 @@ void CSettingsScreen::UpdatePlayerDataFromWidgets(
 			GetWidget(TAG_USE_FULLSCREEN));
 	settings.SetVar(Settings::Fullscreen, pOptionButton->IsChecked());
 	SetFullScreen(pOptionButton->IsChecked());
+
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_RESIZABLE_SCREEN));
+	settings.SetVar(Settings::ResizableWindow, pOptionButton->IsChecked());
+	SetResizableScreen(pOptionButton->IsChecked());
 
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*, GetWidget(TAG_ALPHA));
 	settings.SetVar(Settings::Alpha, pOptionButton->IsChecked());

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -907,6 +907,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_LogicalWaitOr: strText = "Wait for Any:"; break;
 	case MID_LogicalWaitXOR: strText = "Wait for Exactly One:"; break;
 	case MID_LogicalWaitEnd: strText = "Wait for Conditions End"; break;
+	case MID_ResizableWindow: strText = "Resizable Window"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -69,6 +69,7 @@ namespace Settings
 	DEF(PuzzleMode);
 	DEF(ReceiveWhispersOnlyInGame);
 	DEF(RepeatRate);
+	DEF(ResizableWindow);
 	DEF(ShowCheckpoints);
 	DEF(ShowDemosFromLevel);
 	DEF(ShowErrors);

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -69,6 +69,7 @@ namespace Settings
 	DEF(PuzzleMode);
 	DEF(ReceiveWhispersOnlyInGame);
 	DEF(RepeatRate);
+	DEF(ResizableWindow);
 	DEF(ShowCheckpoints);
 	DEF(ShowDemosFromLevel);
 	DEF(ShowErrors);

--- a/FrontEndLib/Screen.cpp
+++ b/FrontEndLib/Screen.cpp
@@ -659,6 +659,16 @@ void CScreen::GetScreenSize(int &nW, int &nH)
 }
 
 //*****************************************************************************
+void CScreen::SetResizableScreen(const bool bResizable)
+{
+	// Can't resize while fullscreen
+	if (IsFullScreen())
+		return;
+
+	SDL_SetWindowResizable(GetMainWindow(), (SDL_bool)bResizable);
+}
+
+//*****************************************************************************
 void CScreen::GetWindowPos(int &nX, int &nY)
 //OUT: windowed app position on screen
 {

--- a/FrontEndLib/Screen.h
+++ b/FrontEndLib/Screen.h
@@ -228,6 +228,7 @@ protected:
 	void           SetDestScreenType(const UINT eSet) {this->eDestScreenType = eSet;}
 	void           SetFullScreen(const bool bSetFull);
 	virtual bool   SetForActivate();
+	void           SetResizableScreen(const bool bResizable);
 	void           SetScreenType(const UINT eSetType) {this->eType = eSetType;}
 	void           ShowCursor();
 	UINT           ShowMessage(const WCHAR* pwczMessage);

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1374,6 +1374,7 @@ enum MID_CONSTANT {
   MID_UnlimitedUndo = 1757,
   MID_AutoUndoOnDeath = 1786,
   MID_ActivateCloudSync = 1794,
+  MID_ResizableWindow = 2027,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/Texts/SettingsScreen.uni
+++ b/Texts/SettingsScreen.uni
@@ -653,3 +653,7 @@ Auto undo on death
 [MID_ActivateCloudSync]
 [eng]
 Activate Cloud Sync
+
+[MID_ResizableWindow]
+[eng]
+Resizable Window


### PR DESCRIPTION
Adds a new setting to enable resizing the game screen when in windowed mode. The ini option isn't removed, but it becomes obselete. It is used to determine the default setting for resizability.
(Help content may need updating?)

See thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45538