### PR TITLE
Consolidate weather constants

### DIFF
--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -50,10 +50,10 @@
 #include <BackEndLib/Types.h>
 
 //Range of weather parameters.
-#define LIGHT_LEVELS (7) //number of light levels
-#define FOG_INCREMENTS (4)
-#define SNOW_INCREMENTS (10)
-#define RAIN_INCREMENTS (20)
+#define LIGHT_LEVELS (MAX_ROOM_LIGHT + 1) //number of light levels
+#define FOG_INCREMENTS (MAX_ROOM_FOG + 1)
+#define SNOW_INCREMENTS (MAX_ROOM_SNOW + 1)
+#define RAIN_INCREMENTS (MAX_ROOM_RAIN + 1)
 extern const float fRoomLightLevel[LIGHT_LEVELS];
 extern const float lightMap[3][NUM_LIGHT_TYPES];
 extern const float darkMap[NUM_DARK_TYPES];

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -68,12 +68,6 @@
 
 #define NO_CHECKPOINT (static_cast<UINT>(-1))
 
-//Max weather values. One less than defines in DROD/RoomWidget.h
-#define MAX_ROOM_LIGHT (6)
-#define MAX_ROOM_FOG (3)
-#define MAX_ROOM_SNOW (9)
-#define MAX_ROOM_RAIN (19)
-
 queue<DEMO_UPLOAD*> CCurrentGame::demosForUpload;
 
 //Game character/monster constant that speaker refers to

--- a/DRODLib/GameConstants.h
+++ b/DRODLib/GameConstants.h
@@ -151,6 +151,12 @@ static const UINT SE = 8;
 static const UINT NO_ORIENTATION = 4;
 static const UINT ORIENTATION_COUNT = 9;
 
+//Max weather values.
+#define MAX_ROOM_LIGHT (6)
+#define MAX_ROOM_FOG (3)
+#define MAX_ROOM_SNOW (9)
+#define MAX_ROOM_RAIN (19)
+
 //******************************************************************************************
 namespace InputCommands
 {


### PR DESCRIPTION
Moves the values for weather definitions currently in `CurrentGame.cpp` into `GameConstants.h` and updates the definitions in `RoomWidget.h` to be based on the game constant versions.