### PR TITLE
RPG: Fix battle preview dialog becoming too large

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -3449,42 +3449,14 @@ void CGameScreen::ShowMonsterStats(CDbRoom *pRoom, CRoomWidget *pRoomWidget)
 	for (std::multimap<UINT, CCoord>::reverse_iterator riter=damageFromMonsters.rbegin();
 			riter!=damageFromMonsters.rend(); ++riter)
 	{
-		//Add monster 2x2 display on left side of dialog, like is done in sidebar monster stats.
 		CMonster *pMonster = pRoom->GetMonsterAtSquare(
 				riter->second.wX, riter->second.wY);
 		ASSERT(pMonster);
 		pMonster = pMonster->GetOwningMonster();
-
-		//Draw monster tiles at current text height.
-		CLabelWidget *pText = DYN_CAST(CLabelWidget*, CWidget*, pStatsDialog->GetWidget(TAG_BATTLETEXT));
-		UINT wTextWidth=0, wTextHeight=0;
-		if (!text.empty()) //determine text height
-			g_pTheFM->GetTextRectHeight(FONTLIB::F_Message,
-					text.c_str(), pText->GetW(), wTextWidth, wTextHeight);
-		float r, g, b;
-		pRoomWidget->TranslateMonsterColor(pMonster->getColor(), r, g, b);
-		UINT tileNo = TI_UNSPECIFIED;
-		for (UINT i=2*2; i--; )
-		{
-			const UINT x = i % 2;
-			const UINT y = i / 2;
-			const bool bCentered = (x==0 && tileNo == TI_UNSPECIFIED);
-			tileNo = GetMonsterDisplayTile(pMonster, x, y);
-			if (tileNo != TI_UNSPECIFIED)
-			{
-				const int xPixel = x * CDrodBitmapManager::CX_TILE +
-						(bCentered ? CDrodBitmapManager::CX_TILE/2 : 0);
-				pTilesWidget->AddTile(tileNo, xPixel,
-						wTextHeight + y * CDrodBitmapManager::CY_TILE, r, g, b);
-			}
-		}
-
-		if (count)
-			text += wszCRLF;
-		text += pRoomWidget->GetMonsterInfo(riter->second.wX, riter->second.wY, true);
+		bool success = AddMonsterStats(pRoom, pRoomWidget, pMonster, text);
 
 		//Show full page of monster stats.
-		if (++count >= MAX_DISPLAY_TYPES)
+		if (++count >= MAX_DISPLAY_TYPES || !success)
 		{
 			ShowBattleDialog(text.c_str());
 			text.resize(0);
@@ -3507,6 +3479,54 @@ void CGameScreen::ShowMonsterStats(CDbRoom *pRoom, CRoomWidget *pRoomWidget)
 //
 //CGameScreen private methods.
 //
+
+//*****************************************************************************
+bool CGameScreen::AddMonsterStats(
+//Add the combat information for a given monster to a string, but only if the
+// resulting string fits within the allowed space.
+//
+//Params:
+	CDbRoom* pRoom, //current room
+	CRoomWidget* pRoomWidget, //the display widget for the room
+	CMonster* pMonster, //monster to display information for
+	WSTRING& text) //string to append to. may be non-empty.
+//
+//Returns: If the text was appended
+{
+	CDialogWidget* pStatsDialog = DYN_CAST(CDialogWidget*, CWidget*, GetWidget(TAG_BATTLEDIALOG));
+	CTilesWidget* pTilesWidget = DYN_CAST(CTilesWidget*, CWidget*, pStatsDialog->GetWidget(TAG_BATTLETILES));
+
+	//Add monster 2x2 display on left side of dialog, like is done in sidebar monster stats.
+	//Draw monster tiles at current text height.
+	CLabelWidget* pText = DYN_CAST(CLabelWidget*, CWidget*, pStatsDialog->GetWidget(TAG_BATTLETEXT));
+	UINT wTextWidth = 0, wTextHeight = 0;
+	if (!text.empty()) //determine text height
+		g_pTheFM->GetTextRectHeight(FONTLIB::F_Message,
+			text.c_str(), pText->GetW(), wTextWidth, wTextHeight);
+	float r, g, b;
+	pRoomWidget->TranslateMonsterColor(pMonster->getColor(), r, g, b);
+	UINT tileNo = TI_UNSPECIFIED;
+	for (UINT i = 2 * 2; i--; )
+	{
+		const UINT x = i % 2;
+		const UINT y = i / 2;
+		const bool bCentered = (x == 0 && tileNo == TI_UNSPECIFIED);
+		tileNo = GetMonsterDisplayTile(pMonster, x, y);
+		if (tileNo != TI_UNSPECIFIED)
+		{
+			const int xPixel = x * CDrodBitmapManager::CX_TILE +
+				(bCentered ? CDrodBitmapManager::CX_TILE / 2 : 0);
+			pTilesWidget->AddTile(tileNo, xPixel,
+				wTextHeight + y * CDrodBitmapManager::CY_TILE, r, g, b);
+		}
+	}
+
+	if (!text.empty())
+		text += wszCRLF;
+	text += pRoomWidget->GetMonsterInfo(pMonster->wX, pMonster->wY, true);
+
+	return true;
+}
 
 //******************************************************************************
 UINT CGameScreen::MarkMapRoom(const UINT roomID)

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -132,6 +132,7 @@ protected:
 
 private:
 	void           AddChatDialog();
+	bool           AddMonsterStats(CDbRoom* pRoom, CRoomWidget* pRoomWidget, CMonster* pMonster, WSTRING& text);
 	void           AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coord, float fDamagePercent=1.0f);
 	void           AddKillEffect(const UINT wMonsterType, const CMoveCoord& coord);
 	void           AmbientSoundSetup();


### PR DESCRIPTION
In some situations, the text for the battle preview dialog can become so long that the resulting dialog becomes larger that the space it is allowed to occupy. With the additional combat information added in 1.2.8, it is now much more likely that this will occur, even when only dealing with four-figure combat damage.
An oversized dialog causes an assert to fire, and also looks bad if the dialog becomes larger than the game window. Reducing the number of entries on the dialog isn't helpful, as characters with sufficently long names can expand the dialog to the point where only one entry can fit.

To fix this, I have refactored `CGameScreen::ShowMonsterStats` by splitting the part that actually gets the monster stats and adds the image to the dialog into a new function, `CGameScreen::AddMonsterStats`. This function checks if the text will become too long before adding a new entry, and will return false if this is the case. `ShowMonsterStats` can then show all the processed entries that will fit, as if the maximum number of entries had been reached.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45778