### PR TITLE
RPG: Additional Scripting Features

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1446,6 +1446,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBehaviorListBox->AddItem(ScriptFlag::NoEnemyDefense, g_pTheDB->GetMessageText(MID_NoEnemyDefense));
 	this->pBehaviorListBox->AddItem(ScriptFlag::AttackFirst, g_pTheDB->GetMessageText(MID_AttackFirst));
 	this->pBehaviorListBox->AddItem(ScriptFlag::AttackLast, g_pTheDB->GetMessageText(MID_AttackLast));
+	this->pBehaviorListBox->AddItem(ScriptFlag::RemovesSword, g_pTheDB->GetMessageText(MID_RemovesSword));
 	this->pBehaviorListBox->AddItem(ScriptFlag::DropTrapdoors, g_pTheDB->GetMessageText(MID_DropTrapdoors));
 	this->pBehaviorListBox->AddItem(ScriptFlag::MoveIntoSwords, g_pTheDB->GetMessageText(MID_MoveIntoSwords));
 	this->pBehaviorListBox->AddItem(ScriptFlag::PushObjects, g_pTheDB->GetMessageText(MID_PushObjects));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -142,11 +142,13 @@ const UINT TAG_ANIMATESPEED = 908;
 const UINT TAG_EDITDEFAULTSCRIPT = 907;
 const UINT TAG_CUSTOM_NPCS = 906;
 const UINT TAG_CUSTOM_NPC_ID = 905;
+const UINT TAG_CHAROPTIONS = 904;
 
 const UINT TAG_ADDCOMMAND2 = 899;
 const UINT TAG_DELETECOMMAND2 = 898;
 const UINT TAG_DEFAULTCOMMANDSLISTBOX = 897;
 const UINT TAG_OK2 = 896;
+const UINT TAG_CHAROPTIONS2 = 895;
 
 const UINT TAG_VARCOMPLIST2 = 895;
 
@@ -156,6 +158,7 @@ const UINT CX_DIALOG = 688;
 const UINT CY_DIALOG = 688;
 
 const UINT CX_SPACE = 15;
+const UINT CX_UPPER_SPACE = 7;
 const UINT CY_SPACE = 10;
 
 const SURFACECOLOR PaleRed = {255, 192, 192};
@@ -368,6 +371,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	, queryX(0), queryY(0), queryW(0), queryH(0)
 	, pGraphicListBox(NULL), pCommandsListBox(NULL), pDefaultScriptCommandsListBox(NULL)
 	, pAddCommandDialog(NULL), pAddCharacterDialog(NULL), pScriptDialog(NULL)
+	, pCharOptionsDialog(NULL)
 	, pActionListBox(NULL), pEventListBox(NULL)
 	, pSpeakerListBox(NULL), pMoodListBox(NULL)
 	, pVisualEffectsListBox(NULL)
@@ -406,13 +410,17 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	static const UINT CX_COMMANDS = CX_DIALOG - X_COMMANDS - CX_GRAPHICLISTBOX - CX_SPACE*2;
 	static const UINT CY_COMMANDS = 25*22 + 4;
 	static const UINT CX_ADDCOMMAND = 130;
-	static const int X_ADDCOMMAND = X_COMMANDS + CX_COMMANDS - CX_ADDCOMMAND - CX_SPACE;
+	static const int X_ADDCOMMAND = X_COMMANDS + CX_COMMANDS - CX_ADDCOMMAND - CX_UPPER_SPACE;
 	static const int Y_ADDCOMMAND = Y_COMMANDSLABEL - 4;
 	static const UINT CY_ADDCOMMAND = CY_STANDARD_BUTTON;
 	static const UINT CX_DELETECOMMAND = 150;
-	static const int X_DELETECOMMAND = X_ADDCOMMAND - CX_DELETECOMMAND - CX_SPACE;
+	static const int X_DELETECOMMAND = X_ADDCOMMAND - CX_DELETECOMMAND - CX_UPPER_SPACE;
 	static const int Y_DELETECOMMAND = Y_ADDCOMMAND;
 	static const UINT CY_DELETECOMMAND = CY_STANDARD_BUTTON;
+	static const UINT CX_CHAROPTIONS = 100;
+	static const int X_CHAROPTIONS = X_DELETECOMMAND - CX_CHAROPTIONS - CX_UPPER_SPACE;
+	static const int Y_CHAROPTIONS = Y_ADDCOMMAND;
+	static const UINT CY_CHAROPTIONS = CY_STANDARD_BUTTON;
 
 	static const int X_GRAPHICLABEL = CX_DIALOG - CX_GRAPHICLISTBOX - CX_SPACE;
 	static const int Y_GRAPHICLABEL = Y_ADDCOMMAND;
@@ -445,6 +453,8 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 			CX_ADDCOMMAND, CY_ADDCOMMAND, g_pTheDB->GetMessageText(MID_AddCommand)));
 	AddWidget(new CButtonWidget(TAG_DELETECOMMAND, X_DELETECOMMAND, Y_DELETECOMMAND,
 			CX_DELETECOMMAND, CY_DELETECOMMAND, g_pTheDB->GetMessageText(MID_DeleteCommand)));
+	AddWidget(new CButtonWidget(TAG_CHAROPTIONS, X_CHAROPTIONS, Y_CHAROPTIONS,
+		CX_CHAROPTIONS, CY_CHAROPTIONS, L"Options"));
 
 	AddWidget(new CLabelWidget(0L, X_COMMANDSLABEL, Y_COMMANDSLABEL,
 			CX_COMMANDSLABEL, CY_COMMANDSLABEL, F_Small, g_pTheDB->GetMessageText(MID_Commands)));
@@ -476,6 +486,13 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 			TAG_OK, X_OKBUTTON, Y_OKBUTTON, CX_BUTTON, CY_STANDARD_BUTTON,
 			g_pTheDB->GetMessageText(MID_Okay));
 	AddWidget(pButton);
+
+	//Options dialog
+	this->pCharOptionsDialog = new CCharacterOptionsDialog();
+
+	AddWidget(this->pCharOptionsDialog);
+	this->pCharOptionsDialog->Center();
+	this->pCharOptionsDialog->Hide();
 
 	AddCommandDialog();
 	AddCharacterDialog();
@@ -1688,6 +1705,11 @@ void CCharacterDialogWidget::AddScriptDialog()
 	static const int Y_DELETECOMMAND = Y_ADDCOMMAND;
 	static const UINT CY_DELETECOMMAND = CY_STANDARD_BUTTON;
 
+	static const UINT CX_CHAROPTIONS = 100;
+	static const int X_CHAROPTIONS = X_DELETECOMMAND - CX_CHAROPTIONS - CX_SPACE;
+	static const int Y_CHAROPTIONS = Y_ADDCOMMAND;
+	static const UINT CY_CHAROPTIONS = CY_STANDARD_BUTTON;
+
 	static const UINT CX_BUTTON = 70;
 	static const int X_OKBUTTON = (CX_SCRIPT_DIALOG - (CX_BUTTON + CX_SPACE)) / 2;
 	static const int Y_OKBUTTON = CY_SCRIPT_DIALOG - CY_STANDARD_BUTTON - 15;
@@ -1704,6 +1726,8 @@ void CCharacterDialogWidget::AddScriptDialog()
 			CX_ADDCOMMAND, CY_ADDCOMMAND, g_pTheDB->GetMessageText(MID_AddCommand)));
 	this->pScriptDialog->AddWidget(new CButtonWidget(TAG_DELETECOMMAND2, X_DELETECOMMAND, Y_DELETECOMMAND,
 			CX_DELETECOMMAND, CY_DELETECOMMAND, g_pTheDB->GetMessageText(MID_DeleteCommand)));
