### PR TITLE
RPG: Fix some predefined variable problems

### DIFF
--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -318,7 +318,7 @@ UINT ScriptVars::getVarDefault(const ScriptVars::Predefined var)
 //*****************************************************************************
 bool ScriptVars::IsStringVar(Predefined val)
 {
-	return val == P_MONSTER_NAME;
+	return val == P_MONSTER_NAME || val == P_MONSTER_CUSTOM_WEAKNESS;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -287,6 +287,35 @@ void ScriptVars::init()
 }
 
 //*****************************************************************************
+UINT ScriptVars::getVarDefault(const ScriptVars::Predefined var)
+{
+	switch (var) {
+		case P_TAR_SPAWN:
+		case P_MUD_SPAWN:
+		case P_GEL_SPAWN:
+		case P_QUEEN_SPAWN:
+			return UINT(-1);
+		case P_SCORE_HP:
+			return UINT(-40);
+		case P_SCORE_ATK:
+			return 5;
+		case P_SCORE_DEF:
+			return 3;
+		case P_SCORE_YKEY:
+			return 10;
+		case P_SCORE_GKEY:
+			return 20;
+		case P_SCORE_BKEY:
+		case P_SCORE_SKEY:
+			return 30;
+		default:
+			return 0;
+	}
+
+	return 0;
+}
+
+//*****************************************************************************
 bool ScriptVars::IsStringVar(Predefined val)
 {
 	return val == P_MONSTER_NAME;
@@ -583,9 +612,7 @@ void PlayerStats::Unpack(CDbPackedVars& stats)
 			continue; //these values are not player/global stats
 
 		ASSERT(predefinedVarTexts[i][0] != 0); //not empty string
-		UINT defaultVal = 0;
-		if (73 <= i && i <= 76)
-			defaultVal = UINT(-1);
+		UINT defaultVal = getVarDefault(ScriptVars::Predefined(-(i+1)));
 		const UINT val = stats.GetVar(predefinedVarTexts[i], defaultVal);
 		switch (i)
 		{

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -70,7 +70,7 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarMyItemMult, MID_VarMyItemHPMult, MID_VarMyItemATKMult, MID_VarMyItemDEFMult, MID_VarMyItemGRMult,
 	MID_VarMudSpawn, MID_VarTarSpawn, MID_VarGelSpawn, MID_VarQueenSpawn,
 	MID_VarMonsterName, MID_VarMySpawn,
-	MID_VarScoreHP, MID_VarScoreAtk, MID_VarScoreDef, MID_VarScoreYKey, MID_VarScoreGKey, MID_VarScoreBKey, MID_VarScoreGold, MID_VarScoreXP,
+	MID_VarScoreHP, MID_VarScoreAtk, MID_VarScoreDef, MID_VarScoreYKey, MID_VarScoreGKey, MID_VarScoreBKey, MID_VarScoreSKey, MID_VarScoreGold, MID_VarScoreXP,
 	MID_VarMyWeakness
 };
 

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -171,6 +171,7 @@ namespace ScriptVars
 	};
 
 	void init();
+	UINT getVarDefault(const ScriptVars::Predefined var);
 	string getVarName(const ScriptVars::Predefined var);
 	WSTRING getVarNameW(const ScriptVars::Predefined var);
 	bool IsStringVar(Predefined val);


### PR DESCRIPTION
1. If you load a pre-1.3 save, all custom scoring variables end up as as zero, due to not having default values set properly in `PlayerStats`. A new function is added that will get default values for predefined vars, and it is used for getting default values.
2. `ScriptVars::IsStringVar` has been updated to correctly return that the custom weakness var is a string.
3. Message id is missing for skeleton key score variable in the message id array, which breaks variable lookup.