### PR TITLE
Upgrade SDL2 and SDL2_tff and accept alternative arrow key bindings

### DIFF
--- a/CompilingDrod_Win.md
+++ b/CompilingDrod_Win.md
@@ -39,8 +39,8 @@ The game requires the following libraries. Different versions may potentially be
  -  `libvorbis-1.3.3` => http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.gz
  -  `lpng-1512` => https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.12/lpng1512.zip
  -  `metakit-2.4.9.7` => https://github.com/jnorthrup/metakit/archive/master.zip
- -  `sdl2-2.0.12` => https://www.libsdl.org/release/SDL2-2.0.12.zip
- -  `sdl-ttf-2.0.14` => https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip
+ -  `sdl2-2.26.1` => https://github.com/libsdl-org/SDL/releases/download/release-2.26.1/SDL2-2.26.1.zip
+ -  `sdl-ttf-2.20.1` => https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.20.1/SDL2_ttf-devel-2.20.1-VC.zip
  -  `zlib` => http://www.zlib.net/fossils/zlib-1.2.11.tar.gz
 
 You need the DLLs from the following libraries to go into the same dir with your built drod.exe:

--- a/DROD/RoomScreen.cpp
+++ b/DROD/RoomScreen.cpp
@@ -347,6 +347,37 @@ void CRoomScreen::InitKeysymToCommandMap(
 				COMMANDKEY_ARRAY[wKeyboard][wIndex]);
 		const bool bInvalidSDL1mapping = nKey >= 128 && nKey <= 323;
 		this->KeysymToCommandMap[bInvalidSDL1mapping ? COMMANDKEY_ARRAY[wKeyboard][wIndex] : nKey] = commands[wIndex];
+
+		// Numlock being off can cause the numpad to be treated as different keys, but only the arrows for some reason
+		// So we store an alternative key map that flips arrow keys and some numpad keys so we can check for both
+		int altKey = nKey;
+		switch (nKey) {
+			case SDLK_KP_8:
+				altKey = SDLK_UP;
+				break;
+			case SDLK_KP_4:
+				altKey = SDLK_LEFT;
+				break;
+			case SDLK_KP_6:
+				altKey = SDLK_RIGHT;
+				break;
+			case SDLK_KP_2:
+				altKey = SDLK_DOWN;
+				break;
+			case SDLK_UP:
+				altKey = SDLK_KP_8;
+				break;
+			case SDLK_LEFT:
+				altKey = SDLK_KP_4;
+				break;
+			case SDLK_RIGHT:
+				altKey = SDLK_KP_6;
+				break;
+			case SDLK_DOWN:
+				altKey = SDLK_KP_2;
+				break;
+		}
+		this->AlternativeKeysymToCommandMap[bInvalidSDL1mapping ? COMMANDKEY_ARRAY[wKeyboard][wIndex] : altKey] = commands[wIndex];
 	}
 }
 
@@ -356,6 +387,10 @@ int CRoomScreen::GetCommandForKeysym(const SDL_Keycode& sym) const
 	std::map<SDL_Keycode,int>::const_iterator it = this->KeysymToCommandMap.find(sym);
 	if (it != this->KeysymToCommandMap.end())
 		return it->second;
+
+	std::map<SDL_Keycode, int>::const_iterator itAlternative = this->AlternativeKeysymToCommandMap.find(sym);
+	if (itAlternative != this->AlternativeKeysymToCommandMap.end())
+		return itAlternative->second;
 
 	return CMD_UNSPECIFIED;
 }

--- a/DROD/RoomScreen.h
+++ b/DROD/RoomScreen.h
@@ -91,6 +91,7 @@ protected:
 
 private:
 	std::map<SDL_Keycode,int> KeysymToCommandMap;
+	std::map<SDL_Keycode, int> AlternativeKeysymToCommandMap;
 };
 
 #endif //...#ifndef ROOMSCREEN_H

--- a/DRODLib/GameConstants.cpp
+++ b/DRODLib/GameConstants.cpp
@@ -124,6 +124,10 @@ namespace InputCommands
 			case SDLK_KP_9: return MID_KEY_KP9;
 			case SDLK_KP_0: return MID_KEY_KP0;
 			case SDLK_KP_PERIOD: return MID_KEY_KP_PERIOD;
+			case SDLK_LEFT: return MID_KEY_LEFT;
+			case SDLK_RIGHT: return MID_KEY_RIGHT;
+			case SDLK_UP: return MID_KEY_UP;
+			case SDLK_DOWN: return MID_KEY_DOWN;
 			default: return static_cast<MESSAGE_ID>((long) MID_UNKNOWN + nKey);
 		}
 	}

--- a/Scripts/InstallDependencies.win32.vs2013.py
+++ b/Scripts/InstallDependencies.win32.vs2013.py
@@ -39,7 +39,7 @@ DependenciesLibraries = DependenciesDir + "Library\\"
 DependenciesDlls = DependenciesDir + "Dll\\"
 ZlibUrl = 'http://www.zlib.net/fossils/zlib-1.2.11.tar.gz'
 LibOggName = 'libogg-1.3.0'
