### PR TITLE
RPG: Add support for custom weaknesses for scripted monsters and equipment

### DIFF
--- a/BackEndLib/Wchar.cpp
+++ b/BackEndLib/Wchar.cpp
@@ -69,6 +69,7 @@ const WCHAR wszSpace[] =        { We(' '),We(0) };
 const WCHAR wszUnderscore[] =   { We('_'),We(0) };
 const WCHAR wszZero[] =         { We('0'),We(0) };
 const WCHAR wszTilde[] =        { We('~'),We(0) };
+const WCHAR wszStringToken[] =  { We('%'),We('s'),We(0) };
 #ifdef WIN32
 const WCHAR wszSlash[] = { We('\\'),We(0) };
 #else

--- a/BackEndLib/Wchar.h
+++ b/BackEndLib/Wchar.h
@@ -83,7 +83,8 @@ extern const WCHAR wszAmpersand[], wszAsterisk[], wszOpenAngle[], wszCloseAngle[
 	wszExclamation[], wszForwardSlash[], wszHyphen[], wszParentDir[],
 	wszPercent[], wszPeriod[], wszPoundSign[], wszPlus[], wszQuestionMark[], wszQuote[],
 	wszLeftBracket[], wszRightBracket[], wszLeftParen[], wszRightParen[],
-	wszSemicolon[], wszSpace[], wszSlash[], wszUnderscore[], wszZero[], wszTilde[];
+	wszSemicolon[], wszSpace[], wszSlash[], wszUnderscore[], wszZero[], wszTilde[],
+	wszStringToken[];
 
 //HTML formatting strings.
 extern const WCHAR wszHtml[], wszEndHtml[], wszBody[], wszEndBody[], wszHeader[],

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4382,6 +4382,7 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_XP_MULT, g_pTheDB->GetMessageText(MID_VarMonsterXPMult));
 
 	this->pVarListBox->AddItem(ScriptVars::P_SCRIPT_MONSTER_SPAWN, g_pTheDB->GetMessageText(MID_VarMySpawn));
+	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_CUSTOM_WEAKNESS, g_pTheDB->GetMessageText(MID_VarMyWeakness));
 
 	this->pVarListBox->AddItem(ScriptVars::P_ITEM_MULT, g_pTheDB->GetMessageText(MID_VarItemMult));
 	this->pVarListBox->AddItem(ScriptVars::P_ITEM_HP_MULT, g_pTheDB->GetMessageText(MID_VarItemHPMult));

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1736,7 +1736,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 	int atk=0, def=0;
 	bool bMetal=false, bBeamBlock=false, bBriar=false, bLuckyGR=false,
 		bAttackFirst=false, bAttackLast=false, bBackstab=false, bNoEnemyDEF=false,
-		bGoblinWeakness=false, bSerpentWeakness=false, bLuckyXP=false;
+		bGoblinWeakness=false, bSerpentWeakness=false, bCustomWeakness=false, bLuckyXP=false;
 
 	CCharacter *pCharacter = NULL; //custom equipment
 	switch (eCommand)
@@ -1754,6 +1754,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 					def = (int)pCharacter->getDEF();
 					bGoblinWeakness = pCharacter->HasGoblinWeakness();
 					bSerpentWeakness = pCharacter->HasSerpentWeakness();
+					bCustomWeakness = pCharacter->HasCustomWeakness();
 				}
 			}
 			bMetal = this->pCurrentGame->IsSwordMetal(st.sword);
@@ -1795,6 +1796,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 					bBeamBlock = pCharacter->HasRayBlocking();
 					bGoblinWeakness = pCharacter->HasGoblinWeakness();
 					bSerpentWeakness = pCharacter->HasSerpentWeakness();
+					bCustomWeakness = pCharacter->HasCustomWeakness();
 				}
 			}
 			bLuckyGR = this->pCurrentGame->IsLuckyGRItem(ScriptFlag::Accessory);
@@ -1854,6 +1856,17 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 		if (bNeedCR)
 			text += wszCRLF;
 		text += g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness);