+	this->pScriptDialog->AddWidget(new CButtonWidget(TAG_CHAROPTIONS2, X_CHAROPTIONS, Y_CHAROPTIONS,
+		CX_CHAROPTIONS, CY_CHAROPTIONS, L"Options"));
 
 	this->pScriptDialog->AddWidget(new CLabelWidget(0, X_COMMANDSLABEL, Y_COMMANDSLABEL,
 			CX_COMMANDSLABEL, CY_COMMANDSLABEL, F_Small, g_pTheDB->GetMessageText(MID_Commands)));
@@ -1864,6 +1888,20 @@ void CCharacterDialogWidget::OnClick(
 			this->pCharListBox->SelectItem(this->pCharacter->wLogicalIdentity);
 
 			EditCustomCharacters();
+		break;
+
+		case TAG_CHAROPTIONS:
+		{
+			this->pCharOptionsDialog->SetCharacter(this->pCharacter);
+			UINT dwTagNo = this->pCharOptionsDialog->Display();
+			this->pCharOptionsDialog->Hide();
+
+			if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
+				this->pCharacter->wProcessSequence = this->pCharOptionsDialog->GetProcessSequence();
+			}
+
+			Paint();
+		}
 		break;
 
 		case TAG_DELETECOMMAND:
@@ -2881,6 +2919,20 @@ void CCharacterDialogWidget::EditDefaultScriptForCustomNPC()
 					delete this->pSound;
 					this->pSound = NULL;
 				}
+			}
+			break;
+
+			case TAG_CHAROPTIONS2:
+			{
+				this->pCharOptionsDialog->SetCharacter(pChar);
+				UINT dwTagNo = this->pCharOptionsDialog->Display();
+				this->pCharOptionsDialog->Hide();
+
+				if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
+					pChar->ExtraVars.SetVar(ParamProcessSequenceStr, this->pCharOptionsDialog->GetProcessSequence());
+				}
+
+				Paint();
 			}
 			break;
 

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -454,7 +454,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	AddWidget(new CButtonWidget(TAG_DELETECOMMAND, X_DELETECOMMAND, Y_DELETECOMMAND,
 			CX_DELETECOMMAND, CY_DELETECOMMAND, g_pTheDB->GetMessageText(MID_DeleteCommand)));
 	AddWidget(new CButtonWidget(TAG_CHAROPTIONS, X_CHAROPTIONS, Y_CHAROPTIONS,
-		CX_CHAROPTIONS, CY_CHAROPTIONS, L"Options"));
+		CX_CHAROPTIONS, CY_CHAROPTIONS, g_pTheDB->GetMessageText(MID_CharOptions)));
 
 	AddWidget(new CLabelWidget(0L, X_COMMANDSLABEL, Y_COMMANDSLABEL,
 			CX_COMMANDSLABEL, CY_COMMANDSLABEL, F_Small, g_pTheDB->GetMessageText(MID_Commands)));
@@ -1727,7 +1727,7 @@ void CCharacterDialogWidget::AddScriptDialog()
 	this->pScriptDialog->AddWidget(new CButtonWidget(TAG_DELETECOMMAND2, X_DELETECOMMAND, Y_DELETECOMMAND,
 			CX_DELETECOMMAND, CY_DELETECOMMAND, g_pTheDB->GetMessageText(MID_DeleteCommand)));
 	this->pScriptDialog->AddWidget(new CButtonWidget(TAG_CHAROPTIONS2, X_CHAROPTIONS, Y_CHAROPTIONS,
-		CX_CHAROPTIONS, CY_CHAROPTIONS, L"Options"));
+		CX_CHAROPTIONS, CY_CHAROPTIONS, g_pTheDB->GetMessageText(MID_CharOptions)));
 
 	this->pScriptDialog->AddWidget(new CLabelWidget(0, X_COMMANDSLABEL, Y_COMMANDSLABEL,
 			CX_COMMANDSLABEL, CY_COMMANDSLABEL, F_Small, g_pTheDB->GetMessageText(MID_Commands)));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4436,6 +4436,7 @@ void CCharacterDialogWidget::PopulateVarList()
 
 	this->pVarListBox->AddItem(ScriptVars::P_SCRIPT_MONSTER_SPAWN, g_pTheDB->GetMessageText(MID_VarMySpawn));
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_CUSTOM_WEAKNESS, g_pTheDB->GetMessageText(MID_VarMyWeakness));
+	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_CUSTOM_DESCRIPTION, g_pTheDB->GetMessageText(MID_VarMyDescription));
 
 	this->pVarListBox->AddItem(ScriptVars::P_ITEM_MULT, g_pTheDB->GetMessageText(MID_VarItemMult));
 	this->pVarListBox->AddItem(ScriptVars::P_ITEM_HP_MULT, g_pTheDB->GetMessageText(MID_VarItemHPMult));

--- a/drodrpg/DROD/CharacterDialogWidget.h
+++ b/drodrpg/DROD/CharacterDialogWidget.h
@@ -31,6 +31,7 @@
 #define CHARACTERDIALOGWIDGET_H
 
 #include "EntranceSelectDialogWidget.h"
+#include "CharacterOptionsWidget.h"
 #include "../DRODLib/Character.h"
 #include "../DRODLib/DbData.h"
 #include <FrontEndLib/DialogWidget.h>
@@ -171,6 +172,7 @@ private:
 	COptionButtonWidget *pIsVisibleButton;
 	CListBoxWidget *pCommandsListBox, *pDefaultScriptCommandsListBox;
 	CRenameDialogWidget *pAddCommandDialog, *pAddCharacterDialog, *pScriptDialog;
+	CCharacterOptionsDialog* pCharOptionsDialog;
 	CListBoxWidget *pActionListBox;
 	CListBoxWidget *pEventListBox;
 	CListBoxWidget *pSpeakerListBox;

--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -47,13 +47,13 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 		g_pTheDB->GetMessageText(MID_Cancel)));
 
 	AddWidget(new CLabelWidget(0L, X_TITLE, Y_TITLE,
-		CX_TITLE, CY_TITLE, F_Header, L"Options"));
+		CX_TITLE, CY_TITLE, F_Header, g_pTheDB->GetMessageText(MID_CharOptionsTitle)));
 
 	AddWidget(new CLabelWidget(0L, X_SEQUENCELABEL, Y_SEQUENCELABEL,
-		CX_SEQUENCELABEL, CY_SEQUENCELABEL, F_Small, L"Processing Sequence"));
+		CX_SEQUENCELABEL, CY_SEQUENCELABEL, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequence)));
 
 	AddWidget(new CLabelWidget(0L, X_SEQUENCEHELP, Y_SEQUENCEHELP,
-		CX_SEQUENCEHELP, CY_SEQUENCEHELP, F_Small, L"Scripts with a lower processing sequence value will run before scripts with a higher value"));
+		CX_SEQUENCEHELP, CY_SEQUENCEHELP, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequenceDescription)));
 
 	this->pSequenceTextBox = new CTextBoxWidget(0L, X_SEQUENCETEXT, Y_SEQUENCETEXT,
 		CX_SEQUENCETEXT, CY_SEQUENCETEXT, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);

