### PR TITLE
Rework of Brained Construct Pathing

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2337,7 +2337,8 @@ void CDbRoom::CreatePathMap(
 		if (eMovement == WALL || eMovement == WATER) //allow for non-wall/water
 			dwPathThroughObstacleCost = 1000;         //squares to be in the path
 		this->pPathMap[eMovement] = new CPathMap(this->wRoomCols, this->wRoomRows,
-				wX, wY, dwPathThroughObstacleCost, bMovementSupportsPartialObstacles(eMovement));
+				wX, wY, dwPathThroughObstacleCost, bMovementSupportsPartialObstacles(eMovement),
+				bMovementNeedsSubPath(eMovement));
 	}
 	else
 		this->pPathMap[eMovement]->SetTarget(wX, wY);

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -2037,6 +2037,15 @@ const
 }
 
 //*****************************************************************************
+bool CMonster::CanWadeInShallowWater() const
+//Returns: If this monster can move onto shallow water tiles
+{
+	return this->eMovement == GROUND_AND_SHALLOW_WATER ||
+		this->eMovement == GROUND_AND_SHALLOW_WATER_FORCE ||
+		this->eMovement == GROUND_AND_SHALLOW_WATER_NO_OREMITES;
+}
+
+//*****************************************************************************
 bool CMonster::OnAnswer(
 //Overridable method for responding to an answer given by player to a question asked by the
 //monster.

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -164,6 +164,15 @@ static inline MovementType GetHornMovementType(MovementType movement)
 	}
 }
 
+static inline bool bMovementNeedsSubPath(MovementType movement) {
+	switch (movement) {
+		case GROUND_AND_SHALLOW_WATER_NO_OREMITES:
+			return true;
+		default:
+			return false;
+	}
+}
+
 //******************************************************************************************
 //method used herein should be public
 #define IMPLEMENT_CLONE(CBase, CDerived) virtual CBase* Clone() const \

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -245,7 +245,7 @@ public:
 	virtual bool  CanPushMonsters() const { return CanPushObjects(); }
 	virtual bool  CanPressPressurePlates() const { return !this->IsFlying(); }
 	virtual bool  CanSmellObjectAt(const UINT wX, const UINT wY) const;
-	virtual bool  CanWadeInShallowWater() const { return this->eMovement == GROUND_AND_SHALLOW_WATER; }
+	virtual bool  CanWadeInShallowWater() const;
 	virtual bool  CheckForDamage(CCueEvents& CueEvents);
 	void          Clear();
 	bool          ConfirmPath();

--- a/DRODLib/PathMap.cpp
+++ b/DRODLib/PathMap.cpp
@@ -336,7 +336,7 @@ void CPathMap::SetSquare(
 
 	if (this->subPath) {
 		this->subPath->SetSquare(
-			wX, wY, eBlockedDirections == DMASK_SEMI ? DMASK_NONE : eBlockedDirections);
+			wX, wY, eBlockedDirections & DMASK_ALL);
 	}
 }
 

--- a/DRODLib/PathMap.cpp
+++ b/DRODLib/PathMap.cpp
@@ -146,9 +146,11 @@ void CPathMap::CalcPaths()
 						//then leave it, but on re-entering an obstacle, the path cost
 						//will be set as though it never left the obstacle.
 						dwScore = (coord.wMoves+1) * (this->dwPathThroughObstacleCost + 1);
