### PR TITLE
Make brained constructs path around oremites

### DIFF
--- a/DRODLib/Construct.h
+++ b/DRODLib/Construct.h
@@ -35,7 +35,7 @@ class CConstruct : public CRockGolem
 {
 public:
 	CConstruct(CCurrentGame *pSetCurrentGame = NULL)
-		: CRockGolem(pSetCurrentGame, M_CONSTRUCT)
+		: CRockGolem(pSetCurrentGame, M_CONSTRUCT, GROUND_AND_SHALLOW_WATER_NO_OREMITES)
 		, wTurnDisabled(0), bOremiteDamage(false)
 	{ }
 	IMPLEMENT_CLONE_REPLICATE(CMonster, CConstruct);

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -7344,6 +7344,9 @@ const
 			if (!bIsWater(wOSquare))
 				return DMASK_ALL;
 			break;
+		case GROUND_AND_SHALLOW_WATER_NO_OREMITES:
+			if (wOSquare == T_GOO)
+				return DMASK_ALL;
 		case GROUND_AND_SHALLOW_WATER:
 		case GROUND_AND_SHALLOW_WATER_FORCE:
 			if (!(bIsFloor(wOSquare) || bIsOpenDoor(wOSquare) || bIsPlatform(wOSquare) ||

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -7315,6 +7315,9 @@ const
 	if (wOSquare == T_FIRETRAP_ON)
 		return DMASK_ALL;
 
+	// Blocks movement, but can be pathed through expensively
+	bool bSemiObstacle = false;
+
 	switch (eMovement)
 	{
 		case GROUND:
@@ -7345,8 +7348,11 @@ const
 				return DMASK_ALL;
 			break;
 		case GROUND_AND_SHALLOW_WATER_NO_OREMITES:
-			if (wOSquare == T_GOO)
-				return DMASK_ALL;
+			if (wOSquare == T_GOO) {
+				bSemiObstacle = true;
+				break;
+			}
+		//no break
 		case GROUND_AND_SHALLOW_WATER:
 		case GROUND_AND_SHALLOW_WATER_FORCE:
 			if (!(bIsFloor(wOSquare) || bIsOpenDoor(wOSquare) || bIsPlatform(wOSquare) ||
@@ -7369,6 +7375,10 @@ const
 	}
 
 	UINT wBlockDir = DMASK_NONE;
+
+	if (bSemiObstacle)
+		wBlockDir |= DMASK_SEMI;
+
 	if (DoesGentryiiPreventDiagonal(wX,wY,wX-1,wY-1))
 		wBlockDir |= DMASK_NW;
 	if (DoesGentryiiPreventDiagonal(wX,wY,wX-1,wY+1))

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -103,6 +103,7 @@ enum MovementType {
 	AIR_FORCE,
 	WATER_FORCE,
 	WALL_FORCE,
+	GROUND_AND_SHALLOW_WATER_NO_OREMITES,
 	NumMovementTypes
 };
 
@@ -157,6 +158,7 @@ static inline MovementType GetHornMovementType(MovementType movement)
 			return GROUND_FORCE;
 
 		case GROUND_AND_SHALLOW_WATER:
+		case GROUND_AND_SHALLOW_WATER_NO_OREMITES:
 		default:
 			return GROUND_AND_SHALLOW_WATER_FORCE;
 	}

--- a/DRODLib/PathMap.cpp
+++ b/DRODLib/PathMap.cpp
@@ -116,6 +116,8 @@ void CPathMap::CalcPaths()
 				(this->bSupportPartialObstacles ? parent_square.eBlockedDirections : 0) |
 						square.eBlockedDirections) & rdirmask[nIndex]) != 0;
 
+			const bool bIsSemiObstacle = (!bIsObstacle && (square.eBlockedDirections & DMASK_SEMI));
+
 			//If this square is considered a valid candidate...
 			if (!bIsObstacle || this->dwPathThroughObstacleCost)
 			{
@@ -134,6 +136,9 @@ void CPathMap::CalcPaths()
 						//then leave it, but on re-entering an obstacle, the path cost
 						//will be set as though it never left the obstacle.
 						dwScore = (coord.wMoves+1) * (this->dwPathThroughObstacleCost + 1);
+				} else if (bIsSemiObstacle && parent_square.eBlockedDirections != DMASK_SEMI) {
+					//Penalize moving into "semi-obstacle" area
+					dwScore += 1000;
 				}
 				if (dwScore < square.dwTargetDist)
 				{

--- a/DRODLib/Pathmap.h
+++ b/DRODLib/Pathmap.h
@@ -58,6 +58,7 @@
 #define DMASK_SW   0x20
 #define DMASK_W    0x40
 #define DMASK_NW   0x80
+#define DMASK_SEMI 0x16
 #define DMASK_ALL  0xff
 
 //Path map square that contains only information needed for determining paths.

--- a/DRODLib/RockGolem.h
+++ b/DRODLib/RockGolem.h
@@ -33,8 +33,12 @@
 class CRockGolem : public CMonster
 {
 public:
-	CRockGolem(CCurrentGame *pSetCurrentGame = NULL, UINT monsterType=M_ROCKGOLEM)
-		: CMonster(monsterType, pSetCurrentGame, GROUND_AND_SHALLOW_WATER), bBroken(false) {}
+	CRockGolem(
+		CCurrentGame *pSetCurrentGame = NULL,
+		UINT monsterType=M_ROCKGOLEM,
+		MovementType movementType=GROUND_AND_SHALLOW_WATER
+	)
+		: CMonster(monsterType, pSetCurrentGame, movementType), bBroken(false) {}
 	IMPLEMENT_CLONE_REPLICATE(CMonster, CRockGolem);
 	
 	virtual bool CheckForDamage(CCueEvents& CueEvents);

--- a/DRODLibTests/DRODLibTest.2019.vcxproj
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj
@@ -359,6 +359,7 @@
     <ClCompile Include="src\tests\Monsters\Aumtlich\GenericAumtlich.cpp" />
     <ClCompile Include="src\tests\Monsters\Citizen\CitizenPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Clone.cpp" />
+    <ClCompile Include="src\tests\Monsters\Construct\BrainedConstruct.cpp" />
     <ClCompile Include="src\tests\Monsters\Fegundo.cpp" />
     <ClCompile Include="src\tests\Monsters\Guard\GuardPuffObstacle.cpp" />
     <ClCompile Include="src\tests\Monsters\Halph\HalphPuffObstacle.cpp" />

--- a/DRODLibTests/DRODLibTest.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTest.2019.vcxproj.filters
@@ -267,6 +267,9 @@
     <ClCompile Include="src\tests\Scripting\Build\RemovingTransparentObjects.cpp">
       <Filter>Tests\Scripting\Build</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Monsters\Construct\BrainedConstruct.cpp">
+      <Filter>Tests\Monsters\Construct</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\catch.hpp" />
@@ -368,6 +371,9 @@
     </Filter>
     <Filter Include="Tests\Scripting\Behavior">
       <UniqueIdentifier>{b4b0c8c7-58a6-4f30-9fe5-770cc1698fbf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Monsters\Construct">
+      <UniqueIdentifier>{32171c16-acdd-4281-aae8-b48bbb27aac5}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/DRODLibTests/src/tests/Monsters/Construct/BrainedConstruct.cpp
+++ b/DRODLibTests/src/tests/Monsters/Construct/BrainedConstruct.cpp
@@ -1,0 +1,33 @@
+#include "../../../test-include.hpp"
+
+TEST_CASE("Brained Construct", "[game][construct][brain]") {
+	RoomBuilder::ClearRoom();
+
+	SECTION("Test Construct pathing with oremites") {
+		RoomBuilder::PlotRect(T_WALL, 5, 7, 8, 7);
+		RoomBuilder::PlotRect(T_WALL, 5, 8, 5, 9);
+		RoomBuilder::PlotRect(T_WALL, 8, 8, 8, 9);
+		RoomBuilder::Plot(T_WALL, 7, 9);
+		RoomBuilder::PlotRect(T_WALL, 5, 11, 8, 11);
+		RoomBuilder::Plot(T_GOO, 8, 10);
+		RoomBuilder::Plot(T_DOOR_Y, 5, 10);
+		RoomBuilder::Plot(T_ORB, 11, 9);
+		RoomBuilder::AddOrbDataToTile(11, 9);
+		RoomBuilder::LinkOrb(11, 9, 5, 10, OrbAgentType::OA_OPEN);
+
+		RoomBuilder::AddMonster(M_CONSTRUCT, 7, 8);
+		RoomBuilder::AddMonster(M_BRAIN, 5, 5);
+
+		CCurrentGame* game = Runner::StartGame(10, 10, E);
+		Runner::ExecuteCommand(CMD_WAIT, 2);
+
+		//Should move to tile adjacent to oremites
+		AssertMonsterType(7, 10, M_CONSTRUCT);
+
+		Runner::ExecuteCommand(CMD_CC);
+		Runner::ExecuteCommand(CMD_WAIT);
+
+		//Should move along non-oremite path
+		AssertMonsterType(5, 10, M_CONSTRUCT);
+	}
+}


### PR DESCRIPTION
Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=44966

Currently, constructs use the `GROUND_AND_SHALLOW_WATER` movement type, and it's accompaning brain pathmap. This pathmap tries to make them walk through oremites, which they can't do. This leads to weird situations where a construct gets caught in a dead end due to oremites, even if another path is available. People don't like this.

With a new movement type, `GROUND_AND_SHALLOW_WATER_NO_OREMITES`, constructs can have their own special pathmap that avoids oremites.

People also thought constructs should at least be able to get near the player, even if oremites are in the way. By adding a new `DMASK_SEMI`, tiles in a room can be marked as "semi-obstacles". A tweak to the pathmap construction makes it so moving into a "semi-obstacle" is allowed, but very expensive (1000 addition tiles). This is similar to how monsters using the `WALL` and `WATER` movement types act.