### PR TITLE
Fix zero duration text effects

### DIFF
--- a/FrontEndLib/Effect.h
+++ b/FrontEndLib/Effect.h
@@ -117,7 +117,7 @@ public:
 	void           RequestRetainOnClear(const bool bVal=true) {this->bRequestRetainOnClear = bVal;}
 	bool           RequestsRetainOnClear() const {return this->bRequestRetainOnClear;}
 	void           SetOpacity(float fOpacity) {this->fOpacity = fOpacity;}
-	bool           Update(const UINT wDeltaTime); // Updates the state of the effect without drawing it
+	virtual bool   Update(const UINT wDeltaTime); // Updates the state of the effect without drawing it
 
 	vector<SDL_Rect>  dirtyRects; //bounding boxes covered by effect this frame
 

--- a/FrontEndLib/TextEffect.cpp
+++ b/FrontEndLib/TextEffect.cpp
@@ -71,6 +71,18 @@ CTextEffect::~CTextEffect()
 	SDL_FreeSurface(this->pTextSurface);
 }
 
+//*****************************************************************************
+bool CTextEffect::Update(
+	const UINT wDeltaTime)     //(in) Time between this and last draw, can be 0 to just draw the effect as-is without any state update
+{
+	this->dwTimeElapsed += wDeltaTime;
+
+	if (this->dwDuration && this->dwTimeElapsed >= this->dwDuration)
+		return false;
+
+	return this->Update(wDeltaTime, this->dwTimeElapsed);
+}
+
 //********************************************************************************
 bool CTextEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 //Draws text in the middle of the parent widget.

--- a/FrontEndLib/TextEffect.h
+++ b/FrontEndLib/TextEffect.h
@@ -53,6 +53,7 @@ public:
 	int		Y() const {return this->nY;}
 	void		Move(const int nX, const int nY);
 	void     SetText(const WCHAR *text, const UINT eFont);
+	virtual bool Update(const UINT wDeltaTime); // Updates the state of the effect without drawing it
 
 protected:
 	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);


### PR DESCRIPTION
Text effects with a duration of zero are meant to display indefinitely. However, #228 removed the effect-specific code in `CTextEffect` that made this work, and the generalized code causes zero duration text effects to never display. I've overridden the update function in `CTextEffect` to restore the intended behaviour.

Pointing at master branch since various regressions in 5.1.1 mean we probably want to release a 5.1.2 quite soon.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45817