### PR TITLE
RPG: Add "Wait until expression" and complex conditionals script commands

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -148,6 +148,7 @@ const UINT TAG_DELETECOMMAND2 = 898;
 const UINT TAG_DEFAULTCOMMANDSLISTBOX = 897;
 const UINT TAG_OK2 = 896;
 
+const UINT TAG_VARCOMPLIST2 = 895;
 
 const UINT MAX_TEXT_LABEL_SIZE = 100;
 
@@ -371,7 +372,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	, pDirectionListBox(NULL), pDirectionListBox2(NULL), pDirectionListBox3(NULL)
 	, pOnOffListBox(NULL), pOnOffListBox2(NULL), pOnOffListBox3(NULL), pOpenCloseListBox(NULL)
 	, pGotoLabelListBox(NULL), pMusicListBox(NULL)
-	, pVarListBox(NULL), pVarOpListBox(NULL), pVarCompListBox(NULL)
+	, pVarListBox(NULL), pVarOpListBox(NULL), pVarCompListBox(NULL), pVarCompListBox2(NULL)
 	, pWaitFlagsListBox(NULL), pImperativeListBox(NULL), pBuildItemsListBox(NULL)
 	, pEquipmentTypesListBox(NULL), pCustomNPCListBox(NULL), pEquipTransListBox(NULL)
 	, pCharNameText(NULL), pCharListBox(NULL)
@@ -1545,6 +1546,18 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pVarCompListBox->AddItem(ScriptVars::LessThanOrEqual, g_pTheDB->GetMessageText(MID_VarLessThanOrEqual));
 	this->pVarCompListBox->AddItem(ScriptVars::Inequal, g_pTheDB->GetMessageText(MID_VarInequal));
 	this->pVarCompListBox->SelectLine(0);
+
+	this->pVarCompListBox2 = new CListBoxWidget(TAG_VARCOMPLIST2,
+		X_VARCOMPLIST, Y_VARCOMPLIST, CX_VARCOMPLIST, CY_VARCOMPLIST);
+	this->pAddCommandDialog->AddWidget(this->pVarCompListBox2);
+	this->pVarCompListBox2->AddHotkey(SDLK_RETURN, TAG_OK);
+	this->pVarCompListBox2->AddItem(ScriptVars::Equals, g_pTheDB->GetMessageText(MID_VarEquals));
+	this->pVarCompListBox2->AddItem(ScriptVars::Greater, g_pTheDB->GetMessageText(MID_VarGreater));
+	this->pVarCompListBox2->AddItem(ScriptVars::GreaterThanOrEqual, g_pTheDB->GetMessageText(MID_VarGreaterThanOrEqual));
+	this->pVarCompListBox2->AddItem(ScriptVars::Less, g_pTheDB->GetMessageText(MID_VarLess));
+	this->pVarCompListBox2->AddItem(ScriptVars::LessThanOrEqual, g_pTheDB->GetMessageText(MID_VarLessThanOrEqual));
+	this->pVarCompListBox2->AddItem(ScriptVars::Inequal, g_pTheDB->GetMessageText(MID_VarInequal));
+	this->pVarCompListBox2->SelectLine(0);
 
 	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_VARVALUELABEL,
 			X_VARVALUELABEL, Y_VARVALUELABEL, CX_VARVALUELABEL, CY_VARVALUELABEL,
@@ -3485,6 +3498,16 @@ const
 		}
 		break;
 
+		case CCharacterCommand::CC_WaitForExpression:
+		{
+			wstr += command.label;
+			wstr += wszSpace;
+			AddOperatorSymbol(wstr, command.y);
+			wstr += wszSpace;
+			wstr += _itoW(command.x, temp, 10);
+		}
+		break;
+
 		case CCharacterCommand::CC_SetPlayerAppearance:
 		case CCharacterCommand::CC_SetNPCAppearance:
 		{
@@ -3845,6 +3868,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 //	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForNoBuilding, g_pTheDB->GetMessageText(MID_WaitForNoBuilding));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForTurn, g_pTheDB->GetMessageText(MID_WaitForTurn));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForVar, g_pTheDB->GetMessageText(MID_WaitForVar));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForExpression, L"Wait until expression");
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForNotRect, g_pTheDB->GetMessageText(MID_WaitWhileEntity));
 	this->pActionListBox->SelectLine(0);
 	this->pActionListBox->SetAllowFiltering(true);