--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -1,0 +1,112 @@
+// $Id$
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2002, 2005
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ * Mike Rimer (mrimer)
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#include "CharacterOptionsWidget.h"
+#include <FrontEndLib/TextBoxWidget.h>
+#include <FrontEndLib/LabelWidget.h>
+#include "DrodFontManager.h"
+
+//******************************************************************************
+CCharacterOptionsDialog::CCharacterOptionsDialog(
+//Constructor.
+)
+: CDialogWidget(0L, 0, 0, CCharacterOptionsDialog::CX_DIALOG, CCharacterOptionsDialog::CY_DIALOG, false)
+{
+	AddWidget(new CButtonWidget(TAG_SAVE,
+		X_SAVE, Y_SAVE,
+		CX_SAVE, CY_SAVE,
+		g_pTheDB->GetMessageText(MID_Save)));
+
+	AddWidget(new CButtonWidget(CCharacterOptionsDialog::TAG_CANCEL,
+		CCharacterOptionsDialog::X_CANCEL, CCharacterOptionsDialog::Y_CANCEL,
+		CCharacterOptionsDialog::CX_CANCEL, CCharacterOptionsDialog::CY_CANCEL,
+		g_pTheDB->GetMessageText(MID_Cancel)));
+
+	AddWidget(new CLabelWidget(0L, X_TITLE, Y_TITLE,
+		CX_TITLE, CY_TITLE, F_Header, L"Options"));
+
+	AddWidget(new CLabelWidget(0L, X_SEQUENCELABEL, Y_SEQUENCELABEL,
+		CX_SEQUENCELABEL, CY_SEQUENCELABEL, F_Small, L"Processing Sequence"));
+
+	AddWidget(new CLabelWidget(0L, X_SEQUENCEHELP, Y_SEQUENCEHELP,
+		CX_SEQUENCEHELP, CY_SEQUENCEHELP, F_Small, L"Scripts with a lower processing sequence value will run before scripts with a higher value"));
+
+	this->pSequenceTextBox = new CTextBoxWidget(0L, X_SEQUENCETEXT, Y_SEQUENCETEXT,
+		CX_SEQUENCETEXT, CY_SEQUENCETEXT, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);
+
+	this->pSequenceTextBox->SetDigitsOnly(true);
+	this->pSequenceTextBox->SetAllowNegative(false);
+	this->pSequenceTextBox->AddHotkey(SDLK_RETURN, TAG_SAVE);
+
+	AddWidget(this->pSequenceTextBox);
+}
+
+//*****************************************************************************
+void CCharacterOptionsDialog::SetCharacter(
+	const CCharacter *pCharacter
+){
+	const UINT bufferLength = PROCESSING_SEQUENCE_MAX_LENGTH + 1; // Added space for null-termination
+	WCHAR temp[bufferLength];
+
+	_itoW(pCharacter->wProcessSequence, temp, 10, bufferLength);
+
+	this->pSequenceTextBox->SetText(temp);
+}
+
+//*****************************************************************************
+void CCharacterOptionsDialog::SetCharacter(
+	HoldCharacter *pCharacter
+){
+	const UINT bufferLength = PROCESSING_SEQUENCE_MAX_LENGTH + 1; // Added space for null-termination
+	WCHAR temp[bufferLength];
+
+	_itoW(pCharacter->ExtraVars.GetVar(ParamProcessSequenceStr, 9999), temp, 10, bufferLength);
+
+	this->pSequenceTextBox->SetText(temp);
+}
+
+//*****************************************************************************
+UINT CCharacterOptionsDialog::GetProcessSequence(){
+	return (UINT) this->pSequenceTextBox->GetNumber();
+}
+
+//*****************************************************************************
+void CCharacterOptionsDialog::OnKeyDown(
+//Called when widget receives SDL_KEYDOWN event.
+//
+//Params:
+	const UINT /*dwTagNo*/,       //(in)   Widget that event applied to.
+	const SDL_KeyboardEvent &Key) //(in)   Event.
+{
+	switch (Key.keysym.sym) 
+	{
+		case SDLK_ESCAPE:
+			Deactivate();
+			dwDeactivateValue = CCharacterOptionsDialog::TAG_CANCEL;
+			break;
+	}
+}

--- a/drodrpg/DROD/CharacterOptionsWidget.h
+++ b/drodrpg/DROD/CharacterOptionsWidget.h
@@ -1,0 +1,97 @@
+// $Id$
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2002, 2005
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ * Mike Rimer (mrimer)
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+//This is a CDialog that has been augmented to customize options of a character monster
+
+#ifndef CHARACTEROPTIONSDIALOGWIDGET_H
+#define CHARACTEROPTIONSDIALOGWIDGET_H
+
+#include "EditRoomScreen.h"
+#include <FrontEndLib/DialogWidget.h>
+#include <FrontEndLib/ButtonWidget.h>
+
+#include "../Texts/MIDs.h"
+#include "../DRODLib/Db.h"
+
+class CCharacterOptionsDialog: public CDialogWidget
+{
+public:
+	static const UINT TAG_SAVE = 996;
+	static const UINT TAG_CANCEL = 995;
+
+	CCharacterOptionsDialog();
+
+	CTextBoxWidget *pSequenceTextBox;
+
+	void SetCharacter(const CCharacter *pCharacter);
+	void SetCharacter(HoldCharacter *pCharacter);
+	UINT GetProcessSequence();
+
+protected:
+	virtual void OnKeyDown(const UINT dwTagNo, const SDL_KeyboardEvent &Key);
+
+private:
+	static const UINT CY_SPACE = 15;
+	static const UINT CX_SPACE = 15;
+
+	static const int CX_DIALOG = 400;
+	static const int CY_DIALOG = 230;
+
+	static const int CX_TITLE = 200;
+	static const int CY_TITLE = 30;
+	static const int X_TITLE = (CX_DIALOG - CX_TITLE) / 2;
+	static const int Y_TITLE = CY_SPACE;
+
+	static const int CX_SEQUENCELABEL = 150;
+	static const int CY_SEQUENCELABEL = CY_STANDARD_BUTTON;
+	static const int X_SEQUENCELABEL = CX_SPACE;
+	static const int Y_SEQUENCELABEL = Y_TITLE + CY_TITLE + CY_SPACE;
+
+	static const int CX_SEQUENCEHELP = 370;
+	static const int CY_SEQUENCEHELP = 270;
+	static const int X_SEQUENCEHELP = CX_SPACE;
+	static const int Y_SEQUENCEHELP = Y_SEQUENCELABEL + CY_SEQUENCELABEL + CY_SPACE;
+
+	static const int CX_SEQUENCETEXT = 130;
+	static const int CY_SEQUENCETEXT = CY_STANDARD_BUTTON;
+	static const int X_SEQUENCETEXT = X_SEQUENCELABEL + CX_SEQUENCELABEL + CX_SPACE;
+	static const int Y_SEQUENCETEXT = Y_SEQUENCELABEL;
+
+	static const int CX_SAVE = 100;
+	static const int CY_SAVE = CY_STANDARD_BUTTON;
+	static const int X_SAVE = CX_DIALOG / 2 - CX_SAVE - CX_SPACE / 2;
+	static const int Y_SAVE = CY_DIALOG - CY_SAVE - CY_SPACE;
+
+	static const int CX_CANCEL = 100;
+	static const int CY_CANCEL = CY_STANDARD_BUTTON;
+	static const int X_CANCEL = CX_DIALOG / 2 + CX_SPACE / 2;
+	static const int Y_CANCEL = CY_DIALOG - CY_SAVE - CY_SPACE;
+
+	static const int PROCESSING_SEQUENCE_MAX_LENGTH = 9;
+};
+
+#endif

--- a/drodrpg/DROD/DROD.2019.vcxproj
+++ b/drodrpg/DROD/DROD.2019.vcxproj
@@ -537,6 +537,7 @@
     <ClCompile Include="BoundingBox.cpp" />
     <ClCompile Include="BrowserScreen.cpp" />
     <ClCompile Include="CharacterDialogWidget.cpp" />
+    <ClCompile Include="CharacterOptionsWidget.cpp" />
     <ClCompile Include="Chat.cpp" />
     <ClCompile Include="ChatScreen.cpp" />
     <ClCompile Include="ClockWidget.cpp" />
@@ -604,6 +605,7 @@
     <ClInclude Include="BoundingBox.h" />
     <ClInclude Include="BrowserScreen.h" />
     <ClInclude Include="CharacterDialogWidget.h" />
