### PR TITLE
Track all image overlay turn counts with player turns

### DIFF
--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -612,7 +612,7 @@ void CImageOverlayEffect::StartNextCommand()
 	case ImageOverlayCommand::TurnDuration:
 	{
 		const CDbRoom* pRoom = this->pRoomWidget->GetRoom();
-		const UINT gameTurn = pRoom ? pRoom->GetCurrentGame()->wTurnNo : 0;
+		const UINT gameTurn = pRoom ? pRoom->GetCurrentGame()->wPlayerTurn : 0;
 		this->executionState.endTurn = gameTurn + max(0, val);
 	}
 	break;


### PR DESCRIPTION
Image overlays using `DisplayTurns` use the player turn to decide when to end. However, the end turn is set based on the total turn number. Game actions that cause the turn numbers to diverge will extend the duration of image overlays incorrectly. This is a regression introduced by #228.

To fix this issue, image overlays should do all turn tracking based on the player turn.

Related thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45702