### PR TITLE
RPG: Also override switcher token with spawn overrides

### DIFF
--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -103,6 +103,7 @@ public:
 	vector<WSTRING> GetCustomDescriptions() const;
 	WSTRING        GetCustomWeakness() const { return this->customWeakness; };
 	virtual UINT   GetIdentity() const {return this->wIdentity;}
+	virtual UINT   GetLogicalIdentity() const {return this->wLogicalIdentity;}
 	UINT           GetNextSpeechID();
 	virtual UINT   GetResolvedIdentity() const;
 	virtual UINT   GetSpawnType(UINT defaultMonsterID) const;

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -7353,6 +7353,13 @@ void CDbRoom::SwitchTarstuff(const UINT wType1, const UINT wType2)
 	const int mudId = this->pCurrentGame->getSpawnID(M_MUDBABY);
 	const int gelId = this->pCurrentGame->getSpawnID(M_GELBABY);
 
+	//Don't try to swap from or to multi-tile monsters
+	if ((bTar && bIsLargeMonster(tarId)) ||
+		(bMud && bIsLargeMonster(mudId)) ||
+		(bGel && bIsLargeMonster(gelId))) {
+		return; 
+	}
+
 	UINT wX, wY;
 	CCueEvents Ignored;
 	for (wY=0; wY<this->wRoomRows; ++wY)

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -191,6 +191,7 @@ public:
 			const MovementIQ movementIQ=SmartDiagonalOnly,
 			const bool bIncludeNonTarget=false) const;
 	virtual UINT  GetIdentity() const {return this->wType;}
+	virtual UINT  GetLogicalIdentity() const {return this->wType;}
 	static  bool  GetNextGaze(CCueEvents &CueEvents, CMonster *pCaster, CDbRoom *pRoom,
 			const bool bElevatedSource, UINT& cx, UINT& cy, int& dx, int& dy);
 	UINT          GetOrientationFacingTarget(const UINT wX, const UINT wY) const;

--- a/drodrpg/DRODLib/MonsterFactory.h
+++ b/drodrpg/DRODLib/MonsterFactory.h
@@ -126,6 +126,8 @@ static inline bool bIsGoblin(const UINT mt) {return mt == M_GOBLIN || mt == M_GO
 
 static inline bool bIsSerpent(const UINT mt) {return mt==M_SERPENT || mt==M_SERPENTG || mt==M_SERPENTB;}
 
+static inline bool bIsLargeMonster(const UINT mt) { return bIsSerpent(mt) || mt == M_ROCKGIANT; }
+
 static inline bool bMonsterHasDirection(const UINT mt) {
 	switch (mt)
 	{


### PR DESCRIPTION
Reworks `CDbRoom::SwitchTarstuff` so that it considers the values set for the tarstuff baby override variables. This makes it easier to integrate switcher tokens into rooms using custom tarstuff spawns.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45895