### PR TITLE
Initialize invisible character inspectability to false

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -169,6 +169,8 @@ CCharacter::CCharacter(
 	, bStunnable(true)
 	, bBrainPathmapObstacle(false), bNPCPathmapObstacle(true)
 	, bWeaponOverride(false)
+	, bInvisibleInspectable(false)
+	, bInvisibleCountsMoveOrder(false)
 	, bFriendly(true)
 	, movementIQ(SmartOmniDirection)
 	, worldMapID(0)


### PR DESCRIPTION
With the introduction of new imperatives, invisible characters can be detected by right clicking. However, `bInvisibleInspectable` and `bInvisibleCountsMoveOrder` are not set in CCharacter's constructor, and they end up being true by default.

This would cause confusion, so I have updated the constructor so they are false by default.