### PR TITLE
RPG: Remove orthosquare highlighting

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -860,19 +860,10 @@ void CRoomWidget::HighlightSelectedTile()
 		break;
 	}
 
+	/* Currently no F-layer highlights
 	switch (this->pRoom->GetFSquare(wX,wY))
 	{
-		case T_NODIAGONAL:
-		{
-			for (UINT wY=this->pRoom->wRoomRows; wY--; )
-				for (UINT wX=this->pRoom->wRoomCols; wX--; )
-					if (this->pRoom->GetFSquare(wX,wY) == T_NODIAGONAL)
-						AddShadeEffect(wX, wY, PaleYellow);
-//			bRemoveHighlightNextTurn = false;
-		}
-		break;
-		default: break;
-	}
+	}*/
 
 	const UINT wOSquare = this->pRoom->GetOSquare(wX,wY);
 	switch (wOSquare)


### PR DESCRIPTION
The feature where all orthosquares in a room are highlighted when an orthosquare is right-clicked isn't considered helpful. It was already removed from mainline DROD. Now it will be removed from DROD RPG.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45775