### PR TITLE
Fix custom character speaker resolution when not talking

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -6194,6 +6194,10 @@ void CGameScreen::UpdatePlayerFace()
 	}
 
 	SPEAKER player = getSpeakerType(MONSTERTYPE(dwCharID));
+	if (pPlayerHoldCharacter) {
+		player = getSpeakerType(MONSTERTYPE(pPlayerHoldCharacter->wType));
+	}
+
 	if (player == Speaker_None)
 	{
 		//If player is not in the room, show Beethro's face if NPC Beethro is in the room.


### PR DESCRIPTION
Due to an oversight in the new face code, a custom player role that's a custom character type without a custom portrait will always show the default face during gameplay, unless the player is talking. We need to properly find the speaker type for the hold character assigned as a player role.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45024