+    <ClInclude Include="CharacterOptionsWidget.h" />
     <ClInclude Include="Chat.h" />
     <ClInclude Include="ChatScreen.h" />
     <ClInclude Include="ClockWidget.h" />

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1735,7 +1735,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 	const PlayerStats& st = this->pCurrentGame->pPlayer->st;
 	int atk=0, def=0;
 	bool bMetal=false, bBeamBlock=false, bBriar=false, bLuckyGR=false,
-		bAttackFirst=false, bAttackLast=false, bBackstab=false, bNoEnemyDEF=false,
+		bAttackFirst=false, bAttackLast=false, bRemovesSword=false, bBackstab=false, bNoEnemyDEF=false,
 		bGoblinWeakness=false, bSerpentWeakness=false, bCustomWeakness=false, bLuckyXP=false;
 
 	CCharacter *pCharacter = NULL; //custom equipment
@@ -1811,6 +1811,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 		bAttackLast |= pCharacter->CanAttackLast();
 		bBackstab |= pCharacter->TurnToFacePlayerWhenFighting();
 		bNoEnemyDEF |= pCharacter->HasNoEnemyDefense();
+		bRemovesSword |= pCharacter->RemovesSword();
 	}
 
 	//Format as text.
@@ -1909,6 +1910,13 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 		if (bNeedCR)
 			text += wszCRLF;
 		text += g_pTheDB->GetMessageText(MID_AttackLast);
+		bNeedCR = true;
+	}
+	if (bRemovesSword)
+	{
+		if (bNeedCR)
+			text += wszCRLF;
+		text += g_pTheDB->GetMessageText(MID_RemovesSword);
 		bNeedCR = true;
 	}
 	if (bBackstab)

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1736,7 +1736,8 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 	int atk=0, def=0;
 	bool bMetal=false, bBeamBlock=false, bBriar=false, bLuckyGR=false,
 		bAttackFirst=false, bAttackLast=false, bRemovesSword=false, bBackstab=false, bNoEnemyDEF=false,
-		bGoblinWeakness=false, bSerpentWeakness=false, bCustomWeakness=false, bLuckyXP=false;
+		bGoblinWeakness=false, bSerpentWeakness=false, bCustomWeakness=false, bLuckyXP=false,
+		bCustomDescription=false;
 
 	CCharacter *pCharacter = NULL; //custom equipment
 	switch (eCommand)
@@ -1812,6 +1813,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 		bBackstab |= pCharacter->TurnToFacePlayerWhenFighting();
 		bNoEnemyDEF |= pCharacter->HasNoEnemyDefense();
 		bRemovesSword |= pCharacter->RemovesSword();
+		bCustomDescription = pCharacter->HasCustomDescription();
 	}
 
 	//Format as text.
@@ -1932,6 +1934,19 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 			text += wszCRLF;
 		text += g_pTheDB->GetMessageText(MID_NoEnemyDefense);
 		bNeedCR = true;