-				} else if (bIsSemiObstacle && parent_square.eBlockedDirections != DMASK_SEMI) {
+				} else if (bIsSemiObstacle) {
 					//Penalize moving into "semi-obstacle" area
-					dwScore += 1000;
+					ASSERT(this->subPath);
+					const SQUARE& refSquare = this->subPath->GetSquare(wNewX, wNewY);
+					dwScore = refSquare.dwTargetDist * 1000;
 				}
 				if (dwScore < square.dwTargetDist)
 				{

--- a/DRODLib/Pathmap.h
+++ b/DRODLib/Pathmap.h
@@ -98,12 +98,14 @@ public:
 	CPathMap(const UINT wCols, const UINT wRows,
 			const UINT xTarget=(UINT)-1, const UINT yTarget=(UINT)-1,
 			const UINT dwPathThroughObstacleCost=(UINT)-1,
-			const bool bSupportPartialObstacles=false);
+			const bool bSupportPartialObstacles=false,
+			const bool bMakeSubPath=false);
 	CPathMap(const CPathMap &Src) {SetMembers(Src);}
 	CPathMap &operator= (const CPathMap &Src) {
 		SetMembers(Src);
 		return *this;
 	}
+	~CPathMap();
 
 	void CalcPaths();
 	void GetDebugOutput(bool bShowDirection, bool bShowState, bool bShowDistance,
@@ -137,6 +139,10 @@ private:
 	//Support force arrows, orthosquares, etc. If false (default), these are
 	//treated as full obstacles.
 	bool bSupportPartialObstacles;
+
+	//Optional sub path to calculate secondary path values
+	//Currently only used for semi-obstacle scoring
+	CPathMap* subPath = NULL;
 };
 
 #endif //...#ifndef PATHMAP_H

--- a/DRODLibTests/src/tests/Monsters/Construct/BrainedConstruct.cpp
+++ b/DRODLibTests/src/tests/Monsters/Construct/BrainedConstruct.cpp
@@ -30,4 +30,29 @@ TEST_CASE("Brained Construct", "[game][construct][brain]") {
 		//Should move along non-oremite path
 		AssertMonsterType(5, 10, M_CONSTRUCT);
 	}
+
+	SECTION("Test Construct pathing with multiple oremite paths") {
+		RoomBuilder::PlotRect(T_WALL, 5, 5, 11, 11);
+		RoomBuilder::PlotRect(T_FLOOR, 7, 7, 9, 7);
+		RoomBuilder::PlotRect(T_FLOOR, 9, 7, 9, 9);
+		RoomBuilder::Plot(T_GOO, 5, 8);
+		RoomBuilder::Plot(T_FLOOR, 6, 8);
+		RoomBuilder::Plot(T_GOO, 8, 11);
+		RoomBuilder::Plot(T_FLOOR, 8, 10);
+
+		RoomBuilder::AddMonster(M_CONSTRUCT, 8, 8);
+		RoomBuilder::AddMonster(M_BRAIN, 1, 1);
+
+		CCurrentGame* game = Runner::StartGame(4, 11, E);
+		Runner::ExecuteCommand(CMD_WAIT, 3);
+
+		//Should move near oremites closest to player.
+		AssertMonsterType(6, 8, M_CONSTRUCT);
+
+		Runner::ExecuteCommand(CMD_SE);
+		Runner::ExecuteCommand(CMD_WAIT, 4);
+
+		//Should move near oremites closest to player.
+		AssertMonsterType(8, 10, M_CONSTRUCT);
+	}
 }


### PR DESCRIPTION
There was [some discussion](https://forum.caravelgames.com/viewtopic.php?TopicID=44966&page=0#444706) on how Constructs that are brained could act. A proposal is that if no non-oremite paths are available, a Construct will move towards oremites closest to the player. This makes them seem smarter.

Implementing this was a little tricker, as it requires a secondary pathmap which can path over oremites normally to provide scores. When a semi-obstacle tile is encountered, its score is made equal to its score on the sub-pathmap multiplied by 1000.
Due to memory issues, the only way I was able to have the subpath system work was to add an option for a `CPathMap` to own another `CPathMap`, which it can pass tile mask data to, with alterations if required. Since this is only required for one movement type at the moment, the memory and computation overhead is not too much.

There is also a fix, as adding the new movement type in #443 ended up removing Constructs' ability to move over shallow water tiles. By default, wading is now possible for all `GROUND_AND_SHALLOW_WATER` movement variants.