@@ -4537,7 +4561,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 {
 	//Code is structured in this way to facilitate quick addition of
 	//additional action parameters.
-	static const UINT NUM_WIDGETS = 38;
+	static const UINT NUM_WIDGETS = 39;
 	static const UINT widgetTag[NUM_WIDGETS] = {
 		TAG_WAIT, TAG_EVENTLISTBOX, TAG_DELAY, TAG_SPEECHTEXT,
 		TAG_SPEAKERLISTBOX, TAG_MOODLISTBOX, TAG_ADDSOUND, TAG_TESTSOUND, TAG_DIRECTIONLISTBOX,
@@ -4550,7 +4574,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_EQUIPMENTTYPE_LISTBOX, TAG_CUSTOMNPC_LISTBOX, TAG_EQUIPTRANS_LISTBOX,
 		TAG_DIRECTIONLISTBOX2,
 		TAG_VISUALEFFECTS_LISTBOX, TAG_DIRECTIONLISTBOX3, TAG_ONOFFLISTBOX3,
-		TAG_TEXT2, TAG_STATLISTBOX, TAG_MOVETYPELISTBOX
+		TAG_TEXT2, TAG_STATLISTBOX, TAG_MOVETYPELISTBOX, TAG_VARCOMPLIST2
 	};
 
 	static const UINT NO_WIDGETS[] =  {0};
@@ -4581,6 +4605,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT EFFECT[] =      { TAG_VISUALEFFECTS_LISTBOX, TAG_DIRECTIONLISTBOX3, TAG_ONOFFLISTBOX3, 0 };
 	static const UINT STATSET[] =     { TAG_STATLISTBOX, TAG_SPEECHTEXT, 0 };
 	static const UINT MOVETYPE[] =    { TAG_MOVETYPELISTBOX, 0 };
+	static const UINT EXPRESSION[] =  { TAG_GOTOLABELTEXT, TAG_VARCOMPLIST2, TAG_VARVALUE, 0 };
 
 	static const UINT* activeWidgets[CCharacterCommand::CC_Count] = {
 		NO_WIDGETS,
@@ -4655,7 +4680,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		STATSET,            //CC_SetMonsterVar
 		MOVETYPE,           //CC_SetMovementType
 		NO_WIDGETS,         //CC_ReplaceWithDefault
-		VARSET              //CC_VarSetAt
+		VARSET,             //CC_VarSetAt
+		EXPRESSION,         //CC_WaitForExpression
 	};
 
 	static const UINT NUM_LABELS = 26;
@@ -4692,6 +4718,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT EFFECT_L[NUM_LABELS] =       { TAG_SOUNDEFFECTLABEL, 0 };
 	static const UINT MAP_L[NUM_LABELS] =          { TAG_ROOMREVEALLABEL, 0 };
 	static const UINT STAT_L[NUM_LABELS] =         { TAG_VALUE_OR_EXPRESSION, 0 };
+	static const UINT EXPRESSION_L[NUM_LABELS] =   { TAG_VARVALUELABEL, 0 };
 
 	static const UINT* activeLabels[CCharacterCommand::CC_Count] = {
 		NO_LABELS,
@@ -4767,6 +4794,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_SetMovementType
 		NO_LABELS,          //CC_ReplaceWithDefault
 		VARSET_L,           //CC_VarSetAt
+		EXPRESSION_L,       //CC_WaitForExpression
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -5619,6 +5647,28 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		}
 		break;
 
+		case CCharacterCommand::CC_WaitForExpression:
+		{
+			CTextBoxWidget* pAmount = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_VARVALUE));
+			ASSERT(pAmount);
+			const WCHAR* pAmountText = pAmount->GetText();
+			ASSERT(pAmountText);
+
+			this->pCommand->x = _Wtoi(pAmountText);
+			this->pCommand->y = this->pVarCompListBox2->GetSelectedItem();
+
+			this->pCommand->label;
+
+			CTextBoxWidget* pExpressionText = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_GOTOLABELTEXT));
+			ASSERT(pExpressionText);
+			this->pCommand->label = pExpressionText->GetText();
+
+			AddCommand();
+		}
+		break;
+
 		case CCharacterCommand::CC_SetPlayerAppearance:
 		case CCharacterCommand::CC_SetNPCAppearance:
 			this->pCommand->x = this->pPlayerGraphicListBox->GetSelectedItem();