+	}
+	if (bCustomDescription) {
+		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
+
+		for (WSTRING& description : descriptions) {
+			if (description.empty()) continue;
+
+			if (bNeedCR)
+				text += wszCRLF;
+
+			text += description;
+			bNeedCR = true;
+		}
 	}
 
 	return text;

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1938,7 +1938,8 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 	if (bCustomDescription) {
 		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
 
-		for (WSTRING& description : descriptions) {
+		for (size_t i = 0; i < descriptions.size(); ++i) {
+			WSTRING description = descriptions[i];
 			if (description.empty()) continue;
 
 			if (bNeedCR)

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1801,7 +1801,8 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		ASSERT(pCharacter);
 		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
 
-		for (WSTRING& description : descriptions) {
+		for (size_t i = 0; i < descriptions.size(); ++i) {
+			WSTRING description = descriptions[i];
 			if (description.empty()) continue;
 
 			if(count)

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1690,7 +1690,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 	bool bAttackInFront = pMonster->wType == M_EYE || pMonster->wType == M_MADEYE;
 	bool bAttackInFrontWhenBack = pMonster->wType == M_GOBLIN || pMonster->wType == M_GOBLINKING;
 	bool bSpawnEggs = pMonster->wType == M_QROACH;
-	bool bCustomWeakness = false;
+	bool bCustomWeakness = false, bCustomDescription = false;
 
 	if (pMonster->wType == M_CHARACTER)
 	{
@@ -1700,6 +1700,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		bAttackInFrontWhenBack |= pCharacter->AttacksInFrontWhenBackTurned();
 		bSpawnEggs |= pCharacter->CanSpawnEggs();
 		bCustomWeakness = pCharacter->HasCustomWeakness();
+		bCustomDescription = pCharacter->HasCustomDescription();
 	}
 
 	if (pMonster->HasRayGun())
@@ -1794,6 +1795,23 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 			pCharacter->GetCustomWeakness()
 		);
 		++count;
+	}
+	if (bCustomDescription) {
+		CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
+		ASSERT(pCharacter);
+		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
+
+		for (WSTRING& description : descriptions) {
+			if (description.empty()) continue;
+
+			if(count)
+			{
+				wstr += wszComma;
+				wstr += wszSpace;
+			}
+			wstr += description;
+			++count;
+		}
 	}
 
 	//Unique.

--- a/drodrpg/DROD/drod.2019.vcxproj.filters
+++ b/drodrpg/DROD/drod.2019.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="DamagePreviewEffect.cpp">
       <Filter>Effects</Filter>
     </ClCompile>
+    <ClCompile Include="CharacterOptionsWidget.cpp">
+      <Filter>Widgets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Chat.h">
@@ -419,6 +422,9 @@
     </ClInclude>
     <ClInclude Include="DamagePreviewEffect.h">
       <Filter>Effects</Filter>
+    </ClInclude>
+    <ClInclude Include="CharacterOptionsWidget.h">
+      <Filter>Widgets</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4985,6 +4985,10 @@ void CCharacter::ResolveLogicalIdentity(CDbHold *pHold)
 			if (this->pCustomChar)
 			{
 				this->wIdentity = this->pCustomChar->wType;
+
+				if (this->commands.empty()) {
+					this->wProcessSequence = this->pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
+				}
 			}
 			else
 				//When character has a dangling reference to a custom character definition
@@ -5389,6 +5393,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->paramW = vars.GetVar(ParamWStr, this->paramW);
 	this->paramH = vars.GetVar(ParamHStr, this->paramH);
 	this->paramF = vars.GetVar(ParamFStr, this->paramF);
+	this->wProcessSequence = vars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
 
 	//Modifiers
 	this->monsterHPmult = vars.GetVar(MonsterHPMultStr, this->monsterHPmult);
@@ -5534,6 +5539,8 @@ const
 		vars.SetVar(ParamHStr, this->paramH);
 	if (this->paramF != NO_OVERRIDE)
 		vars.SetVar(ParamFStr, this->paramF);
+	if (this->wProcessSequence != 9999)
+		vars.SetVar(ParamProcessSequenceStr, this->wProcessSequence);
 
 	// Modifiers
 	if (this->monsterHPmult != 100)

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -519,6 +519,8 @@ WSTRING CCharacter::getPredefinedVarString(const UINT varIndex) const
 			return this->customName;
 		case (UINT)ScriptVars::P_MONSTER_CUSTOM_WEAKNESS:
 			return this->customWeakness;
+		case (UINT)ScriptVars::P_MONSTER_CUSTOM_DESCRIPTION:
+			return this->customDescription;
 		default:
 			ASSERT(!"getPredefinedStringVar val not supported");
 			return WSTRING();
@@ -884,6 +886,9 @@ void CCharacter::setPredefinedVarString(
 		break;
 	case (UINT)ScriptVars::P_MONSTER_CUSTOM_WEAKNESS:
 		this->customWeakness = val;
+		break;
+	case (UINT)ScriptVars::P_MONSTER_CUSTOM_DESCRIPTION:
+		this->customDescription = val;
 		break;
 	}
 }

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -824,6 +824,8 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 					case (UINT)ScriptVars::P_TOTALMOVES:
 					case (UINT)ScriptVars::P_TOTALTIME:
 					case (UINT)ScriptVars::P_LEVEL_MULT:
+					case (UINT)ScriptVars::P_ROOM_X:
+					case (UINT)ScriptVars::P_ROOM_Y:
 						//cannot alter
 					break;
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -126,6 +126,7 @@ const UINT MAX_ANSWERS = 9;
 #define MoveIntoSwordsStr "MoveIntoSwords"
 #define PushObjectsStr "PushObjects"
 #define SpawnEggsStr "SpawnEggs"
+#define RemovesSwordStr "RemovesSword"
 #define MovementTypeStr "MovementType"
 
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
@@ -240,6 +241,7 @@ CCharacter::CCharacter(
 	, bMetal(false), bLuckyGR(false), bLuckyXP(false), bBriar(false), bNoEnemyDEF(false)
 	, bAttackFirst(false), bAttackLast(false)
 	, bDropTrapdoors(false), bMoveIntoSwords(false), bPushObjects(false), bSpawnEggs(false)
+	, bRemovesSword(false)
 
 	, wJumpLabel(0)
 	, bWaitingForCueEvent(false)
@@ -2586,7 +2588,7 @@ void CCharacter::Process(
 						this->bSurprisedFromBehind =
 						this->bGoblinWeakness = this->bSerpentWeakness =
 						this->bMetal = this->bLuckyGR = this->bLuckyXP = this->bBriar = this->bNoEnemyDEF =
-						this->bAttackFirst = this->bAttackLast =
+						this->bAttackFirst = this->bAttackLast = this->bRemovesSword =
 						this->bDropTrapdoors = this->bMoveIntoSwords = this->bPushObjects = this->bSpawnEggs =
 							false;
 						this->movementIQ = SmartDiagonalOnly;
@@ -2671,6 +2673,9 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::SpawnEggs:
 						this->bSpawnEggs = true;
+					break;
+					case ScriptFlag::RemovesSword:
+						this->bRemovesSword = true;
 					break;
 
 					default:
@@ -5365,6 +5370,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bMoveIntoSwords = vars.GetVar(MoveIntoSwordsStr, this->bMoveIntoSwords);
 	this->bPushObjects = vars.GetVar(PushObjectsStr, this->bPushObjects);
 	this->bSpawnEggs = vars.GetVar(SpawnEggsStr, this->bSpawnEggs);
+	this->bRemovesSword = vars.GetVar(RemovesSwordStr, this->bRemovesSword);
 
 	if (vars.DoesVarExist(MovementTypeStr)) {
 		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
@@ -5505,6 +5511,8 @@ const
 		vars.SetVar(PushObjectsStr, this->bPushObjects);
 	if (this->bSpawnEggs)
 		vars.SetVar(SpawnEggsStr, this->bSpawnEggs);
+	if (this->bRemovesSword)
+		vars.SetVar(RemovesSwordStr, this->bSpawnEggs);
 	if (this->eMovement)
 		vars.SetVar(MovementTypeStr, this->eMovement);
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -823,6 +823,7 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 					case (UINT)ScriptVars::P_SPEED:
 					case (UINT)ScriptVars::P_TOTALMOVES:
 					case (UINT)ScriptVars::P_TOTALTIME:
+					case (UINT)ScriptVars::P_LEVEL_MULT:
 						//cannot alter
 					break;
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -86,6 +86,7 @@ const UINT MAX_ANSWERS = 9;
 
 #define SpawnTypeStr "SpawnType"
 #define WeaknessStr "Weakness"
+#define TooltipStr "Tooltip"
 
 #define TurnDelayStr "TurnDelay"
 #define XRelStr "XRel"
@@ -4341,6 +4342,13 @@ UINT CCharacter::GetResolvedIdentity() const
 	return wIdentity;
 }
 
+//*****************************************************************************
+//Returns: custom tooltips for the NPC, divided into a vector
+vector<WSTRING> CCharacter::GetCustomDescriptions() const
+{
+	return WCSExplode(this->customDescription, *wszSemicolon);
+}
+
 UINT CCharacter::GetSpawnType(UINT defaultMonsterID) const
 {
 	if (this->wSpawnType >= 0) {
@@ -5413,6 +5421,9 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 
 	//Custom weakness
 	this->customWeakness = vars.GetVar(WeaknessStr, this->customWeakness.c_str());
+
+	//Custom tooltip
+	this->customWeakness = vars.GetVar(TooltipStr, this->customDescription.c_str());
 }
 
 //*****************************************************************************
@@ -5572,6 +5583,10 @@ const
 	//Custom weakness
 	if (!this->customWeakness.empty())
 		vars.SetVar(WeaknessStr, this->customWeakness.c_str());
+
+	//Custom tooltip
+	if (!this->customDescription.empty())
+		vars.SetVar(TooltipStr, this->customDescription.c_str());
 
 	vars.SetVar(scriptIDstr, this->dwScriptID);
 

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -56,6 +56,7 @@
 using std::vector;
 
 #define DefaultCustomCharacterName wszEmpty
+#define ParamProcessSequenceStr "ProcessSequenceParam"
 
 class CSwordsman;
 struct HoldCharacter;

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -100,12 +100,14 @@ public:
 
 	void           FailedIfCondition();
 	const CCharacterCommand* GetCommandWithLabel(const UINT label) const;
+	vector<WSTRING> GetCustomDescriptions() const;
 	WSTRING        GetCustomWeakness() const { return this->customWeakness; };
 	virtual UINT   GetIdentity() const {return this->wIdentity;}
 	UINT           GetNextSpeechID();
 	virtual UINT   GetResolvedIdentity() const;
 	virtual UINT   GetSpawnType(UINT defaultMonsterID) const;
 	float          GetStatModifier(ScriptVars::StatModifiers statType) const;
+	virtual bool   HasCustomDescription() const { return !this->customDescription.empty(); }
 	virtual bool   HasCustomWeakness() const { return !this->customWeakness.empty(); }
 	bool           HasSpecialDeath() const;
 	virtual bool   HasGoblinWeakness() const {return this->bGoblinWeakness;}
@@ -319,6 +321,7 @@ private:
 	UINT itemMult, itemHPmult, itemATKmult, itemDEFmult, itemGRmult; // item value modifiers
 	int wSpawnType; // type of monster to spawm when spawning eggs
 	WSTRING customWeakness; // matching weakness does strong hit, empty means no custom weakness
+	WSTRING customDescription; // additional monster information
 };
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -148,6 +148,7 @@ public:
 	bool           IsSwordSafeToPlayer() const {return this->bSwordSafeToPlayer;}
 	virtual bool   IsTileObstacle(const UINT wTileNo) const;
 	bool IsValidEntityWait(const CCharacterCommand& command, const CDbRoom& room) const;
+	bool           RemovesSword() const {return this->bRemovesSword;}
 
 	static bool    IsValidExpression(const WCHAR *pwStr, UINT& index, CDbHold *pHold, const char closingChar=0);
 	static bool    IsValidTerm(const WCHAR *pwStr, UINT& index, CDbHold *pHold);
@@ -296,6 +297,7 @@ private:
 	bool bMoveIntoSwords;      //can move onto swords instead of being blocked by them
 	bool bPushObjects;         //can push movable objects
 	bool bSpawnEggs;           //will spawn eggs in reaction to combats
+	bool bRemovesSword;        //prevents player having sword when equipped
 
 	UINT wJumpLabel;			//if non-zero, jump to the label if this command is satisfied
 	bool bWaitingForCueEvent;

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -140,6 +140,7 @@ namespace ScriptFlag
 		AttackLast=23,          //I always attack last in combat
 		BeamBlock=24,           //blocks beam attacks
 		SpawnEggs=25,           //will spawn eggs in reaction to combats
+		RemovesSword=26,        //prevents player having sword when equipped
 	};
 
 	//Inventory and global script types.

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3323,6 +3323,22 @@ bool CCurrentGame::IsLuckyXPItem(const UINT type) const
 }
 
 //*****************************************************************************
+bool CCurrentGame::IsPlayerSwordRemoved() const
+{
+	CCharacter* pCharacter = getCustomEquipment(ScriptFlag::Weapon);
+	if (pCharacter && pCharacter->RemovesSword())
+		return true;
+	pCharacter = getCustomEquipment(ScriptFlag::Armor);
+	if (pCharacter && pCharacter->RemovesSword())
+		return true;
+	pCharacter = getCustomEquipment(ScriptFlag::Accessory);
+	if (pCharacter && pCharacter->RemovesSword())
+		return true;
+
+	return false;
+}
+
+//*****************************************************************************
 bool CCurrentGame::DoesPlayerAttackFirst() const
 //Returns: whether the player has an ability to attack first in combat.
 {

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1385,6 +1385,10 @@ UINT CCurrentGame::getVar(const UINT varIndex) const
 		}
 		return 0;
 
+		//Level information
+		case (UINT)ScriptVars::P_LEVEL_MULT:
+			return this->pLevel->dwMultiplier;
+
 		default:
 			return player.st.getVar(ScriptVars::Predefined(varIndex));
 	}
@@ -2382,6 +2386,7 @@ void CCurrentGame::ProcessCommandSetVar(
 		case (UINT)ScriptVars::P_SPEED:
 		case (UINT)ScriptVars::P_TOTALMOVES:
 		case (UINT)ScriptVars::P_TOTALTIME:
+		case (UINT)ScriptVars::P_LEVEL_MULT:
 			//cannot alter
 			return;
 	}

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1388,6 +1388,13 @@ UINT CCurrentGame::getVar(const UINT varIndex) const
 		//Level information
 		case (UINT)ScriptVars::P_LEVEL_MULT:
 			return this->pLevel->dwMultiplier;
+		case (UINT)ScriptVars::P_ROOM_X:
+		case (UINT)ScriptVars::P_ROOM_Y:
+		{
+			int dX, dY;
+			this->pRoom->GetPositionInLevel(dX, dY);
+			return varIndex == (UINT)ScriptVars::P_ROOM_X ? dX : dY;
+		}
 
 		default:
 			return player.st.getVar(ScriptVars::Predefined(varIndex));
@@ -2387,6 +2394,8 @@ void CCurrentGame::ProcessCommandSetVar(
 		case (UINT)ScriptVars::P_TOTALMOVES:
 		case (UINT)ScriptVars::P_TOTALTIME:
 		case (UINT)ScriptVars::P_LEVEL_MULT:
+		case (UINT)ScriptVars::P_ROOM_X:
+		case (UINT)ScriptVars::P_ROOM_Y:
 			//cannot alter
 			return;
 	}

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -287,6 +287,7 @@ public:
 	bool     IsFighting(const CMonster* pMonster) const;
 	bool     IsLuckyGRItem(const UINT type) const;
 	bool     IsLuckyXPItem(const UINT type) const;
+	bool     IsPlayerSwordRemoved() const;
 	bool     IsNewRoom() const {return this->bIsNewRoom;}
 	bool     IsPlayerAt(const UINT wX, const UINT wY) const;
 	bool     IsPlayerDying() const;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -766,6 +766,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_CharOptions: strText = "Options"; break;
 		case MID_ProcessingSequence: strText = "Processing sequence:"; break;
 		case MID_ProcessingSequenceDescription: strText = "Scripts with a lower processing sequence value will run before scripts with a higher value."; break;
+		case MID_VarMyDescription: strText = "_MyDescription"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -759,6 +759,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_StrongAgainstAspect: strText = "Strong against %s"; break;
 		case MID_ShowScore: strText = "Show score"; break;
 		case MID_RemovesSword: strText = "Removes sword"; break;
+		case MID_VarLevelMultiplier: strText = "_LevelMultiplier"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -760,6 +760,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ShowScore: strText = "Show score"; break;
 		case MID_RemovesSword: strText = "Removes sword"; break;
 		case MID_VarLevelMultiplier: strText = "_LevelMultiplier"; break;
+		case MID_VarRoomX: strText = "_RoomX"; break;
+		case MID_VarRoomY: strText = "_RoomY"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -758,6 +758,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_CustomAspect: strText = "%s aspect"; break;
 		case MID_StrongAgainstAspect: strText = "Strong against %s"; break;
 		case MID_ShowScore: strText = "Show score"; break;
+		case MID_RemovesSword: strText = "Removes sword"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -762,6 +762,10 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarLevelMultiplier: strText = "_LevelMultiplier"; break;
 		case MID_VarRoomX: strText = "_RoomX"; break;
 		case MID_VarRoomY: strText = "_RoomY"; break;
+		case MID_CharOptionsTitle: strText = "Character Options"; break;
+		case MID_CharOptions: strText = "Options"; break;
+		case MID_ProcessingSequence: strText = "Processing sequence:"; break;
+		case MID_ProcessingSequenceDescription: strText = "Scripts with a lower processing sequence value will run before scripts with a higher value."; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -5203,10 +5203,8 @@ void CDbRoom::GetLevelPositionDescription(
 										//desc. text (default=false)
 {
 	//calculate how far from entrance
-	UINT dwRoomX, dwRoomY; //level starting room coords
-	CDbLevels::GetStartingRoomCoords(this->dwLevelID, dwRoomX, dwRoomY);
-	const int dX = this->dwRoomX - dwRoomX;   //offset from starting room
-	const int dY = this->dwRoomY - dwRoomY;
+	int dX, dY;
+	GetPositionInLevel(dX, dY);
 
 	//Call language-specific version of method.
 	switch (Language::GetLanguage())
@@ -5221,6 +5219,16 @@ void CDbRoom::GetLevelPositionDescription(
 			GetLevelPositionDescription_English(wstrDescription, dX, dY, bAbbreviate);
 		break;
 	}
+}
+
+//*****************************************************************************
+void CDbRoom::GetPositionInLevel(int& dx, int& dy) const
+{
+	UINT dwRoomX, dwRoomY; //level starting room coords
+	CDbLevels::GetStartingRoomCoords(this->dwLevelID, dwRoomX, dwRoomY);
+
+	dx = this->dwRoomX - dwRoomX;   //offset from starting room
+	dy = this->dwRoomY - dwRoomY;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -3126,7 +3126,8 @@ CMonster* CDbRoom::AddNewMonster(
 	const UINT wMonsterType,      //(in)   One of M_* constants indicating
 							//    type of monster to create.
 	const UINT wX, const UINT wY, //(in) position of monster
-	const bool bInRoom) //monster is in room on player entrance [default=true]
+	const bool bInRoom, //monster is in room on player entrance [default=true]
+	const bool bLinkMonster) // whether to link the monster [default=true]
 //
 //Returns:
 //Pointer to new monster object.
@@ -3163,7 +3164,8 @@ CMonster* CDbRoom::AddNewMonster(
 	}
 */
 
-	LinkMonster(pNew, bInRoom);
+	if(bLinkMonster)
+		LinkMonster(pNew, bInRoom);
 
 	//Return pointer to the new monster.
 	return pNew;
@@ -6201,7 +6203,7 @@ CMonster* CDbRoom::LoadMonster(const c4_RowRef& row)
 	const UINT wMonsterType = p_Type(row);
 	const UINT wX = p_X(row), wY = p_Y(row);
 
-	CMonster *pNew = AddNewMonster((MONSTERTYPE)wMonsterType, wX, wY);
+	CMonster *pNew = AddNewMonster((MONSTERTYPE)wMonsterType, wX, wY, true, false);
 	if (!pNew) throw CException("CDbRoom::LoadMonster: Alloc failed");
 //	pNew->bIsFirstTurn = (p_IsFirstTurn(row) == 1);
 	pNew->wO = pNew->wPrevO = p_O(row);
@@ -6230,6 +6232,8 @@ CMonster* CDbRoom::LoadMonster(const c4_RowRef& row)
 		UINT wTempX, wTempY;
 		pSerpent->GetTail(wTempX, wTempY);
 	}
+
+	LinkMonster(pNew);
 
 	return pNew;
 }

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -251,6 +251,7 @@ public:
 	COrbData*      GetOrbAtCoords(const UINT wX, const UINT wY) const;
 	UINT           GetOSquare(const UINT wX, const UINT wY) const;
 	UINT           GetOSquareWithGuessing(int nX, int nY) const;
