### PR TITLE
Add tie-breaking for horn entrance selection

### DIFF
--- a/DRODLib/PathMap.cpp
+++ b/DRODLib/PathMap.cpp
@@ -464,8 +464,8 @@ bool CompareEntrances::operator()(const SORTPOINT& lhs, const SORTPOINT& rhs)
 	if (lhs.wY > rhs.wY)
 		return true;
 
-	if (lhs.wX > rhs.wX)
-		return true;
+	if (lhs.wY < rhs.wY)
+		return false;
 
-	return false;
+	return (lhs.wX > rhs.wX);
 }

--- a/DRODLib/PathMap.cpp
+++ b/DRODLib/PathMap.cpp
@@ -191,7 +191,7 @@ void CPathMap::GetEntrances(
 	CalcPaths();
 	sortPoints.clear();
 
-	std::priority_queue<SORTPOINT> ecopy(this->entrySquares);
+	SortedEntrances ecopy(this->entrySquares);
 
 	while (!ecopy.empty())
 	{
@@ -448,4 +448,24 @@ const
 		//Append end of row CR/LF.
 		strOutput += NEWLINE;
 	}
+}
+
+//**************************************************************************************
+//Returns if a sortpoint is less than another, accounting for relative room position in
+//addition to tile score. If scores are equal, compare the y position, then x position.
+bool CompareEntrances::operator()(const SORTPOINT& lhs, const SORTPOINT& rhs)
+{
+	if (lhs < rhs)
+		return true;
+
+	if (rhs < lhs)
+		return false;
+
+	if (lhs.wY > rhs.wY)
+		return true;
+
+	if (lhs.wX > rhs.wX)
+		return true;
+
+	return false;
 }

--- a/DRODLib/Pathmap.h
+++ b/DRODLib/Pathmap.h
@@ -87,7 +87,7 @@ public:
 		: wX(wX), wY(wY), wMoves(wMoves), dwScore(dwScore) { }
 	UINT wX, wY, wMoves;
 	UINT dwScore;
-	bool operator <(const SORTPOINT& rhs) const { return this->dwScore >= rhs.dwScore; }
+	bool operator <(const SORTPOINT& rhs) const { return this->dwScore > rhs.dwScore; }
 };
 typedef std::vector<SORTPOINT> SORTPOINTS;
 

--- a/DRODLib/Pathmap.h
+++ b/DRODLib/Pathmap.h
@@ -91,6 +91,11 @@ public:
 };
 typedef std::vector<SORTPOINT> SORTPOINTS;
 
+struct CompareEntrances {
+		bool operator()(const SORTPOINT& lhs, const SORTPOINT& rhs);
+};
+typedef std::priority_queue<SORTPOINT, SORTPOINTS, CompareEntrances> SortedEntrances;
+
 class CCoord;
 class CPathMap
 {
@@ -130,7 +135,7 @@ private:
 	std::priority_queue<SORTPOINT> recalcSquares;
 
 	//closest entrance squares to target
-	std::priority_queue<SORTPOINT> entrySquares;
+	SortedEntrances entrySquares;
 
 	//This value is set for use when no obstacle-free path to the target exists,
 	//but a mostly-valid path needs to be calculated anyway.


### PR DESCRIPTION
Problem: If multiple room entrance tiles have the same calculated distance from a horn, the one that has priority is not well-defined. While it is deterministic, it is not reasonably predictable as to which tile would have priority.

Solutions:

1. Fix `SORTPOINT`'s less than operator function. It should provide a strict weak ordering if it is used in `std::priority_queue`, but current it does not as it is reflexive. This causes problems as it means seemingly unrelated room changes can alter the outcome of a horn's tile choice. This shouldn't break pathmap construction, as the order equally-scored tiles are evaluated in doesn't change the outcome.
2. Add a new comparison function that can be used to rank room entrances such that when there are multiple best entrances, the one chosen is consistent. The chosen metric should prefer entrances with a lower Y for east/west room edges, and entrances with a lower X for north/south edges. In corner cases, North is prefered to East or West, which are prefered to South.

Since only 44 rooms use horns, and many of them are constructed in a way that avoid horns having multiple nearest entrances, I think this change will be not be too disruptive.

Related thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45834