@@ -5981,6 +6031,21 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 					pVarOperand->SetText(_itoW(this->pCommand->w, temp, 10));
 				pVarText->SetText(wszEmpty);
 			}
+		}
+		break;
+
+		case CCharacterCommand::CC_WaitForExpression:
+		{
+			CTextBoxWidget* pAmount = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_VARVALUE));
+			ASSERT(pAmount);
+			pAmount->SetText(_itoW(this->pCommand->x, temp, 10));
+
+			this->pVarCompListBox2->SelectItem(this->pCommand->y);
+
+			CTextBoxWidget* pExpression = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_GOTOLABELTEXT));
+			pExpression->SetText(this->pCommand->label.c_str());
 		}
 		break;
 
@@ -6743,6 +6808,59 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 	}
 	break;
 
+	case CCharacterCommand::CC_WaitForExpression:
+	{
+		parseChar('"');
+		WSTRING expression;
+		const bool bRes = getTextToLastQuote(pText, pos, expression);
+
+		if (!bRes)
+		{
+			delete pCommand;
+			return NULL;
+		}
+
+		pCommand->label = expression;
+		skipWhitespace;
+
+		const char varOperator = char(WCv(pText[pos]));
+		++pos;
+		const char varOperator2 = pos < textLength ? char(WCv(pText[pos])) : 0;
+		switch (varOperator)
+		{
+			default: //robust default for bad operator char
+			case '=': pCommand->y = ScriptVars::Equals; break;
+			case '>':
+				if (varOperator2 == '=') {
+					pCommand->y = ScriptVars::GreaterThanOrEqual;
+					++pos;
+				}
+				else {
+					pCommand->y = ScriptVars::Greater;
+				}
+			break;
+			case '<':
+				if (varOperator2 == '=') {
+					pCommand->y = ScriptVars::LessThanOrEqual;
+					++pos;
+				}
+				else {
+					pCommand->y = ScriptVars::Less;
+				}
+			break;
+			case '!':
+				if (varOperator2 == '=') {
+					pCommand->y = ScriptVars::Inequal;
+					++pos;
+				}
+			break;
+		}
+
+		skipWhitespace;
+		parseNumber(pCommand->x);
+	}
+	break;
+
 	case CCharacterCommand::CC_WaitForVar:
 	{
 		//Var name is all text between outermost quotes.
@@ -7200,7 +7318,19 @@ WSTRING CCharacterDialogWidget::toText(
 		}
 	}
 	break;
-	
+
+	case CCharacterCommand::CC_WaitForExpression:
+	{
+		wstr += wszQuote;
+		wstr += c.label.c_str();
+		wstr += wszQuote;
+		wstr += wszSpace;
+		AddOperatorSymbol(wstr, c.y);
+		wstr += wszSpace;
+		concatNum(c.x);
+	}
+	break;
+
 	case CCharacterCommand::CC_WaitForVar:
 	{
 		const WCHAR *wszVarName = this->pVarListBox->GetTextForKey(c.x);

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -3895,10 +3895,10 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForVar, g_pTheDB->GetMessageText(MID_WaitForVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForExpression, g_pTheDB->GetMessageText(MID_WaitForExpression));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForNotRect, g_pTheDB->GetMessageText(MID_WaitWhileEntity));
-	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitAnd, L"Logical And");
-	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitOr, L"Logical Or");
-	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitXOR, L"Logical Xor");
-	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitEnd, L"Logical End");
+	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitAnd, g_pTheDB->GetMessageText(MID_LogicalWaitAnd));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitOr, g_pTheDB->GetMessageText(MID_LogicalWaitOr));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitXOR, g_pTheDB->GetMessageText(MID_LogicalWaitXOR));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitEnd, g_pTheDB->GetMessageText(MID_LogicalWaitEnd));
 	this->pActionListBox->SelectLine(0);
 	this->pActionListBox->SetAllowFiltering(true);
 }

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -3868,7 +3868,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 //	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForNoBuilding, g_pTheDB->GetMessageText(MID_WaitForNoBuilding));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForTurn, g_pTheDB->GetMessageText(MID_WaitForTurn));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForVar, g_pTheDB->GetMessageText(MID_WaitForVar));
-	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForExpression, L"Wait until expression");
+	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForExpression, g_pTheDB->GetMessageText(MID_WaitForExpression));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForNotRect, g_pTheDB->GetMessageText(MID_WaitWhileEntity));
 	this->pActionListBox->SelectLine(0);
 	this->pActionListBox->SetAllowFiltering(true);

