### PR TITLE
Fix pit obstacle check when NPC is on platform

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4158,7 +4158,8 @@ const
 				if (room.GetOSquare(this->wX, this->wY) == T_PLATFORM_P)
 				{
 					const int nFirstO = nGetO((int)wCol - (int)this->wX, (int)wRow - (int)this->wY);
-					if (room.CanMovePlatform(this->wX, this->wY, nFirstO))
+					// @FIXME - nDist is a temporary fix to prevent hard crashes
+					if (nDist(wCol, wRow, this->wX, this->wY) == 1 && room.CanMovePlatform(this->wX, this->wY, nFirstO))
 						break;
 				}
 			return true;


### PR DESCRIPTION
Problem: Game crashes when a pathfinding NPC is standing on a platform and the room has pits.
Solution: Only do the platform check when the NPC is directly next to a pit tile in `CCharacter::DoesSquareContainObstacle`

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45853
See also: https://forum.caravelgames.com/viewtopic.php?TopicID=40798&page=0#403645