### PR TITLE
Add _CharacterType script primitive function

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -615,6 +615,21 @@ int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vect
 			return -1;
 		}
 		break;
+		case ScriptVars::P_CharacterType:
+		{
+			CMonster* pMonster = this->pRoom->GetMonsterAtSquare(params[0], params[1]);
+			if (!pMonster) {
+				return -1;
+			}
+
+			CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
+			if (!pCharacter) {
+				return -1;
+			}
+
+			return pCharacter->wLogicalIdentity;
+		}
+		break;
 		case ScriptVars::P_EntityWeapon:
 		{
 			if (IsPlayerAt(params[0], params[1])) {

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -28,7 +28,7 @@ string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call
 
 //*****************************************************************************
 // Values are not case sensitive; caps added here for readability
-const char ScriptVars::primitiveNames[PrimitiveCount][14] =
+const char ScriptVars::primitiveNames[PrimitiveCount][15] =
 {
 	"_abs",
 	"_min",
@@ -46,6 +46,7 @@ const char ScriptVars::primitiveNames[PrimitiveCount][14] =
 	"_ArrowDir",
 	"_RoomTile",
 	"_MonsterType",
+	"_CharacterType",
 	"_EntityWeapon",
 	"_BrainScore"
 };
@@ -109,6 +110,7 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_RotateDist:
 		case P_ArrowDir:
 		case P_MonsterType:
+		case P_CharacterType:
 		case P_EntityWeapon:
 			return 2;
 		case P_RoomTile:

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -105,6 +105,7 @@ namespace ScriptVars
 		P_ArrowDir,  //(x,y) --> direction of arrow at (x,y)
 		P_RoomTile,  //(x,y,z) --> id of room tile at (x,y) on layer z
 		P_MonsterType,//(x,y) --> type of monster at (x,y), or -1 if no monster is there
+		P_CharacterType,//(x,y) --> appearance of character at (x,y) or -1 if no character is there
 		P_EntityWeapon,//(x,y) --> weapon type of monster/player at (x,y), or -1 if no weapon holder is there
 		P_BrainScore,//(x,y,t) --> pathmap score of tile at (x,y) for movement type t
 		PrimitiveCount
@@ -127,7 +128,7 @@ namespace ScriptVars
 	//All predefined vars.
 	extern const UINT predefinedVarMIDs[PredefinedVarCount];
 	extern string midTexts[PredefinedVarCount];
-	extern const char primitiveNames[PrimitiveCount][14]; //expand buffer size as needed
+	extern const char primitiveNames[PrimitiveCount][15]; //expand buffer size as needed
 };
 
 //Stats used for various tally operations.

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -610,6 +610,9 @@ Hint: Each layer corresponds to a tab in the editor's tile selection dialog.
 <p><a name="monstertype">* <b>_MonsterType(x,y)</b></a> - Returns the numeric monster type of the monster at (x,y). If no monster is present on the tile, -1 is returned.<br/>
 Hint: This can be used to compare the monsters in different tiles, or for providing a value for _MyScript injection.
 </p>
+<p><a name="charactertype">* <b>_CharacterType(x,y)</b></a> - Returns the logical type of the scripted character at (x,y). If no character is present on the tile, -1 is returned.<br/>
+  Hint: This can be used to provide a value for _MyScript injection.
+</p>
 <p><a name="entityweapon">* <b>_EntityWeapon(x,y)</b></a> - Returns the numeric weapon type of the monster or player at (x,y). The weapon type will be returned even if the entity is currently disarmed. If no weapon-using entity is present, -1 is returned.</p>
 <p><a name="brainscore">* <b>_BrainScore(x,y,t)</b></a> - Returns the distance the given tile is from the player, along a brained path, for the given <a href="#movement-types">movement type</a>. Tiles that cannot access the player return a value of -1.</p>
 


### PR DESCRIPTION
An extension, in a sense, of the `_MonsterType` primitive, `_CharacterType` allows the logical identity of a scripted character be extracted. Useful for cases when you want to do something treats normal and custom elements in the same way.