--- a/drodrpg/DROD/CharacterDialogWidget.h
+++ b/drodrpg/DROD/CharacterDialogWidget.h
@@ -181,7 +181,7 @@ private:
 	CListBoxWidget *pGotoLabelListBox;
 	CListBoxWidget *pMusicListBox;
 	CListBoxWidget *pVarListBox, *pVarOpListBox, *pVarCompListBox, *pWaitFlagsListBox,
-			*pImperativeListBox, *pBuildItemsListBox, *pBehaviorListBox;
+			*pImperativeListBox, *pBuildItemsListBox, *pBehaviorListBox, *pVarCompListBox2;
 	CListBoxWidget *pEquipmentTypesListBox, *pCustomNPCListBox, *pEquipTransListBox;
 	CTextBoxWidget *pCharNameText;
 	CListBoxWidget *pCharListBox;

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3146,6 +3146,14 @@ void CCharacter::Process(
 				bProcessNextCommand = true;
 			}
 			break;
+			case CCharacterCommand::CC_WaitForExpression:
+			{
+				if (!IsExpressionSatisfied(command, pGame))
+					STOP_COMMAND;
+
+				bProcessNextCommand = true;
+			}
+			break;
 
 			case CCharacterCommand::CC_SetPlayerAppearance:
 			{
@@ -3627,6 +3635,32 @@ bool CCharacter::DoesVarSatisfy(const CCharacterCommand& command, CCurrentGame* 
 		}
 		break;
 		default: break;
+	}
+	ASSERT(!"Unrecognized var operator");
+	return false;
+}
+
+//*****************************************************************************
+bool CCharacter::IsExpressionSatisfied(const CCharacterCommand& command, CCurrentGame* pGame)
+{
+	int constant = (int)command.x;
+	//operand is an expression
+	UINT index = 0;
+	int operand = parseExpression(command.label.c_str(), index, pGame, this);
+
+	switch (command.y)
+	{
+		case ScriptVars::Equals: return operand == constant;
+		case ScriptVars::Greater: return operand > constant;
+		case ScriptVars::GreaterThanOrEqual: return operand >= constant;
+		case ScriptVars::Less: return operand < constant;
+		case ScriptVars::LessThanOrEqual: return operand <= constant;
+		case ScriptVars::Inequal: return operand != constant;
+		case ScriptVars::EqualsText:
+		{
+			ASSERT(!"Unsupported var operator for expression");
+			return false;
+		}
 	}
 	ASSERT(!"Unrecognized var operator");
 	return false;

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -85,6 +85,13 @@ public:
 	virtual bool   DoesSquareContainObstacle(const UINT wCol, const UINT wRow) const;
 	bool DoesVarSatisfy(const CCharacterCommand& command, CCurrentGame* pGame);
 
+	bool EvaluateConditionalCommand(
+		const CCharacterCommand& command, CCurrentGame* pGame, const int nLastCommand, CCueEvents& CueEvents);
+	bool EvaluateLogicalAnd(
+		UINT wCommandIndex, CCurrentGame* pGame, const int nLastCommand, CCueEvents& CueEvents);
+	bool EvaluateLogicalOr(UINT wCommandIndex, CCurrentGame* pGame, const int nLastCommand, CCueEvents& CueEvents);
+	bool EvaluateLogicalXOR(UINT wCommandIndex, CCurrentGame* pGame, const int nLastCommand, CCueEvents& CueEvents);
+
 	void   ExportText(CDbRefs &dbRefs, CStretchyBuffer& str);
 	static string ExportXMLSpeech(CDbRefs &dbRefs, const COMMAND_VECTOR& commands, const bool bRef=false);
 	MESSAGE_ID ImportSpeech(CImportInfo &info);
@@ -217,6 +224,7 @@ private:
 	int  GetIndexOfCommandWithLabel(const int label) const;
 	int  GetIndexOfPreviousIf(const bool bIgnoreElseIf) const;
 	int  GetIndexOfNextElse(const bool bIgnoreElseIf) const;
+	int  GetIndexOfNextLogicEnd(const UINT wStartIndex) const;
 	bool HasUnansweredQuestion(CCueEvents &CueEvents) const;
 	bool IsExpressionSatisfied(const CCharacterCommand& command, CCurrentGame* pGame);
 	void MoveCharacter(const int dx, const int dy, const bool bFaceDirection,

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -212,6 +212,7 @@ private:
 	int  GetIndexOfPreviousIf(const bool bIgnoreElseIf) const;
 	int  GetIndexOfNextElse(const bool bIgnoreElseIf) const;
 	bool HasUnansweredQuestion(CCueEvents &CueEvents) const;
+	bool IsExpressionSatisfied(const CCharacterCommand& command, CCurrentGame* pGame);
 	void MoveCharacter(const int dx, const int dy, const bool bFaceDirection,
 			CCueEvents& CueEvents);
 	void TeleportCharacter(const UINT wDestX, const UINT wDestY, CCueEvents& CueEvents);

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -57,6 +57,7 @@ using std::vector;
 
 #define DefaultCustomCharacterName wszEmpty
 
+class CSwordsman;
 struct HoldCharacter;
 class CDbHold;
 class CCharacter : public CPlayerDouble
@@ -80,6 +81,7 @@ public:
 	void           CheckForCueEvent(CCueEvents &CueEvents);
 	virtual bool   CheckForDamage(CCueEvents& CueEvents);
 	void           Defeat();
+	bool           DidPlayerMove(const CCharacterCommand& command, const CSwordsman& player, const int nLastCommand) const;
 	virtual bool   DoesSquareContainObstacle(const UINT wCol, const UINT wRow) const;
 	bool DoesVarSatisfy(const CCharacterCommand& command, CCurrentGame* pGame);
 
@@ -123,16 +125,20 @@ public:
 	virtual bool   IsAggressive() const {return false;}
 	virtual bool   IsCombatable() const;
 	virtual bool   IsDamageableAt(const UINT wX, const UINT wY) const;
+	bool           IsDoorStateAt(const CCharacterCommand& command, const CDbRoom& room) const;
+	bool           IsEntityAt(const CCharacterCommand& command, const CDbRoom& room, const CSwordsman& player) const;
 	virtual bool   IsFriendly() const;
 	bool           IsGhostImage() const {return this->bGhostImage;}
 	bool           IsLuckyGR() const {return this->bLuckyGR;}
 	bool           IsLuckyXP() const {return this->bLuckyXP;}
 	bool           IsMetal() const {return this->bMetal;}
 	virtual bool   IsMissionCritical() const {return this->bMissionCritical;}
+	bool           IsPlayerFacing(const CCharacterCommand& command, const CSwordsman& player) const;
 	bool           IsRestartScriptOnRoomEntrance() const {return this->bRestartScriptOnRoomEntrance;}
 	bool           IsSafeToPlayer() const {return this->bSafeToPlayer;}
 	bool           IsSwordSafeToPlayer() const {return this->bSwordSafeToPlayer;}
 	virtual bool   IsTileObstacle(const UINT wTileNo) const;
+	bool IsValidEntityWait(const CCharacterCommand& command, const CDbRoom& room) const;
 
 	static bool    IsValidExpression(const WCHAR *pwStr, UINT& index, CDbHold *pHold, const char closingChar=0);
 	static bool    IsValidTerm(const WCHAR *pwStr, UINT& index, CDbHold *pHold);

--- a/drodrpg/DRODLib/CharacterCommand.cpp
+++ b/drodrpg/DRODLib/CharacterCommand.cpp
@@ -79,6 +79,31 @@ bool CCharacterCommand::IsRealEquipmentType(ScriptFlag::EquipmentType type)
 	return false;
 }
 
+bool CCharacterCommand::IsLogicalWaitCondition() const {
+	switch (command) {
+	case CC_WaitForCueEvent:
+	case CC_WaitForRect:
+	case CC_WaitForNotRect:
+	case CC_WaitForDoorTo:
+	case CC_WaitForTurn:
+	case CC_WaitForCleanRoom:
+	case CC_WaitForPlayerToFace:
+	case CC_WaitForVar:
+	case CC_SetPlayerAppearance:
+	case CC_WaitForNoBuilding:
+	case CC_WaitForPlayerToMove:
+	case CC_WaitForPlayerToTouchMe:
+	case CC_WaitForDefeat:
+	case CC_WaitForItem:
+	case CC_WaitForOpenMove:
+	case CC_SetMovementType:
+	case CC_WaitForExpression:
+		return true;
+	default:
+		return false;
+	}
+}
+
 //*****************************************************************************
 bool addWithClamp(int& val, const int operand)
 //Multiplies two integers, ensuring the product doesn't overflow.

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -267,6 +267,10 @@ public:
 		CC_ReplaceWithDefault,  //Replaces the character's script with its default script (if possible)
 		CC_VarSetAt,            //Remotely set local variable w (with operation h) of NPC at (x,y) to value in flags
 		CC_WaitForExpression,   //Wait until the expression in string (operation Y) X, e.g. _MyX - _X < 5. Only numeric comparisons are possible.
+		CC_LogicalWaitAnd,      //Begins a logical wait block. Waits until all conditions are true.
+		CC_LogicalWaitOr,       //Begins a logical wait block. Waits until at least one condition is true.
+		CC_LogicalWaitXOR,      //Begins a logical wait block. Waits until exactly one condition is true.
+		CC_LogicalWaitEnd,      //Ends a logical wait block.
 		CC_Count
 	};
 
