### PR TITLE
RPG: Fix accessory slot issue with teleporting accessories

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -2209,7 +2209,7 @@ bool CCurrentGame::UseAccessory(CCueEvents &CueEvents)
 			const UINT wTTileNo = this->pRoom->GetTSquare(this->pPlayer->wX, this->pPlayer->wY);
 			const bool bWasOnSameScroll = wTTileNo == T_SCROLL;
 
-			TeleportPlayer(reflectX, reflectY, CueEvents);
+			TeleportPlayer(reflectX, reflectY, CueEvents, false);
 			this->pPlayer->st.accessory = NoAccessory;
 			ProcessPlayerMoveInteraction(0, 0, CueEvents, bWasOnSameScroll, true, true);
 

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -2205,9 +2205,18 @@ bool CCurrentGame::UseAccessory(CCueEvents &CueEvents)
 			//Warp to reflected room coord.
 			const UINT reflectX = this->pRoom->wRoomCols - this->pPlayer->wX - 1;
 			const UINT reflectY = this->pRoom->wRoomRows - this->pPlayer->wY - 1;
+
+			const UINT wTTileNo = this->pRoom->GetTSquare(this->pPlayer->wX, this->pPlayer->wY);
+			const bool bWasOnSameScroll = wTTileNo == T_SCROLL;
+
 			TeleportPlayer(reflectX, reflectY, CueEvents);
+			this->pPlayer->st.accessory = NoAccessory;
+			ProcessPlayerMoveInteraction(0, 0, CueEvents, bWasOnSameScroll, true, true);
+
 			bMoved = this->pPlayer->bHasTeleported;
 			CueEvents.Add(CID_AccessoryUsed, new CAttachableWrapper<UINT>(accessory), true);
+
+			return bMoved;
 		}
 		break;
 		case WallWalking:
@@ -2215,9 +2224,18 @@ bool CCurrentGame::UseAccessory(CCueEvents &CueEvents)
 			//Warp ahead two tiles in the direction faced.
 			const UINT destX = this->pPlayer->wX + nGetOX(this->pPlayer->wO) * 2;
 			const UINT destY = this->pPlayer->wY + nGetOY(this->pPlayer->wO) * 2;
-			TeleportPlayer(destX, destY, CueEvents);
+
+			const UINT wTTileNo = this->pRoom->GetTSquare(this->pPlayer->wX, this->pPlayer->wY);
+			const bool bWasOnSameScroll = wTTileNo == T_SCROLL;
+
+			TeleportPlayer(destX, destY, CueEvents, false);
+			this->pPlayer->st.accessory = NoAccessory;
+			ProcessPlayerMoveInteraction(0, 0, CueEvents, bWasOnSameScroll, true, true);
+
 			bMoved = this->pPlayer->bHasTeleported;
 			CueEvents.Add(CID_AccessoryUsed, new CAttachableWrapper<UINT>(accessory), true);
+
+			return bMoved;
 		}
 		break;
 
@@ -3942,7 +3960,7 @@ void CCurrentGame::TeleportPlayer(
 	//
 	//Params:
 	const UINT wSetX, const UINT wSetY,  //(in)   Coords of new square.
-	CCueEvents& CueEvents)
+	CCueEvents& CueEvents, bool bProcess)
 {
 	if (!this->pRoom->IsValidColRow(wSetX, wSetY))
 	{
@@ -3970,7 +3988,9 @@ void CCurrentGame::TeleportPlayer(
 
 	this->pPlayer->SetSwordSheathed();
 
-	ProcessPlayerMoveInteraction(0, 0, CueEvents, bWasOnSameScroll, true, true);
+	if (bProcess) {
+		ProcessPlayerMoveInteraction(0, 0, CueEvents, bWasOnSameScroll, true, true);
+	}
 
 	this->pRoom->CheckForFallingAt(wSetX, wSetY, CueEvents);
 

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -348,7 +348,7 @@ public:
 	void     SellInventory(CCueEvents& CueEvents, const UINT type, const bool bShowStatChanges=true);
 	void     SetExecuteNoMoveCommands(const bool bVal=true) {this->bExecuteNoMoveCommands = bVal;}
 	bool     SetPlayer(const UINT wSetX, const UINT wSetY);
-	void     TeleportPlayer(const UINT wSetX, const UINT wSetY, CCueEvents& CueEvents);
+	void     TeleportPlayer(const UINT wSetX, const UINT wSetY, CCueEvents& CueEvents, bool bProcess = true);
 	void     SetPlayerRole(const UINT wType);
 	bool     SetPlayerSwordSheathed();
 	void     SetTurn(UINT wSetTurnNo, CCueEvents &CueEvents);


### PR DESCRIPTION
When the player uses a "Wall Walking" or "Warp Token" accessory, they are moved. If they move onto an accessory slot, the accessory will be placed in the slot instead of being consumed. This happens because of the order that things get processed, such that the accessory is slotted before being removed.

I made it so `CCurrentGame::TeleportPlayer` can be prevented from processing the effects of a player's move. This is used in the accessory use processing to ensure the used accessory is consumed before the move is processed, preventing duplication.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=44917&page=0#441051