### PR TITLE
Fix temporal clone check for tunnel moves

### DIFF
--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -240,9 +240,10 @@ void CTemporalClone::Process(const int /*nLastCommand*/, CCueEvents &CueEvents)
 			command = ConvertToBumpCommand(command);
 			applying_command = false;
 		} else {
+			CDbRoom* pRoom = this->pCurrentGame->pRoom;
 			bEnteredTunnel = this->pCurrentGame->PlayerEnteredTunnel(
-					this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY), nGetO(dx, dy), this->wIdentity) &&
-				!DoesArrowPreventMovement(this->wX, this->wY, dx, dy);
+					pRoom->GetOSquare(this->wX, this->wY), nGetO(dx, dy), this->wIdentity) &&
+				!bIsArrowObstacle(pRoom->GetFSquare(this->wX, this->wY), nGetO(dx, dy));
 			if (bEnteredTunnel) {
 				//If tunnel cannot be exited, then don't expend a turn.
 				UINT destX, destY;

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -424,6 +424,7 @@
     <ClCompile Include="src\tests\Scripting\WaitForSomeoneToPushMe\WaitForSomeoneToPushMe.cpp" />
     <ClCompile Include="src\tests\Scripting\WaitForWeapon\WaitForWeapon.cpp" />
     <ClCompile Include="src\tests\TemporalToken\DoublePlacementPreventsRecording.cpp" />
+    <ClCompile Include="src\tests\TemporalToken\TemporalProjectionTunnels.cpp" />
     <ClCompile Include="src\tests\TemporalToken\TemporalProjectionVsFluff.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -267,6 +267,9 @@
     <ClCompile Include="src\tests\Scripting\Build\RemovingTransparentObjects.cpp">
       <Filter>Tests\Scripting\Build</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\TemporalToken\TemporalProjectionTunnels.cpp">
+      <Filter>Tests\TemporalToken</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />

--- a/DRODLibTests/src/tests/TemporalToken/TemporalProjectionTunnels.cpp
+++ b/DRODLibTests/src/tests/TemporalToken/TemporalProjectionTunnels.cpp
@@ -1,0 +1,34 @@
+#include "../../test-include.hpp"
+
+TEST_CASE("Temporal Projection interaction with tunnels", "[game][time token]") {
+	RoomBuilder::ClearRoom();
+
+	SECTION("Projection uses tunnel") {
+		RoomBuilder::PlotToken(RoomTokenType::TemporalSplit, 10, 10);
+		RoomBuilder::Plot(T_TUNNEL_E, 11, 10);
+		RoomBuilder::Plot(T_TUNNEL_W, 20, 10);
+
+		CCurrentGame* game = Runner::StartGame(9, 10, N);
+		Runner::ExecuteCommand(CMD_E, 3);
+		Runner::ExecuteCommand(CMD_CLONE);
+		Runner::ExecuteCommand(CMD_WAIT, 2);
+
+		// Temporal Projection should travel through tunnel
+		AssertMonsterType(20, 10, M_TEMPORALCLONE);
+	}
+
+	SECTION("Projection tunnel use not blocked by adjacent arrow") {
+		RoomBuilder::PlotToken(RoomTokenType::TemporalSplit, 10, 10);
+		RoomBuilder::Plot(T_TUNNEL_E, 11, 10);
+		RoomBuilder::Plot(T_TUNNEL_W, 20, 10);
+		RoomBuilder::Plot(T_ARROW_W, 12, 10);
+
+		CCurrentGame* game = Runner::StartGame(9, 10, N);
+		Runner::ExecuteCommand(CMD_E, 3);
+		Runner::ExecuteCommand(CMD_CLONE);
+		Runner::ExecuteCommand(CMD_WAIT, 2);
+
+		// Temporal Projection should travel through tunnel
+		AssertMonsterType(20, 10, M_TEMPORALCLONE);
+	}
+}


### PR DESCRIPTION
When a temporal projection is trying to use a tunnel, it uses `DoesArrowPreventMovement()` to check if an arrow will stop the tunnel move. However, this function also checks the adjacent tile in the move's direction for a blocking arrow. This means that an arrow on another tile can block a tunnel move. Using `IsArrowObstacle()` instead allows only the tunnel square to be checked.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45582