@@ -277,6 +281,19 @@ public:
 
 	static bool IsEachEventCommand(CharCommand command);
 	static bool IsRealEquipmentType(ScriptFlag::EquipmentType type);
+	bool IsLogicalWaitCommand() const {
+		switch (command) {
+			case CC_LogicalWaitAnd:
+			case CC_LogicalWaitOr:
+			case CC_LogicalWaitXOR:
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	// Can the command be processed in a logical wait block?
+	bool IsLogicalWaitCondition() const;
 };
 
 class CDbMessageText;

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -294,6 +294,12 @@ public:
 
 	// Can the command be processed in a logical wait block?
 	bool IsLogicalWaitCondition() const;
+
+	// For front-end command formatting
+	bool IsAllowedInLogicBlock() const {
+		return command == CC_LogicalWaitEnd ||
+			IsLogicalWaitCommand() || IsLogicalWaitCondition();
+	}
 };
 
 class CDbMessageText;

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -266,6 +266,7 @@ public:
 		CC_SetMovementType,     //Sets the NPC's movement type to X.
 		CC_ReplaceWithDefault,  //Replaces the character's script with its default script (if possible)
 		CC_VarSetAt,            //Remotely set local variable w (with operation h) of NPC at (x,y) to value in flags
+		CC_WaitForExpression,   //Wait until the expression in string (operation Y) X, e.g. _MyX - _X < 5. Only numeric comparisons are possible.
 		CC_Count
 	};
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -736,6 +736,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarSetAt: strText = "Set var at"; break;
 		case MID_EquipGenerate: strText = "Generate"; break;
 		case MID_DamagePreview: strText = "Combat damage preview"; break;
