### PR TITLE
Add shading for relay stations citizen has visited

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1050,6 +1050,10 @@ void CRoomWidget::HighlightSelectedTile()
 						AddShadeEffect(wX, wY, PaleYellow);
 					}
 				}
+				CCoordSet visitedStations = pCitizen->GetVisitedStations();
+				for (auto& visitedStation : visitedStations) {
+					AddShadeEffect(visitedStation.wX, visitedStation.wY, Red);
+				}
 				bRemoveHighlightNextTurn = false;
 			}
 			break;

--- a/DRODLib/Citizen.cpp
+++ b/DRODLib/Citizen.cpp
@@ -173,6 +173,24 @@ bool CCitizen::GetGoal(UINT& wX, UINT& wY) const
 }
 
 //******************************************************************************
+CCoordSet CCitizen::GetVisitedStations() const
+//Call to query which station locations a citizen has visited
+//
+//Returns: set of positions of each station before the current target station
+{
+	CCoordSet visitedStations;
+	CDbRoom& room = *(this->pCurrentGame->pRoom);
+
+	for (int i = 0; i < this->nVisitingStation && i < this->visitingSequence.size(); ++i) {
+		int index = this->visitingSequence[i];
+		CStation* pStation = room.stations[index];
+		visitedStations.insert(pStation->X(), pStation->Y());
+	}
+
+	return visitedStations;
+}
+
+//******************************************************************************
 void CCitizen::Process(
 //Process a citizen for movement.
 //

--- a/DRODLib/Citizen.h
+++ b/DRODLib/Citizen.h
@@ -49,6 +49,7 @@ public:
 	virtual bool DoesSquareContainObstacle(const UINT wCol, const UINT wRow) const;
 	virtual bool IsTileObstacle(const UINT wTileNo) const;
 	bool GetGoal(UINT& wX, UINT& wY) const;
+	CCoordSet GetVisitedStations() const;
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 	inline int StationType() const {return this->nStationType;}
 


### PR DESCRIPTION
Adds additional information when a citizen is clicked - relay stations that it has visited in the current relay cycle are marked with red shading.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=44495