+	void           GetPositionInLevel(int& dx, int& dy) const;
 	COrbData*      GetPressurePlateAtCoords(const UINT wX, const UINT wY) const;
 	UINT           GetPrimaryKey() const {return this->dwRoomID;}
 	float          GetStatModifierFromCharacters(ScriptVars::StatModifiers statType) const;

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -159,7 +159,7 @@ public:
 	void           ActivateToken(CCueEvents &CueEvents, const UINT wX, const UINT wY);
 //	void           AddDiagonalDoorAssociations();
 	CMonster *     AddNewMonster(const UINT wMonsterType, const UINT wX,
-			const UINT wY, const bool bInRoom=true);
+			const UINT wY, const bool bInRoom=true, const bool bLinkMonster=true);
 	bool           AddOrb(COrbData *pOrb);
 	COrbData *     AddOrbToSquare(const UINT wX, const UINT wY);
 	bool           AddPressurePlateTiles(COrbData* pPlate);

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -43,7 +43,7 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][13] =
 	"", "",
 	"_ScoreHP", "_ScoreATK", "_ScoreDEF", "_ScoreYKEY", "_ScoreGKEY", "_ScoreBKEY", "_ScoreSKEY", "_ScoreGR", "_ScoreXP",
 	"",
-	""
+	"", "", ""
 };
 
 //Message texts corresponding to the above short var texts.
