### PR TITLE
Fix disarmed custom graphics for weapon-having NPCs

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -7816,7 +7816,7 @@ void CRoomWidget::DrawCharacter(
 	UINT wSX, wSY;
 	const bool bHasSword = pCharacter->GetSwordCoords(wSX, wSY);
 	UINT wFrame;
-	if (bHasSword || !bEntityHasSword(wIdentity)) {
+	if (bHasSword || (!bEntityHasSword(wIdentity) && pCharacter->bNoWeapon)) {
 		wFrame = this->pTileImages[this->pRoom->ARRAYINDEX(pCharacter->wX, pCharacter->wY)].animFrame;
 		if (!IsMonsterTypeAnimated(wIdentity))
 			wFrame = wFrame % ANIMATION_FRAMES;

--- a/Data/Help/1/character.html
+++ b/Data/Help/1/character.html
@@ -46,7 +46,7 @@ wielding swords.
 The <u>fourth</u> row, when included, stores custom images for a sword-wielding
 character when they are not currently wielding a sword.
 The <u>fifth</u> and <u>sixth</u> rows are for displaying wading in shallow water,
-with and without wielding a weapon, respectively.
+without a weapon and wielding a weapon, respectively.
 If the third and subsequent rows are not included, then tiles from the first
 row are displayed in their place.  If the type set is an entity without a sword,
 the third, fourth and sixth rows are ignored.<br />


### PR DESCRIPTION
There are some problems with custom graphics for NPCs when the NPC has a weapon:

1. If the NPC's base type is not a weapon weilding monster, it will not be drawn in the disarmed state when its weapon is surpressed. This can look bad. To fix, a small tweak has been made to character drawing to check if the NPC has a weapon, not just if the NPC base type is an armed monster.
2. The help content incorrectly describes the use of the fifth and sixth row of graphics. It says that the fifth row is for armed wading, and the sixth is for unarmed wading. This error has been corrected.

Aiming this at 5.1.1 branch since it's a minor graphical issue that can be scooped up with more major issues that need handling.