### PR TITLE
Fix definition of DMASK_SEMI

### DIFF
--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -439,7 +439,7 @@ const
 	{
 		const SQUARE square = this->pCurrentGame->pRoom->pPathMap[this->eMovement]->
 				GetSquare(this->wX, this->wY);
-		if (square.eBlockedDirections != DMASK_ALL && square.dwTargetDist > 2 &&
+		if ((square.eBlockedDirections & DMASK_ALL) != DMASK_ALL && square.dwTargetDist > 2 &&
 				square.dwTargetDist != static_cast<UINT>(-1))
 		{
 			//Brain-directed "avoid-sword movement".

--- a/DRODLib/Pathmap.h
+++ b/DRODLib/Pathmap.h
@@ -58,7 +58,7 @@
 #define DMASK_SW   0x20
 #define DMASK_W    0x40
 #define DMASK_NW   0x80
-#define DMASK_SEMI 0x16
+#define DMASK_SEMI 0x100
 #define DMASK_ALL  0xff
 
 //Path map square that contains only information needed for determining paths.


### PR DESCRIPTION
The value of `DMASK_SEMI` is currently defined as `0x16`. This means it's actually a combination of bits that can be achieved by combining other pathmap mask values. This can cause pathing breaks.

To fix this, it is now defined as `0x100`, which cannot be created by any combination of other pathmap mask values.

A small change in `CMonster::DistanceToTarget` is also needed due to this change. The blocked directions value is now put through a bitwise and with `DMASK_ALL` before being compared to `DMASK_ALL`, to remove any values outside of the expected comparison range. More simply, it purges the bit indicating semi-obstacles, so that it does not interfere with the comparison.