-SdlName = 'sdl2-2.0.12'
+SdlName = 'sdl2-2.26.1'
 
 if DepsToBuild == "all":
 	DepsToBuild = [
@@ -54,7 +54,7 @@ if DepsToBuild == "all":
 		'lpng-1512',
 		'metakit-2.4.9.7',
 		SdlName,
-		'sdl-ttf-2.0.14',
+		'sdl-ttf-2.20.1',
 		'zlib'
 	]
 
@@ -333,10 +333,10 @@ dependencies = {
 		}
 	},
 	SdlName: {
-		'urls': ['https://www.libsdl.org/release/SDL2-2.0.12.zip'],
+		'urls': ['https://github.com/libsdl-org/SDL/releases/download/release-2.26.1/SDL2-2.26.1.zip'],
 		'builds': [
 			{
-				'sln': 'sdl2-2.0.12/VisualC/SDL.sln',
+				'sln': 'sdl2-2.26.1/VisualC/SDL.sln',
 				'configs': [
 					['Debug', '/project', 'SDL2'],
 					['Release', '/project', 'SDL2'],
@@ -346,30 +346,29 @@ dependencies = {
 			}
 		],
 		'include': {
-			'SDL2-2.0.12/include': '' #Too many files to list them one by one
+			'SDL2-2.26.1/include': '' #Too many files to list them one by one
 		},
 		'libs': {
-			'SDL2-2.0.12/VisualC/Win32/Debug/SDL2.lib': 'Debug',
-			'SDL2-2.0.12/VisualC/Win32/Release/SDL2.lib': 'Release',
-			'SDL2-2.0.12/VisualC/Win32/Debug/SDL2main.lib': 'Debug',
-			'SDL2-2.0.12/VisualC/Win32/Release/SDL2main.lib': 'Release'
+			'SDL2-2.26.1/VisualC/Win32/Debug/SDL2.lib': 'Debug',
+			'SDL2-2.26.1/VisualC/Win32/Release/SDL2.lib': 'Release',
+			'SDL2-2.26.1/VisualC/Win32/Debug/SDL2main.lib': 'Debug',
+			'SDL2-2.26.1/VisualC/Win32/Release/SDL2main.lib': 'Release'
 		},
 		'dlls': {
-			'SDL2-2.0.12/VisualC/Win32/Debug/SDL2.dll': 'Debug',
-			'SDL2-2.0.12/VisualC/Win32/Release/SDL2.dll': 'Release'
+			'SDL2-2.26.1/VisualC/Win32/Debug/SDL2.dll': 'Debug',
+			'SDL2-2.26.1/VisualC/Win32/Release/SDL2.dll': 'Release'
 		}
 	},
-	'sdl-ttf-2.0.14': {
-		'urls': ['https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip'],
+	'sdl-ttf-2.20.1': {
+		'urls': ['https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.20.1/SDL2_ttf-devel-2.20.1-VC.zip'],
 		'include': {
-			'SDL2_ttf-2.0.14/include': ''
+			'SDL2_ttf-2.20.1/include': ''
 		},
 		'libs': {
-			'SDL2_ttf-2.0.14/lib/x86/SDL2_ttf.lib': ['Debug', 'Release']
+			'SDL2_ttf-2.20.1/lib/x86/SDL2_ttf.lib': ['Debug', 'Release']
 		},
 		'dlls': {
-			'SDL2_ttf-2.0.14/lib/x86/SDL2_ttf.dll': ['Debug', 'Release'],
-			'SDL2_ttf-2.0.14/lib/x86/libfreetype-6.dll': ['Debug', 'Release']
+			'SDL2_ttf-2.20.1/lib/x86/SDL2_ttf.dll': ['Debug', 'Release']
 		}
 	},
 	'zlib': {


### PR DESCRIPTION
Issue was reported by Tahnan that DROD does not recognise numpad keys 8, 6, 4 and 2 when numlock is off, but the others are fine.
https://forum.caravelgames.com/viewtopic.php?TopicID=45829
At first I believed this to be an SDL2 issue, and so upgraded SDL2 and SDL2_ttf dependendencies to their latest stable versions. However, this did not seem to fix the issue. I left in the upgrade anyway, because I put in the work.

Instead, I have added functionality to recognise the arrow keys as alternative key binds for the 4 numpad keys with an issue. If you press a key and it is not initially mapped to a game command, the game will then check an alternative keybind mapping with the arrow keys and num keys flipped to see if there is then a match.

P.S. SDL2_ttf no longer uses libfreetype-6.dll so this no longer needs to be included.

This is a repeat of PR https://github.com/CaravelGames/drod/pull/474 but I nuked the messed up commit history to get a clean commit