### PR TITLE
Fix importing of non-compressed data in CDbXML part two

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1910,7 +1910,7 @@ void CDbXML::Import_TallyRecords(
 	XML_SetElementHandler(parser, CDbXMLTallyElementCDecl, NULL);
 
 	//For keeping track of things
-	int totalBytesRead = 0;
+	uLongf totalBytesRead = 0;
 
 	//Parse the XML in chunks to keep memory overhead low.
 	while (info.ImportStatus == MID_ImportSuccessful)
@@ -1991,7 +1991,7 @@ void CDbXML::Import_ParseRecords(
 	CDb::FreezeTimeStamps(true);
 
 	//For keeping track of things
-	int totalBytesRead = 0;
+	uLongf totalBytesRead = 0;
 
 	while (ContinueImport())
 	{


### PR DESCRIPTION
PR #243 improves hold importing. However due to an oversight it can cause crashes when save and demo data is being imported. This is due to the fact that saved game data is handled as a complete uncompressed chunk. This chunk can be larger than the maximum buffer size assigned for XML parsing, which breaks things when an attempt is made to copy save or demo data into the parsing buffer.

To fix this, the amount of bytes that can be read in one go in `CDbXML::Import_TallyRecords` and `Import_ParseRecords` have been capped to `XML_PARSER_BUFF_SIZE`. For uncompressed data that has been directly passed to the import buffer, excess data will now be incrementally parsed, with the buffer pointer being moved as required. When working with directly passed data, the buffer pointer does not own the memory it points to, so this should be safe.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45694