### PR TITLE
Don't mark killed invisible NPCs as dead

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3279,7 +3279,8 @@ void CDbRoom::KillInvisibleCharacter(
 	UnlinkMonster(pCharacter);
 	this->DeadMonsters.push_back(pCharacter);
 
-	pCharacter->bAlive = false;
+	// The character is not marked as dead, as this will cause issues if they are
+	// a speaker for upcoming speech.
 }
 
 //*****************************************************************************


### PR DESCRIPTION
As part of memory improvements (#156), invisible NPCs are killed when their script runs an end command. However, marking them as dead means they are no longer valid speakers, leading to any speech they would speak being skipped. This is a regression, as previously invisible NPCs would be able to talk, even if their script had ended.

To fix this, I changed the `KillInvisibleCharacter` function to not mark the killed NPC as dead. It is still moved to the dead monsters list, meaning it will no longer be processed, but it will retain its ability to be a speaker.

See thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45732