### PR TITLE
RPG: Add prompt when starting new game if a game is active

### DIFF
--- a/drodrpg/DROD/SettingsScreen.cpp
+++ b/drodrpg/DROD/SettingsScreen.cpp
@@ -127,6 +127,8 @@ const UINT TAG_UPLOADSCORES = 1065;
 const UINT TAG_AUTOSAVE = 1070;
 const UINT TAG_ITEMTIPS = 1071;
 
+const UINT TAG_NEWGAMEPROMPT = 1072;
+
 //don't use values 1080-1089
 
 const UINT TAG_CANCEL = 1091;
@@ -269,6 +271,16 @@ CSettingsScreen::CSettingsScreen()
 	static const UINT CX_ITEMTIPS = CX_AUTOSAVE;
 	static const UINT CY_ITEMTIPS = CY_STANDARD_OPTIONBUTTON;
 	static const UINT CY_EDITOR_FRAME = Y_ITEMTIPS + CY_ITEMTIPS + CY_SPACE;
+
+	//New game frame and children
+	static const int X_NEWGAME_FRAME = X_EDITOR_FRAME;
+	static const int Y_NEWGAME_FRAME = Y_EDITOR_FRAME + CY_EDITOR_FRAME + 2*CY_SPACE;
+	static const UINT CX_NEWGAME_FRAME = CX_EDITOR_FRAME;
+	static const int X_NEWGAMEPROMPT = CX_SPACE;
+	static const int Y_NEWGAMEPROMPT = CY_SPACE;
+	static const UINT CX_NEWGAMEPROMPT = CX_NEWGAME_FRAME - X_NEWGAMEPROMPT - CX_SPACE;
+	static const UINT CY_NEWGAMEPROMPT = CY_STANDARD_OPTIONBUTTON;
+	static const UINT CY_NEWGAME_FRAME = Y_NEWGAMEPROMPT + CY_NEWGAMEPROMPT + CY_SPACE;
 
 	//Game speed frame and children.
 	static const int X_SPECIAL_FRAME = X_PERSONAL_FRAME;
@@ -578,6 +590,15 @@ CSettingsScreen::CSettingsScreen()
 					g_pTheDB->GetMessageText(MID_ItemTips), true);
 	pEditorFrame->AddWidget(pOptionButton);
 
+	//New game frame
+	CFrameWidget* pNewGameFrame = new CFrameWidget(0L, X_NEWGAME_FRAME, Y_NEWGAME_FRAME,
+		CX_NEWGAME_FRAME, CY_NEWGAME_FRAME, L"New games");
+	pTabbedMenu->AddWidgetToTab(pNewGameFrame, PERSONAL_TAB);
+
+	pOptionButton = new COptionButtonWidget(TAG_NEWGAMEPROMPT, X_NEWGAMEPROMPT,
+		Y_NEWGAMEPROMPT, CX_NEWGAMEPROMPT, CY_NEWGAMEPROMPT,
+		L"Confirm new game", true);
+	pNewGameFrame->AddWidget(pOptionButton);
 
 	//Graphics and sound tab.
 
@@ -1402,6 +1423,11 @@ void CSettingsScreen::UpdateWidgetsFromPlayerData(
 			GetWidget(TAG_DISABLE_MOUSE_MOVEMENT));
 	pOptionButton->SetChecked(settings.GetVar(Settings::DisableMouse, false));
 
+	//New game settings.
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_NEWGAMEPROMPT));
+	pOptionButton->SetChecked(settings.GetVar(Settings::NewGamePrompt, true));
+
 	//Command settings.
 	for (int nCommand = DCMD_First; nCommand < DCMD_Count; ++nCommand)
 	{
@@ -1529,6 +1555,11 @@ void CSettingsScreen::UpdatePlayerDataFromWidgets(
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_DISABLE_MOUSE_MOVEMENT));
 	settings.SetVar(Settings::DisableMouse, pOptionButton->IsChecked());
+
+	//New game settings.
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_NEWGAMEPROMPT));
+	settings.SetVar(Settings::NewGamePrompt, pOptionButton->IsChecked());
 
 	//Command settings--these were updated in response to previous UI events, 
 	//so nothing to do here.