@@ -73,7 +73,7 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarMonsterName, MID_VarMySpawn,
 	MID_VarScoreHP, MID_VarScoreAtk, MID_VarScoreDef, MID_VarScoreYKey, MID_VarScoreGKey, MID_VarScoreBKey, MID_VarScoreGold, MID_VarScoreXP,
 	MID_VarMyWeakness,
-	MID_VarLevelMultiplier
+	MID_VarLevelMultiplier, MID_VarRoomX, MID_VarRoomY
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -43,7 +43,8 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][13] =
 	"", "",
 	"_ScoreHP", "_ScoreATK", "_ScoreDEF", "_ScoreYKEY", "_ScoreGKEY", "_ScoreBKEY", "_ScoreSKEY", "_ScoreGR", "_ScoreXP",
 	"",
-	"", "", ""
+	"", "", "",
+	""
 };
 
 //Message texts corresponding to the above short var texts.
@@ -73,7 +74,8 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarMonsterName, MID_VarMySpawn,
 	MID_VarScoreHP, MID_VarScoreAtk, MID_VarScoreDef, MID_VarScoreYKey, MID_VarScoreGKey, MID_VarScoreBKey, MID_VarScoreGold, MID_VarScoreXP,
 	MID_VarMyWeakness,
-	MID_VarLevelMultiplier, MID_VarRoomX, MID_VarRoomY
+	MID_VarLevelMultiplier, MID_VarRoomX, MID_VarRoomY,
+	MID_VarMyDescription
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call
@@ -291,7 +293,16 @@ void ScriptVars::init()
 //*****************************************************************************
 bool ScriptVars::IsStringVar(Predefined val)
 {
-	return val == P_MONSTER_NAME;
+	switch (val) {
+		case P_MONSTER_NAME:
+		case P_MONSTER_CUSTOM_WEAKNESS:
+		case P_MONSTER_CUSTOM_DESCRIPTION:
+			return true;
+		default:
+			return false;
+	}
+
+	return false;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -42,6 +42,7 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][13] =
 	"_MudSpawn", "_TarSpawn", "_GelSpawn", "_QueenSpawn",
 	"", "",
 	"_ScoreHP", "_ScoreATK", "_ScoreDEF", "_ScoreYKEY", "_ScoreGKEY", "_ScoreBKEY", "_ScoreSKEY", "_ScoreGR", "_ScoreXP",
+	"",
 	""
 };
 
@@ -71,7 +72,8 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarMudSpawn, MID_VarTarSpawn, MID_VarGelSpawn, MID_VarQueenSpawn,
 	MID_VarMonsterName, MID_VarMySpawn,
 	MID_VarScoreHP, MID_VarScoreAtk, MID_VarScoreDef, MID_VarScoreYKey, MID_VarScoreGKey, MID_VarScoreBKey, MID_VarScoreGold, MID_VarScoreXP,
-	MID_VarMyWeakness
+	MID_VarMyWeakness,
+	MID_VarLevelMultiplier
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -143,7 +143,8 @@ namespace ScriptVars
 		P_SCORE_GOLD = -87,
 		P_SCORE_XP = -88,
 		P_MONSTER_CUSTOM_WEAKNESS = -89,
-		FirstPredefinedVar = P_MONSTER_CUSTOM_WEAKNESS, //set this to the last var in the enumeration
+		P_LEVEL_MULT = -90,
+		FirstPredefinedVar = P_LEVEL_MULT, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -146,7 +146,8 @@ namespace ScriptVars
 		P_LEVEL_MULT = -90,
 		P_ROOM_X = -91,
 		P_ROOM_Y = -92,
-		FirstPredefinedVar = P_ROOM_Y, //set this to the last var in the enumeration
+		P_MONSTER_CUSTOM_DESCRIPTION = -93,
+		FirstPredefinedVar = P_MONSTER_CUSTOM_DESCRIPTION, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -144,7 +144,9 @@ namespace ScriptVars
 		P_SCORE_XP = -88,
 		P_MONSTER_CUSTOM_WEAKNESS = -89,
 		P_LEVEL_MULT = -90,
-		FirstPredefinedVar = P_LEVEL_MULT, //set this to the last var in the enumeration
+		P_ROOM_X = -91,
+		P_ROOM_Y = -92,
+		FirstPredefinedVar = P_ROOM_Y, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/drodrpg/DRODLib/Swordsman.cpp
+++ b/drodrpg/DRODLib/Swordsman.cpp
@@ -483,6 +483,9 @@ bool CSwordsman::HasSword() const
 	if (this->st.sword == NoSword)
 		return false;
 
+	if (this->pCurrentGame->IsPlayerSwordRemoved())
+		return false;
+
 	return !IsSwordDisabled();
 }
 

--- a/drodrpg/Data/Help/1/character.html
+++ b/drodrpg/Data/Help/1/character.html
@@ -35,6 +35,7 @@ enters the room.  Otherwise, it will be invisible.  When an NPC is invisible, it
 script continues to play but it otherwise behaves as if it were not in the room.
 Hint: making a character with a "None" graphic visible will set it to the
 "Citizen 1" type.</p>
+<p><a name="charoptions"><b>Options</b></a> - Click to set the NPC's processing sequence, which controls the order of scripts running in a room. Scripts with lower processing sequence values run earlier, and scripts with higher values run later. This does not effect the order in which equipment scripts will be run.</p>
 <p><a name="addcommand"><b>Add Command</b></a> - Click to add another <a href="script.html">command</a>
 to the script.</p>
 <p><a name="deletecommand"><b>Delete Command</b></a> - Deletes the selected commands from the script.  Also

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -672,6 +672,8 @@ The variable names are case-insensitive.
   </tr><tr>
     <td>_MyMonsterREPMult</td><td>local monster REP multiplier</td><td>100 (percent)</td><td>-MAX,MAX</td>
   </tr><tr>
