### PR TITLE
Fix problems with squad horns on room edges

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3685,7 +3685,7 @@ bool CDbRoom::GetNearestEntranceTo(const UINT wX, const UINT wY, const MovementT
 	{
 		const SORTPOINT& p = *it;
 		if (GetMonsterAtSquare(p.wX, p.wY) != NULL || IsMonsterSwordAt(p.wX, p.wY)
-				|| this->pCurrentGame->IsPlayerWeaponAt(p.wX, p.wY))
+				|| this->pCurrentGame->IsPlayerWeaponAt(p.wX, p.wY) || this->pCurrentGame->IsPlayerAt(p.wX, p.wY))
 			continue;
 		wEX = p.wX;
 		wEY = p.wY;

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3685,7 +3685,8 @@ bool CDbRoom::GetNearestEntranceTo(const UINT wX, const UINT wY, const MovementT
 	{
 		const SORTPOINT& p = *it;
 		if (GetMonsterAtSquare(p.wX, p.wY) != NULL || IsMonsterSwordAt(p.wX, p.wY)
-				|| this->pCurrentGame->IsPlayerWeaponAt(p.wX, p.wY) || this->pCurrentGame->IsPlayerAt(p.wX, p.wY))
+				|| this->pCurrentGame->IsPlayerWeaponAt(p.wX, p.wY) || this->pCurrentGame->IsPlayerAt(p.wX, p.wY)
+				|| bIsPotion(this->GetTSquare(p.wX, p.wY)))
 			continue;
 		wEX = p.wX;
 		wEY = p.wY;


### PR DESCRIPTION
If a squad horn is on the edge of a room, unusual things can happen. It can be activated by a clone summoned by another clone, and this activation can cause a monster to be placed on the player. See the thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45709

Two fixes in `CDbRoom::GetNearestEntranceTo`:

1. Recognise room edge tiles occupied by the player as blocked
2. Consider room edge tiles occupied by horns and potions to be blocked. This is inline with how potions can't be used to place things on horns or potions, and avoids issues with "horn chains" and remote potion consumption. This can be backed out of the other behaviour is preferred.