### PR TITLE
RPG: Cap the score for each resource to prevent overflow.

### DIFF
--- a/drodrpg/DRODLib/DbSavedGames.cpp
+++ b/drodrpg/DRODLib/DbSavedGames.cpp
@@ -2595,6 +2595,15 @@ UINT CDbSavedGames::GetScore(const PlayerStats& st)
 UINT CDbSavedGames::CalculateStatScore(const int stat, const int scoreMultiplier)
 //Return: score for a particular stat
 {
+	const int scoreCap = 100000000;
+	if (scoreMultiplier != 0 && stat > scoreCap / scoreMultiplier) // stat * scoreMultiplier would go above cap
+	{
+		return scoreCap;
+	}
+	if (scoreMultiplier != 0 && stat < -scoreCap / scoreMultiplier) // stat * scoreMultiplier would go below negative cap
+	{
+		return -scoreCap;
+	}
 	return scoreMultiplier < 0 ? stat / abs(scoreMultiplier) : stat * scoreMultiplier;
 }
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -869,9 +869,11 @@ The variable names are case-insensitive.
   These vars determine how much each of the player's resources is worth for scoring
   at score checkpoints. A positive value will make each one worth that much.  A
   negative value will divide your total by that amount, rounding down.  A value of 0
-  will cause it to not be listed on score checkpoints.  <b>Note:</b> Players can look
-  at their current score at any time by right-clicking on the player character, so you
-  should set these values at the earliest opportunity.
+  will cause it to not be listed on score checkpoints.  Each resource is capped at a
+  total score of 100 million, if you are likely to reach this cap, you should lower
+  your score multiplier.  <b>Note:</b> Players can look at their current score at any
+  time by right-clicking on the player character, so you should set these values at
+  the earliest opportunity.
 </p>
 
 <p><a name="functions"><b>Function primitives</b></a> - Predefined


### PR DESCRIPTION
The scores in RPG can overflow MAXINT and MININT. This PR caps each of the 9 scoreable resources at 100 million in either direction, so that their sum cannot overflow.