+		case MID_WaitForExpression: strText = "Wait until expression"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -737,6 +737,10 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_EquipGenerate: strText = "Generate"; break;
 		case MID_DamagePreview: strText = "Combat damage preview"; break;
 		case MID_WaitForExpression: strText = "Wait until expression"; break;
+		case MID_LogicalWaitAnd: strText = "Wait for All:"; break;
+		case MID_LogicalWaitOr: strText = "Wait for Any:"; break;
+		case MID_LogicalWaitXOR: strText = "Wait for Exactly One:"; break;
+		case MID_LogicalWaitEnd: strText = "Wait for Conditions End"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -380,6 +380,7 @@ the state of the room and wait indefinitely until certain events occur.</p>
 	  <a href="#move">Move</a> command in that direction.</li>
   <li><a name="waitforitem"><b>Wait for item</b></a> - Wait until the
       specified element is located in the marked room region.</li>
+  <li><a name="logical-wait"><b>Multi-expression Waits</b></a> - Multi-expression wait commands are used to perform an atomic check on multiple conditions, i.e., as a single combined boolean query, which returns a single true or false value. Script execution halts at this point until the multiple conditions are met as specified. The expression block begins with <b>Wait for All</b>, <b>Wait for Any</b> or <b>Wait for Exactly One</b> command, and should end with a <b>Wait for Conditions End</b> command. An <b>All</b> block will wait until all subqueries are true, an <b>Any</b> block will wait until any subquery is true, and an <b>Exactly One</b> block will wait until exactly one subquery is true. Additionally, a multi-expression wait block can be used as a condition for an <a href="#if">if statement</a>. Multi-expression wait blocks can be nested if more complex logic is required. All "Wait for" commands can be used as subqueries, along with the <a href="#role">Set role</a> and <a href="#set-movement">Set movement type</a> commands, which function as they do when used as an if condition.</li>
 </ol>
 
 <p><a name="decision"><b>5.&nbsp;&nbsp;Decision making</b></a> - Use the

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -362,6 +362,7 @@ the state of the room and wait indefinitely until certain events occur.</p>
       until the player bumps into the NPC.</li>
   <li><a name="waitvar"><b>Wait until var</b></a> - Waits until a <a href="#setvar">
       hold variable</a> meets the condition you specify.</li>
