### PR TITLE
Add functions to correctly import non-compressed game data

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1967,6 +1967,73 @@ void CDbXML::Import_TallyRecords(
 }
 
 //*****************************************************************************
+//Pre-parse the XML payload.
+//Determine the upper limit of how many new records will be added to the DB
+//and add empty rows for them now to minimize memory address fragmentation during import.
+void CDbXML::Import_TallyRecords(const string& xml) //[in] string containg xml to parse
+{
+	ASSERT(parser); //pre-condition: parser is inited and ready to parse new data
+
+	if (CDbXML::info.bPreparsed ||
+		CDbXML::info.typeBeingImported == CImportInfo::LanguageMod) //only adding text records
+		return;
+
+	PerformCallback(MID_ImportTallying);
+	//This callback method is invoked by the XML parser for each record
+	//encountered in the data payload.
+	//It is used to tally the number of records existing of each type.
+	//See the functions's comments for more detail.
+	XML_SetElementHandler(parser, CDbXMLTallyElementCDecl, NULL);
+
+	const char* pXml = xml.c_str();
+	size_t remainingSize = xml.length();
+
+	//Parse the XML in chunks to keep memory overhead low.
+	while (info.ImportStatus == MID_ImportSuccessful)
+	{
+		//Allocate (next) buffer for parsing.
+		void* buff = XML_GetBuffer(parser, XML_PARSER_BUFF_SIZE);
+		if (!buff)
+		{
+			info.ImportStatus = MID_NoMoreMemory;
+			break;
+		}
+
+		const int bytesRead = min(remainingSize, XML_PARSER_BUFF_SIZE);
+		ASSERT(bytesRead >= 0);
+		ASSERT(bytesRead <= XML_PARSER_BUFF_SIZE);
+		memcpy(buff, pXml, bytesRead);
+
+		//Parse data chunk.
+		if (XML_ParseBuffer(parser, bytesRead, bytesRead == 0) == XML_STATUS_ERROR)
+		{
+			//Some problem occurred.
+			info.ImportStatus = MID_FileCorrupted;
+
+			char errorStr[256];
+			_snprintf(errorStr, 256,
+				"Import Parse Error: %s at line %u:%u\n",
+				XML_ErrorString(XML_GetErrorCode(parser)),
+				(UINT)XML_GetCurrentLineNumber(parser),
+				(UINT)XML_GetCurrentColumnNumber(parser));
+			CFiles Files;
+			Files.AppendErrorLog((char*)errorStr);
+		}
+
+		if (bytesRead == 0) //done
+		{
+			AddRowsForPendingRecords();
+			CDbXML::info.bPreparsed = true;
+			break;
+		}
+
+		//Advance pointer by amount of data that has been parsed
+		pXml += bytesRead;
+		remainingSize -= bytesRead;
+	}
+}
+
+//*****************************************************************************
 //Parse the XML data payload, populating database records and staging them
 //for commit at the end of parsing.
 void CDbXML::Import_ParseRecords(
@@ -2032,6 +2099,70 @@ void CDbXML::Import_ParseRecords(
 			//therefore, we must not have anything else to parse
 			break;
 		}
+	}
+
+	CDb::FreezeTimeStamps(false);
+}
+
+
+//*****************************************************************************
+//Parse the XML data payload, populating database records and staging them
+//for commit at the end of parsing.
+void CDbXML::Import_ParseRecords(const string& xml) //[in] string containg xml to parse
+{
+	ASSERT(parser); //pre-condition: parser is inited and ready to parse new data
+
+	//These callback methods are invoked as XML records and attributes are parsed.
+	//Internal database records will be constructed incrementally as these
+	//values are read in. The 'EndElement' callback is used to indicate the
+	//completion of parsing a record, at which point it is staged for write
+	//to the database.  Read their in-place comments for more detail.
+	XML_SetElementHandler(parser, CDbXMLStartElementCDecl, CDbXMLEndElementCDecl);
+
+	CDb::FreezeTimeStamps(true);
+
+	const char* pXml = xml.c_str();
+	size_t remainingSize = xml.length();
+
+	while (ContinueImport()) {
+		//Allocate buffer for parsing.
+		void* buff = XML_GetBuffer(parser, XML_PARSER_BUFF_SIZE);
+		if (!buff) {
+			if (!bImportComplete)
+				info.ImportStatus = MID_NoMoreMemory;
+			break;
+		}
+
+		//Get next chunk of data to parse.
+		const int bytesRead = min(remainingSize, XML_PARSER_BUFF_SIZE);
+		ASSERT(bytesRead >= 0);
+		ASSERT(bytesRead <= XML_PARSER_BUFF_SIZE);
+		memcpy(buff, pXml, bytesRead);
+
+		//Parse data chunk.
+		if (XML_ParseBuffer(parser, bytesRead, bytesRead == 0) == XML_STATUS_ERROR)
+		{
+			//Invalidate import only if data was corrupted somewhere before the end tag.
+			//If something afterwards happens to be wrong, just ignore it.
+			if (!bImportComplete)
+				info.ImportStatus = MID_FileCorrupted;
+
+			char errorStr[256];
+			_snprintf(errorStr, 256,
+				"Import Parse Error: %s at line %u:%u\n",
+				XML_ErrorString(XML_GetErrorCode(parser)),
+				(UINT)XML_GetCurrentLineNumber(parser),
+				(UINT)XML_GetCurrentColumnNumber(parser));
+			CFiles Files;
+			Files.AppendErrorLog((char*)errorStr);
+		}
+
+		if (bytesRead == 0)
+			break; //done
+
+		//Advance pointer by amount of data that has been parsed
+		pXml += bytesRead;
+		remainingSize -= bytesRead;
 	}
 
 	CDb::FreezeTimeStamps(false);

--- a/DRODLib/DbXML.h
+++ b/DRODLib/DbXML.h
@@ -140,7 +140,9 @@ private:
 	static MESSAGE_ID ImportXML(ImportBuffer* pBuffer);
 	static void Import_Init();
 	static void Import_TallyRecords(ImportBuffer* pBuffer);
+	static void Import_TallyRecords(const string& xml);
 	static void Import_ParseRecords(ImportBuffer* pBuffer);
+	static void Import_ParseRecords(const string& xml);
 	static void Import_Resolve();
 
 	static VIEWTYPE ParseViewType(const char *str);


### PR DESCRIPTION
PR #243 improved data importing by performing incremental decompression of compressed game data. However, these changes are not compatible with data that isn't compressed, and attempts to do so may lead to crashes. This is a problem, as the game may try to import internal non-compressed data during a hold update.

To fix this, I have added new versions of `CDbXML::Import_TallyRecords` and `CDbXML::Import_ParseRecords`, which are designed to work with non-compressed XML game data, provided to the functions as a string. These functions still perform incremental parsing, but in a way that is compatible with non-compressed data that may be larger than the maximum buffer size. The overload of `CDbXML::ImportXML` that accepts a string has been changed to perform a full data import, using the new functions.