+		bNeedCR = true;
+	}
+	if (bCustomWeakness)
+	{
+		if (bNeedCR)
+			text += wszCRLF;
+		text += WCSReplace(
+			g_pTheDB->GetMessageText(MID_StrongAgainstAspect),
+			wszStringToken,
+			pCharacter->GetCustomWeakness()
+		);
 		bNeedCR = true;
 	}
 	if (bBeamBlock)

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1690,6 +1690,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 	bool bAttackInFront = pMonster->wType == M_EYE || pMonster->wType == M_MADEYE;
 	bool bAttackInFrontWhenBack = pMonster->wType == M_GOBLIN || pMonster->wType == M_GOBLINKING;
 	bool bSpawnEggs = pMonster->wType == M_QROACH;
+	bool bCustomWeakness = false;
 
 	if (pMonster->wType == M_CHARACTER)
 	{
@@ -1698,6 +1699,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		bAttackInFront |= pCharacter->AttacksInFront();
 		bAttackInFrontWhenBack |= pCharacter->AttacksInFrontWhenBackTurned();
 		bSpawnEggs |= pCharacter->CanSpawnEggs();
+		bCustomWeakness = pCharacter->HasCustomWeakness();
 	}
 
 	if (pMonster->HasRayGun())
@@ -1776,6 +1778,21 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 			wstr += wszSpace;
 		}
 		wstr += g_pTheDB->GetMessageText(MID_RoachQueenAbility);
+		++count;
+	}
+	if (bCustomWeakness) {
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
+		ASSERT(pCharacter);
+		wstr += WCSReplace(
+			g_pTheDB->GetMessageText(MID_CustomAspect),
+			wszStringToken,
+			pCharacter->GetCustomWeakness()
+		);
 		++count;
 	}
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -85,6 +85,7 @@ const UINT MAX_ANSWERS = 9;
 #define ItemGRMultStr "ItemGRMultiplier"
 
 #define SpawnTypeStr "SpawnType"
+#define WeaknessStr "Weakness"
 
 #define TurnDelayStr "TurnDelay"
 #define XRelStr "XRel"
@@ -5385,6 +5386,9 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 
 	//Spawn type
 	this->wSpawnType = vars.GetVar(SpawnTypeStr, this->wSpawnType);
+
+	//Custom weakness
+	this->customWeakness = vars.GetVar(WeaknessStr, this->customWeakness.c_str());
 }
 
 //*****************************************************************************
@@ -5536,6 +5540,10 @@ const
 	// Spawn type
 	if (this->wSpawnType != -1)
 		vars.SetVar(SpawnTypeStr, this->wSpawnType);
