### PR TITLE
Fix CC_LogicalWaitXOR case in CCharacter::EvaluateLogicalOr

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4813,7 +4813,7 @@ bool CCharacter::EvaluateLogicalOr(
 				case CCharacterCommand::CC_LogicalWaitXOR:
 				{
 					if (EvaluateLogicalXOR(wCommandIndex, pGame, nLastCommand, CueEvents))
-						return false;
+						return true;
 				}
 				break;
 			}


### PR DESCRIPTION
`CCharacter::EvaluateLogicalOr()` incorrectly returns `false` when in the case where a nested XOR condition is true. This leads to the Or condition incorrectly evaluating to `false` when it should evaluate to `true`.

To fix, the return value for this case has been corrected.