### PR TITLE
WIN32: Convert bad line ending to good ones when importing uni file

### DIFF
--- a/DRODUtil/Util3_0.cpp
+++ b/DRODUtil/Util3_0.cpp
@@ -728,6 +728,19 @@ const
 	const char* pSource = (const char*)((const BYTE*)Source);
 	WSTRING wideSource = UTF8ToUnicode(pSource);
 
+#ifdef WIN32
+	// We need crlf line ends, at least for Windows builds.
+	// This ensures we get them if the file has lr line ends
+	WSTRING::size_type pos = 0;
+	while ((pos = wideSource.find(L"\n", pos)) != string::npos)
+	{
+		if (wideSource.at(pos-1) != L'\r')
+			wideSource.insert(pos, L"\r");
+
+		pos++;
+	}
+#endif
+
   const WCHAR wszNameTagStart[] = {{'M'},{'I'},{'D'},{'_'},{0}};
   char szNameTag[MAXLEN_NAMETAG + 1];
 


### PR DESCRIPTION
### Problem
Due to a vast and complex history involving typewriters, device drivers and the dubious necessity of carriage returns, different operating systems use different character combinations for indicating line endings. When I converted the `.uni` files to UTF-8, I accidently changed them from `crlf` endings to `lf` endings. git makes it difficult to change them back, and depending on your git settings files can end up with any number of line endings. It's a mess.

DROD on Windows doesn't play nicely with `lf` endings. It wants `crlf` endings. (I don't know about other platforms. We should check during the 5.2 alpha.) Since we will probably live in a world of line ending uncertainty for the foreseeable future, this presents problems.

### Solution
Just fix the line endings in DRODUtil before processing the string into individual database messages. If there's a `lf` without a `cr`, bolt the required `\r` character in front of the `\n` character. Currently this is only enabled for Windows builds of `DRODUtil`. As far as I can tell, this unbreaks multi-line messages.

I will create an RPG PR if this PR is merged.