+
+	//Custom weakness
+	if (!this->customWeakness.empty())
+		vars.SetVar(WeaknessStr, this->customWeakness.c_str());
 
 	vars.SetVar(scriptIDstr, this->dwScriptID);
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -514,6 +514,8 @@ WSTRING CCharacter::getPredefinedVarString(const UINT varIndex) const
 	{
 		case (UINT)ScriptVars::P_MONSTER_NAME:
 			return this->customName;
+		case (UINT)ScriptVars::P_MONSTER_CUSTOM_WEAKNESS:
+			return this->customWeakness;
 		default:
 			ASSERT(!"getPredefinedStringVar val not supported");
 			return WSTRING();
@@ -873,6 +875,9 @@ void CCharacter::setPredefinedVarString(
 	{
 	case (UINT)ScriptVars::P_MONSTER_NAME:
 		this->customName = val;
+		break;
+	case (UINT)ScriptVars::P_MONSTER_CUSTOM_WEAKNESS:
+		this->customWeakness = val;
 		break;
 	}
 }

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -99,11 +99,13 @@ public:
 
 	void           FailedIfCondition();
 	const CCharacterCommand* GetCommandWithLabel(const UINT label) const;
+	WSTRING        GetCustomWeakness() const { return this->customWeakness; };
 	virtual UINT   GetIdentity() const {return this->wIdentity;}
 	UINT           GetNextSpeechID();
 	virtual UINT   GetResolvedIdentity() const;
 	virtual UINT   GetSpawnType(UINT defaultMonsterID) const;
 	float          GetStatModifier(ScriptVars::StatModifiers statType) const;
+	virtual bool   HasCustomWeakness() const { return !this->customWeakness.empty(); }
 	bool           HasSpecialDeath() const;
 	virtual bool   HasGoblinWeakness() const {return this->bGoblinWeakness;}
 	virtual bool   HasNoEnemyDefense() const {return this->bNoEnemyDEF;}
@@ -313,6 +315,7 @@ private:
 	UINT monsterHPmult, monsterATKmult, monsterDEFmult, monsterGRmult, monsterXPmult; // monster stat modifiers
 	UINT itemMult, itemHPmult, itemATKmult, itemDEFmult, itemGRmult; // item value modifiers
 	int wSpawnType; // type of monster to spawm when spawning eggs
+	WSTRING customWeakness; // matching weakness does strong hit, empty means no custom weakness
 };
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3504,13 +3504,19 @@ bool CCurrentGame::IsSwordStrongAgainst(const CMonster* pMonster) const
 bool CCurrentGame::IsEquipmentStrongAgainst(const CMonster* pMonster, const UINT type) const
 //Returns: whether the player has an item that is strong against this monster
 {
-	CCharacter* pCharacter = getCustomEquipment(type);
-	if (pCharacter)
+	CCharacter* pEquipment = getCustomEquipment(type);
+	if (pEquipment)
 	{
-		if (pMonster->HasGoblinWeakness() && pCharacter->HasGoblinWeakness())
+		if (pMonster->HasGoblinWeakness() && pEquipment->HasGoblinWeakness())
 			return true;
-		if (pMonster->HasSerpentWeakness() && pCharacter->HasSerpentWeakness())
+		if (pMonster->HasSerpentWeakness() && pEquipment->HasSerpentWeakness())
 			return true;
+		if (pMonster->HasCustomWeakness() && pEquipment->HasCustomWeakness()) {
+			const CCharacter* pCharacter = dynamic_cast<const CCharacter*>(pMonster);
+			ASSERT(pCharacter);
+			if (pCharacter->GetCustomWeakness() == pEquipment->GetCustomWeakness())
+				return true;
+		}
 	}
 
 	return false;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -755,7 +755,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_BKEYStatFull: strText = "Blue Keys"; break;
 		case MID_SKEYStatFull: strText = "Skeleton Keys"; break;
 		case MID_VarMyWeakness: strText = "_MyWeakness"; break;
-		case MID_CustomWeakness: strText = "%s weakness"; break;
+		case MID_CustomAspect: strText = "%s aspect"; break;
+		case MID_StrongAgainstAspect: strText = "Strong against %s"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -754,6 +754,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_GKEYStatFull: strText = "Green Keys"; break;
 		case MID_BKEYStatFull: strText = "Blue Keys"; break;
 		case MID_SKEYStatFull: strText = "Skeleton Keys"; break;
+		case MID_VarMyWeakness: strText = "_MyWeakness"; break;
+		case MID_CustomWeakness: strText = "%s weakness"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -211,6 +211,7 @@ public:
 	virtual UINT  getSword() const;
 	virtual int   getXP() const; //may be negative
 
+	virtual bool  HasCustomWeakness() const {return false;}
 	virtual bool  HasGoblinWeakness() const {return false;}
 	virtual bool  HasNoEnemyDefense() const {return false;}
 	virtual bool  HasRayGun() const {return false;}

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -41,7 +41,8 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][13] =
 	"", "", "", "", "",
 	"_MudSpawn", "_TarSpawn", "_GelSpawn", "_QueenSpawn",
 	"", "",
-	"_ScoreHP", "_ScoreATK", "_ScoreDEF", "_ScoreYKEY", "_ScoreGKEY", "_ScoreBKEY", "_ScoreSKEY", "_ScoreGR", "_ScoreXP"
+	"_ScoreHP", "_ScoreATK", "_ScoreDEF", "_ScoreYKEY", "_ScoreGKEY", "_ScoreBKEY", "_ScoreSKEY", "_ScoreGR", "_ScoreXP",
+	""
 };
 
 //Message texts corresponding to the above short var texts.