+  <li><a name="wait-expression"><b>Wait until expression</b></a> - Waits until a given expression satisfies the condition you specify. In addition to hold variables, expressions can also use <a href="#functions">function primitives</a>. Expressions can only be compared to constant values.</li>
   <li><a name="waitdefeat"><b>Wait for defeat</b></a> - Waits until the
       NPC has been defeated (i.e. its HP has been reduced to zero).
 	  This must be used in conjunction with

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1491,6 +1491,7 @@ enum MID_CONSTANT {
   MID_VarSetAt = 1807,
   MID_EquipGenerate = 1808,
   MID_DamagePreview = 1809,
+  MID_WaitForExpression = 1810,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1492,6 +1492,10 @@ enum MID_CONSTANT {
   MID_EquipGenerate = 1808,
   MID_DamagePreview = 1809,
   MID_WaitForExpression = 1810,
+  MID_LogicalWaitAnd = 1811,
+  MID_LogicalWaitOr = 1812,
+  MID_LogicalWaitXOR = 1813,
+  MID_LogicalWaitEnd = 1814,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1303,3 +1303,19 @@ Generate
 [MID_WaitForExpression]
 [eng]
 Wait until expression
+
+[MID_LogicalWaitAnd]
+[eng]
+"Wait for All:
+
+[MID_LogicalWaitOr]
+[eng]
+Wait for Any:
+
+[MID_LogicalWaitXOR]
+[eng]
+Wait for Exactly One:
+
+[MID_LogicalWaitEnd]
+[eng]
+Wait for Conditions End

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1299,3 +1299,7 @@ Set var at
 [MID_EquipGenerate]
 [eng]
 Generate
+
+[MID_WaitForExpression]
+[eng]
+Wait until expression


### PR DESCRIPTION
A script command that halts execution until a given expression statisfies a comparsion to a constant value. This is useful because `Wait until var` doesn't really support that.

Additionally, adds support for complex conditional commands. See #433 for more details.