+    <td>_LevelMultiplier</td><td>current level's item stat multiplier(<a href="#levelmult">*</a>)</td><td></td><td></td>
+  </tr><tr>
     <td>_ItemMult</td><td>global item stat multiplier(<a href="#itemmult">*</a>)</td><td>100 (percent)</td><td>-MAX,MAX</td>
   </tr><tr>
     <td>_ItemHPMult</td><td>global health item multiplier</td><td>100 (percent)</td><td>-MAX,MAX</td>
@@ -755,6 +757,10 @@ The variable names are case-insensitive.
     <td>_Y</td><td>player's Y coordinate (room row)</td><td></td><td>0,15</td>
   </tr><tr>
     <td>_O</td><td>player's orientation (direction faced)</td><td></td><td>0,8</td>
+  </tr><tr>
+    <td>_RoomX</td><td>current room's X coordinate in level(<a href="#roompositionvars">*</a>)</td><td></td><td></td>
+  </tr><tr>
+    <td>_RoomY</td><td>current room's Y coordinate in level(<a href="#roompositionvars">*</a>)</td><td></td><td></td>
   </tr><tr>
     <td><b>Play info</b></td><td></td><td></td><td></td>
   </tr><tr>
@@ -848,6 +854,10 @@ The variable names are case-insensitive.
   and are available in global and local versions, and are applied when items are
   collected. If the total multiplier for an item is negative, collecting it will
   reduce the player's statistics.
+</p>
+<p><a name="levelmult"><b>*_LevelMultiplier</b></a> - This value contains the currents level's item multiplier, as set in the editor. It is a read-only value.
+</p>
+<p><a name="roompositionvars"><b>*_RoomX, _RoomY</b></a> - These values contain the X and Y position of the current room in the level. The entrance is at (0,0), with East and South being positive directions, and North and West being negative directions. These are read-only values.
 </p>
 <p><a name="damage"><b>*_HotTile, _Explosion</b></a> - When damage is set to a
   positive value, it indicates the percentage of HP the target will

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -633,6 +633,10 @@ The variable names are case-insensitive.
     <td>_MyColor</td><td>NPC's RGB modifier (<a href="#mycolor">*</a>)</td><td>505050</td><td>000000,999999</td>
   </tr><tr>
     <td>_MySword</td><td>NPC's sword type (<a href="#mysword">*</a>)</td><td>-1 (use base type)</td><td>-1,9</td>
+	</tr><tr>
+    <td>_MyWeakness</td><td>NPC's custom weakness type (<a href="#myweakness">*</a>)</td><td></td><td>Text</td>
+  </tr><tr>
+    <td>_MyDescription</td><td>NPC's custom description (<a href="#mydescription">*</a>)</td><td></td><td>Text</td>
   </tr><tr>
     <td>_MyX</td><td>NPC's X coordinate (room column)</td><td></td><td>0,15</td>
   </tr><tr>
@@ -822,6 +826,8 @@ The variable names are case-insensitive.
   A value of 0 indicates no sword.
 </p>
 <p><a name="myweakness"><b>*_MyWeakness</b></a> - Allows a custom weakness to be set for a monster or equipment. A weapon or accessory is strong (i.e. player gets x2 ATK) against a monster if both _MyWeakness values are the same. The comparison is case-sensitive, so for example the values "Eyeball" and "eyeball" would not be considered the same.
+</p>
+<p><a name="mydescription"><b>*_MyDescription</b></a> - A custom description property that can be set for a monster or equipment. It will be displayed after any behavior descriptors that apply to the character. A semi-colon can be used to split the description into multiple descriptors that will be displayed separately.
 </p>
 <p><a name="paramoverride"><b>*_MyScriptX</b></a> - This and the other script
   command parameter overrides are used if variable parameters are required

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -574,6 +574,8 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
 	  protection against monsters with this attack ability.</li>
   <li><a name="be_attacklast"><u>Attack last</u></a>:
 	  Always attack last against the enemy.</li>
+  <li><a name="be_attacklast"><u>Removes sword</u></a>:
+	  A piece of equipment with this behavior will prevent the player from holding a sword, even if they have a weapon equipped. The player still benefits from the weapon's stat increases, and any other scripted effects it may have.</li>
   <li><a name="be_droptrapdoors"><u>Drop Trapdoors</u></a>:
 	  When moving off trapdoors, setting this causes them to drop.
 	  Otherwise, nothing happens (default).</li>

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1591,6 +1591,8 @@ enum MID_CONSTANT {
   MID_VarScoreXP = 1823,
   MID_VarMyWeakness = 1828,
   MID_VarLevelMultiplier = 1833,
+  MID_VarRoomX = 1834,
+  MID_VarRoomY = 1835,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1503,6 +1503,7 @@ enum MID_CONSTANT {
   MID_LogicalWaitEnd = 1814,
   MID_CustomAspect = 1829,
   MID_StrongAgainstAspect = 1830,
+  MID_RemovesSword = 1832,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1504,6 +1504,10 @@ enum MID_CONSTANT {
   MID_CustomAspect = 1829,
   MID_StrongAgainstAspect = 1830,
   MID_RemovesSword = 1832,
+  MID_CharOptionsTitle = 1836,
+  MID_CharOptions = 1837,
+  MID_ProcessingSequence = 1838,
+  MID_ProcessingSequenceDescription = 1839,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1590,6 +1590,7 @@ enum MID_CONSTANT {
   MID_VarScoreGold = 1822,
   MID_VarScoreXP = 1823,
   MID_VarMyWeakness = 1828,
+  MID_VarLevelMultiplier = 1833,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1597,6 +1597,7 @@ enum MID_CONSTANT {
   MID_VarLevelMultiplier = 1833,
   MID_VarRoomX = 1834,
   MID_VarRoomY = 1835,
+  MID_VarMyDescription = 1840,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1331,3 +1331,19 @@ Strong against %s
 [MID_RemovesSword]
 [eng]
 Removes sword
+
+[MID_CharOptionsTitle]
+[eng]
+Character Options
+
+[MID_CharOptions]
+[eng]
+Options
+
+[MID_ProcessingSequence]
+[eng]
+Processing Sequence:
+
+[MID_ProcessingSequenceDescription]
+[eng]
+Scripts with a lower processing sequence value will run before scripts with a higher value.

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1327,3 +1327,7 @@ Wait for Conditions End
 [MID_StrongAgainstAspect]
 [eng]
 Strong against %s
+
+[MID_RemovesSword]
+[eng]
+Removes sword

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -337,3 +337,11 @@ _MyWeakness
 [MID_VarLevelMultiplier]
 [eng]
 _LevelMultiplier
+
+[MID_VarRoomX]
+[eng]
+_RoomX
+
+[MID_VarRoomY]
+[eng]
+_RoomY

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -333,3 +333,7 @@ _ScoreREP
 [MID_VarMyWeakness]
 [eng]
 _MyWeakness
+
+[MID_VarLevelMultiplier]
+[eng]
+_LevelMultiplier

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -345,3 +345,7 @@ _RoomX
 [MID_VarRoomY]
 [eng]
 _RoomY
+
+[MID_VarMyDescription]
+[eng]
+_MyDescription


### PR DESCRIPTION
## Introduction
This is a group of new scripting features for RPG.

### Pre-defined vars
New vars to access various game state information

`_RoomX`, `_RoomY`: The position of the current room relative to the level entrance (read-only)
`_LevelMultiplier`: Read-only access to the current level's base multiplier value
`_MyDescription`: A NPC variable to allow additional tooltip content ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=45811))

### Behaviour
A new NPC behaviour

`Removes Sword` - Equipment behaviour that causes the player not to have a sword. ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=26959))

### Custom processing sequence
All the stuff has been plumbed in to allow NPCs to have a custom processing sequence. Doesn't effect the order equipment scripts get run because those are run in a special way.