@@ -69,7 +70,8 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarMyItemMult, MID_VarMyItemHPMult, MID_VarMyItemATKMult, MID_VarMyItemDEFMult, MID_VarMyItemGRMult,
 	MID_VarMudSpawn, MID_VarTarSpawn, MID_VarGelSpawn, MID_VarQueenSpawn,
 	MID_VarMonsterName, MID_VarMySpawn,
-	MID_VarScoreHP, MID_VarScoreAtk, MID_VarScoreDef, MID_VarScoreYKey, MID_VarScoreGKey, MID_VarScoreBKey, MID_VarScoreGold, MID_VarScoreXP
+	MID_VarScoreHP, MID_VarScoreAtk, MID_VarScoreDef, MID_VarScoreYKey, MID_VarScoreGKey, MID_VarScoreBKey, MID_VarScoreGold, MID_VarScoreXP,
+	MID_VarMyWeakness
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -142,7 +142,8 @@ namespace ScriptVars
 		P_SCORE_SKEY = -86,
 		P_SCORE_GOLD = -87,
 		P_SCORE_XP = -88,
-		FirstPredefinedVar = P_SCORE_XP, //set this to the last var in the enumeration
+		P_MONSTER_CUSTOM_WEAKNESS = -89,
+		FirstPredefinedVar = P_MONSTER_CUSTOM_WEAKNESS, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -813,6 +813,8 @@ The variable names are case-insensitive.
   available choices, numbered in order of appearance.
   A value of 0 indicates no sword.
 </p>
+<p><a name="myweakness"><b>*_MyWeakness</b></a> - Allows a custom weakness to be set for a monster or equipment. A weapon or accessory is strong (i.e. player gets x2 ATK) against a monster if both _MyWeakness values are the same. The comparison is case-sensitive, so for example the values "Eyeball" and "eyeball" would not be considered the same.
+</p>
 <p><a name="paramoverride"><b>*_MyScriptX</b></a> - This and the other script
   command parameter overrides are used if variable parameters are required
   for certain script commands instead of hard-coded values.

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1500,6 +1500,7 @@ enum MID_CONSTANT {
   MID_LogicalWaitOr = 1812,
   MID_LogicalWaitXOR = 1813,
   MID_LogicalWaitEnd = 1814,
+  MID_CustomWeakness = 1829,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,
@@ -1585,6 +1586,7 @@ enum MID_CONSTANT {
   MID_VarScoreSKey = 1821,
   MID_VarScoreGold = 1822,
   MID_VarScoreXP = 1823,
+  MID_VarMyWeakness = 1828,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1500,7 +1500,8 @@ enum MID_CONSTANT {
   MID_LogicalWaitOr = 1812,
   MID_LogicalWaitXOR = 1813,
   MID_LogicalWaitEnd = 1814,
-  MID_CustomWeakness = 1829,
+  MID_CustomAspect = 1829,
+  MID_StrongAgainstAspect = 1830,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1319,3 +1319,7 @@ Wait for Exactly One:
 [MID_LogicalWaitEnd]
 [eng]
 Wait for Conditions End
+
+[MID_CustomWeakness]
+[eng]
+%s weakness

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1320,6 +1320,10 @@ Wait for Exactly One:
 [eng]
 Wait for Conditions End
 
-[MID_CustomWeakness]
+[MID_CustomAspect]
 [eng]
-%s weakness
+%s aspect
+
+[MID_StrongAgainstAspect]
+[eng]
+Strong against %s

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -293,3 +293,7 @@ _QueenSpawn
 [MID_VarMySpawn]
 [eng]
 _MySpawn
+
+[MID_VarMyWeakness]
+[eng]
+_MyWeakness


### PR DESCRIPTION
Adds a new pre-defined var, `_MyWeakness`, that allows for scripted monsters and equipment to support additional weakness types beyond the current Goblin and Wyrm weaknesses. If the player battles a monster with a custom weakness value, and the custom weakness value of their weapon or accessory matches, the player will benefit from the x2 ATK bonus. This check is case-sensitive.

In the UI, a monster's weakness is given as its "aspect", while equipment tooltips show a "Strong against" line if a weakness is set.

Currently, a scripted entity can only have one aspect or strength, but it would be possible to use a specified character as a delimiter and support multiples.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45774