--- a/drodrpg/DROD/SettingsScreen.cpp
+++ b/drodrpg/DROD/SettingsScreen.cpp
@@ -592,12 +592,12 @@ CSettingsScreen::CSettingsScreen()
 
 	//New game frame
 	CFrameWidget* pNewGameFrame = new CFrameWidget(0L, X_NEWGAME_FRAME, Y_NEWGAME_FRAME,
-		CX_NEWGAME_FRAME, CY_NEWGAME_FRAME, L"New games");
+		CX_NEWGAME_FRAME, CY_NEWGAME_FRAME, g_pTheDB->GetMessageText(MID_NewGames));
 	pTabbedMenu->AddWidgetToTab(pNewGameFrame, PERSONAL_TAB);
 
 	pOptionButton = new COptionButtonWidget(TAG_NEWGAMEPROMPT, X_NEWGAMEPROMPT,
 		Y_NEWGAMEPROMPT, CX_NEWGAMEPROMPT, CY_NEWGAMEPROMPT,
-		L"Confirm new game", true);
+		g_pTheDB->GetMessageText(MID_ConfirmNewGame), true);
 	pNewGameFrame->AddWidget(pOptionButton);
 
 	//Graphics and sound tab.

--- a/drodrpg/DROD/TitleScreen.cpp
+++ b/drodrpg/DROD/TitleScreen.cpp
@@ -768,8 +768,10 @@ SCREENTYPE CTitleScreen::ProcessMenuSelection(
 			CGameScreen *pGameScreen = DYN_CAST(CGameScreen*, CScreen*,
 					g_pTheSM->GetScreen(SCR_Game));
 			ASSERT(pGameScreen);
-			if (pGameScreen->IsGameLoaded())
+			if (pGameScreen->IsGameLoaded()) {
+				if (ShowYesNoMessage(L"Really start a new game?") != TAG_YES) return SCR_Title;
 				pGameScreen->UnloadGame();
+			}
 			if (!pGameScreen->LoadNewGame(dwCurrentHoldID))
 			{
 				ShowOkMessage(MID_LoadGameFailed);

--- a/drodrpg/DROD/TitleScreen.cpp
+++ b/drodrpg/DROD/TitleScreen.cpp
@@ -771,7 +771,8 @@ SCREENTYPE CTitleScreen::ProcessMenuSelection(
 			CGameScreen *pGameScreen = DYN_CAST(CGameScreen*, CScreen*,
 					g_pTheSM->GetScreen(SCR_Game));
 			ASSERT(pGameScreen);
-			if (pGameScreen->IsGameLoaded()) {
+			const UINT dwContinueID = g_pTheDB->SavedGames.FindByContinue();
+			if (pGameScreen->IsGameLoaded() || dwContinueID) {
 				if (!ConfirmNewGame()) return SCR_Title;
 				pGameScreen->UnloadGame();
 			}

--- a/drodrpg/DROD/TitleScreen.cpp
+++ b/drodrpg/DROD/TitleScreen.cpp
@@ -941,7 +941,7 @@ bool CTitleScreen::ConfirmNewGame()
 	if (!this->bNewGamePrompt)
 		return true;
 
-	return (ShowYesNoMessage(L"Really start a new game?") == TAG_YES);
+	return (ShowYesNoMessage(g_pTheDB->GetMessageText(MID_ReallyStartNewGame)) == TAG_YES);
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/TitleScreen.cpp
+++ b/drodrpg/DROD/TitleScreen.cpp
@@ -114,6 +114,7 @@ CTitleScreen::CTitleScreen() : CDrodScreen(SCR_Title)
 	, pMarqueeWidget(NULL)
 	, bWaitingForHoldlist(false)
 	, bPredarken(true), bReloadGraphics(false)
+	, bNewGamePrompt(true)
 //Constructor.
 {
 	string TitleBG;
@@ -265,6 +266,8 @@ bool CTitleScreen::SetForActivate()
 
 	const CDbPackedVars settings = g_pTheDB->GetCurrentPlayerSettings();
 	g_pTheSound->bNoFocusPlaysMusic = settings.GetVar(Settings::NoFocusPlaysMusic, false);
+
+	this->bNewGamePrompt = settings.GetVar(Settings::NewGamePrompt, true);
 
 	ASSERT(!this->bWaitingForHoldlist); //no previous transaction should be left uncompleted
 	if (g_pTheNet->IsEnabled()) //if CaravelNet connection hasn't been disabled
@@ -769,7 +772,7 @@ SCREENTYPE CTitleScreen::ProcessMenuSelection(
 					g_pTheSM->GetScreen(SCR_Game));
 			ASSERT(pGameScreen);
 			if (pGameScreen->IsGameLoaded()) {
-				if (ShowYesNoMessage(L"Really start a new game?") != TAG_YES) return SCR_Title;
+				if (!ConfirmNewGame()) return SCR_Title;
 				pGameScreen->UnloadGame();
 			}
 			if (!pGameScreen->LoadNewGame(dwCurrentHoldID))
@@ -928,6 +931,17 @@ void CTitleScreen::Animate()
 {
 	//Redraw the screen.
 	RedrawScreen();
+}
+
+//*****************************************************************************
+bool CTitleScreen::ConfirmNewGame()
+//Returns: If player really wants to start a new game
+{
+	//New game confirmation is disabled in player settings
+	if (!this->bNewGamePrompt)
+		return true;
+
+	return (ShowYesNoMessage(L"Really start a new game?") == TAG_YES);
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/TitleScreen.h
+++ b/drodrpg/DROD/TitleScreen.h
@@ -71,6 +71,8 @@ protected:
 private:
 	void     Animate();
 
+	bool ConfirmNewGame();
+
 	void     RequestNews();
 	UINT    GetNextDemoID();
 	virtual void   Paint(bool bUpdateRect=true);
@@ -126,6 +128,9 @@ private:
 	//Graphics.
 	bool bPredarken;
 	bool bReloadGraphics;
+
+	//New game
+	bool bNewGamePrompt;
 };
 
 #endif //...#ifndef TITLESCREEN_H

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -767,6 +767,9 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ProcessingSequence: strText = "Processing sequence:"; break;
 		case MID_ProcessingSequenceDescription: strText = "Scripts with a lower processing sequence value will run before scripts with a higher value."; break;
 		case MID_VarMyDescription: strText = "_MyDescription"; break;
+		case MID_NewGames: strText = "New games"; break;
+		case MID_ConfirmNewGame: strText = "Confirm new game"; break;
+		case MID_ReallyStartNewGame: strText = "Really start a new game?"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/SettingsKeys.cpp
+++ b/drodrpg/DRODLib/SettingsKeys.cpp
@@ -66,6 +66,7 @@ namespace Settings
 	DEF(MoveCounter);
 	DEF(Music);
 	DEF(MusicVolume);
+	DEF(NewGamePrompt);
 	DEF(NoFocusPlaysMusic);
 	DEF(PlaySessions);
 	DEF(PuzzleMode);

--- a/drodrpg/DRODLib/SettingsKeys.h
+++ b/drodrpg/DRODLib/SettingsKeys.h
@@ -66,6 +66,7 @@ namespace Settings
 	DEF(MoveCounter);
 	DEF(Music);
 	DEF(MusicVolume);
+	DEF(NewGamePrompt);
 	DEF(NoFocusPlaysMusic);
 	DEF(PlaySessions);
 	DEF(PuzzleMode);

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1168,6 +1168,8 @@ enum MID_CONSTANT {
   MID_DisableMouseMovement = 1735,
   MID_NoFocusPlaysMusic = 1746,
   MID_ShowScore = 1831,
+  MID_NewGames = 1841,
+  MID_ConfirmNewGame = 1842,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,
@@ -1635,6 +1637,7 @@ enum MID_CONSTANT {
   MID_ChatTip = 1468,
   MID_InvalidCaravelNetKey = 1195,
   MID_UnsentCaravelNetProgress = 1196,
+  MID_ReallyStartNewGame = 1843,
 
   //Messages from Weather.uni:
   MID_WeatherTitle = 1143,

--- a/drodrpg/Texts/SettingsScreen.uni
+++ b/drodrpg/Texts/SettingsScreen.uni
@@ -441,3 +441,11 @@ Combat damage preview
 [MID_ShowScore]
 [eng]
 Show score
+
+[MID_NewGames]
+[eng]
+New games
+
+[MID_ConfirmNewGame]
+[eng]
+Confirm new game

--- a/drodrpg/Texts/TitleScreen.uni
+++ b/drodrpg/Texts/TitleScreen.uni
@@ -127,3 +127,7 @@ Your CaravelNet user key is invalid.  Go to the Settings Screen to request a new
 [MID_UnsentCaravelNetProgress]
 [eng]
 You have progress that hasn't been sent to CaravelNet.  Click "Submit My Scores" on the Settings Screen to send it.
+
+[MID_ReallyStartNewGame]
+[eng]
+Really start a new game?


### PR DESCRIPTION
Starting a new game in DROD RPG overwrites the existing game, in a non-recoverable manner. This can lead to a loss of progress if a manual save has not been created recently.

To reduce the chance of this, we can confirm if the player really wants to start a new game with a yes/no dialog. This prompt can be disabled in the settings, if the player wants.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45874