### PR TITLE
Fix importing of non-compressed data in CDbXML

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1958,6 +1958,10 @@ void CDbXML::Import_TallyRecords(
 			}
 
 			pBuffer->totalParseSize += pBuffer->uncompressedSize; //sum during first data pass
+		} else if (bImportComplete) {
+			//we aren't decompressing data and we hit an end tag
+			//therefore, we must not have anything else to parse
+			break;
 		}
 	}
 }
@@ -2023,6 +2027,10 @@ void CDbXML::Import_ParseRecords(
 				info.ImportStatus = mid;
 				break;
 			}
+		} else if (bImportComplete) {
+			//we aren't decompressing data and we hit an end tag
+			//therefore, we must not have anything else to parse
+			break;
 		}
 	}
 


### PR DESCRIPTION
PR #243 reduces the memory use during hold imports by decompressing the data in chunks rather than decompressing all imported data in one go. Unfortunately, this change breaks the re-importing of saved games and demos.

When a buffer created from non-compressed data is passed into `Import_TallyRecords` or `Import_ParseRecords`, the function will hang, and possibly crash. If this happens during a hold import, any existing save and demo data for the hold will be destroyed. This is because the exit condition for the loop requires the decompression stream to exist. If a buffer has no decompression stream, the buffer containing uncompressed data will never become empty. This means the loop will keep copying the already parsed data from the import buffer into the xml parser. As this results in a non-zero number of bytes being copied, the loop will never exit. As a side effect, drod.err is filled with errors produced by the xml parser, as it continually tries to continue parsing at the end of the file and fails. (even if the loop somehow breaks, tens of thousands of lines can be written this way)

To fix this issue, the loop should break in the case where `ImportBuffer::d_stream` is null and `bImportComplete` is true.

Related thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45694