### PR TITLE
RPG: Fix movement default when importing from PackedVars

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5359,7 +5359,12 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bMoveIntoSwords = vars.GetVar(MoveIntoSwordsStr, this->bMoveIntoSwords);
 	this->bPushObjects = vars.GetVar(PushObjectsStr, this->bPushObjects);
 	this->bSpawnEggs = vars.GetVar(SpawnEggsStr, this->bSpawnEggs);
-	this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
+
+	if (vars.DoesVarExist(MovementTypeStr)) {
+		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
+	} else {
+		SetDefaultMovementType();
+	}
 
 	//Stats.
 	this->color = vars.GetVar(ColorStr, this->color);

--- a/drodrpg/DRODLib/DbPackedVars.h
+++ b/drodrpg/DRODLib/DbPackedVars.h
@@ -116,7 +116,7 @@ public:
 	}
 
 	void        Clear();
-	bool        DoesVarExist(const char *pszVarName)
+	bool        DoesVarExist(const char *pszVarName) const
 	{
 		return FindVarByName(pszVarName)!=NULL;
 	}


### PR DESCRIPTION
Due to an oversight with how setting the movement type for charactes in RPG works, characters in a saved game without a saved movement type will always become `GROUND` movers. This is wrong.

To fix this, when setting a character's members from a `CDbPackedVars`, there is now a check to see if a movement type is serialized. If there isn't one, the character will run `SetDefaultMovementType` to initialize movement.

This change required `CDbPackedVars::DoesVarExist` to be made const, which was okay since in only called const functions.