### PR TITLE
Enlarge Add Command dialog

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -922,8 +922,8 @@ void CCharacterDialogWidget::AddCommandDialog()
 //Create another dialog for entering a script command.
 //Separated from constructor for readability.
 {
-	static const UINT CY_COMMAND_DIALOG = 412;
-	static const UINT CY_ACTIONLISTBOX = 13*LIST_LINE_HEIGHT+4;
+	static const UINT CY_COMMAND_DIALOG = 650;
+	static const UINT CY_ACTIONLISTBOX = 23*LIST_LINE_HEIGHT+4;
 
 #ifdef RUSSIAN_BUILD
 	static const UINT CX_COMMAND_DIALOG = 795;
@@ -1027,7 +1027,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CY_SPEAKERLABEL = CY_WAITLABEL;
 	static const int X_SPEAKERLISTBOX = X_SPEAKERLABEL;
 	static const int Y_SPEAKERLISTBOX = Y_SPEAKERLABEL + CY_SPEAKERLABEL;
-	static const UINT CY_SPEAKERLISTBOX = 7*LIST_LINE_HEIGHT+4;
+	static const UINT CY_SPEAKERLISTBOX = 18*LIST_LINE_HEIGHT+4;
 
 	static const UINT CX_MOODLISTBOX = 100;
 	static const int X_MOODLABEL = X_SPEAKERLABEL + CX_SPEAKERLABEL + CX_SPACE;
@@ -1036,7 +1036,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CY_MOODLABEL = CY_WAITLABEL;
 	static const int X_MOODLISTBOX = X_MOODLABEL;
 	static const int Y_MOODLISTBOX = Y_MOODLABEL + CY_MOODLABEL;
-	static const UINT CY_MOODLISTBOX = 5*LIST_LINE_HEIGHT+4;
+	static const UINT CY_MOODLISTBOX = 7*LIST_LINE_HEIGHT+4;
 
 	static const UINT CX_BUTTON = 80;
 	static const int X_OKBUTTON = (CX_COMMAND_DIALOG - (CX_BUTTON + CX_SPACE) * 2) / 2;
@@ -1080,11 +1080,11 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const int Y_WATERTRAVERSALLISTBOX = Y_ONOFFLISTBOX;
 
 	static const UINT CX_IMPERATIVELISTBOX = 420;
-	static const UINT CY_IMPERATIVELISTBOX = 12*LIST_LINE_HEIGHT + 4;
+	static const UINT CY_IMPERATIVELISTBOX = CY_ACTIONLISTBOX;
 	static const int X_IMPERATIVELISTBOX = X_ONOFFLISTBOX;
 	static const int Y_IMPERATIVELISTBOX = Y_ONOFFLISTBOX;
 
-	static const UINT CY_BEHAVIORLISTBOX = 10 * LIST_LINE_HEIGHT + 4;
+	static const UINT CY_BEHAVIORLISTBOX = CY_ACTIONLISTBOX - 3 * LIST_LINE_HEIGHT;
 
 	static const UINT CX_OPENCLOSELISTBOX = 100;
 	static const UINT CY_OPENCLOSELISTBOX = 53;
@@ -1101,7 +1101,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CY_GOTOLABELTEXT = CY_WAIT;
 
 	static const UINT CX_GOTOLABELLISTBOX = CX_GOTOLABELTEXT;
-	static const UINT CY_GOTOLABELLISTBOX = 10*LIST_LINE_HEIGHT+4;
+	static const UINT CY_GOTOLABELLISTBOX = CY_ACTIONLISTBOX - 2* LIST_LINE_HEIGHT;
 	static const int X_GOTOLABELLISTBOX = X_EVENTLISTBOX;
 	static const int Y_GOTOLABELLISTBOX = Y_GOTOLABELTEXT + CY_GOTOLABELTEXT + CY_SPACE;
 
@@ -1146,7 +1146,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CY_VARTEXTLABEL = CY_WAITLABEL;
 
 	static const UINT CX_VARLISTBOX = 280;
-	static const UINT CY_VARLISTBOX = 10*LIST_LINE_HEIGHT+4;
+	static const UINT CY_VARLISTBOX = 18*LIST_LINE_HEIGHT+4;
 	static const int X_VARLISTBOX = X_EVENTLISTBOX;
 	static const int Y_VARLISTBOX = Y_TEXT + CY_TEXT + CY_SPACE;
 
@@ -1168,7 +1168,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const int X_VARCOMPLIST = X_VARADD;
 	static const int Y_VARCOMPLIST = Y_VAROPLIST;
 	static const int CX_VARCOMPLIST = CX_VAROPLIST;
-	static const int CY_VARCOMPLIST = 6*LIST_LINE_HEIGHT + 4;
+	static const int CY_VARCOMPLIST = 7*LIST_LINE_HEIGHT + 4;
 
 	static const int X_VARVALUELABEL = X_VAROPLIST + CX_VAROPLIST + CX_SPACE/2;
 	static const UINT CY_VARVALUELABEL = CY_WAITLABEL;
@@ -1210,7 +1210,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const int X_EFFECTLISTBOX = X_DIRECTIONLISTBOX3 + CX_DIRECTIONLISTBOX3 + CX_SPACE;
 	static const int Y_EFFECTLISTBOX = Y_GRAPHICLISTBOX2;
 	static const UINT CX_EFFECTLISTBOX = 200;
-	static const UINT CY_EFFECTLISTBOX = CY_ACTIONLISTBOX;
+	static const UINT CY_EFFECTLISTBOX = CY_ACTIONLISTBOX - LIST_LINE_HEIGHT;
 
 	static const int X_SOUNDEFFECTLABEL = X_DIRECTIONLISTBOX3;
 	static const int Y_SOUNDEFFECTLABEL = Y_DIRECTIONLISTBOX3 + CY_DIRECTIONLISTBOX3 + CY_SPACE/2;
@@ -1280,10 +1280,13 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT IGNOREFLAGSLISTBOX_CX = CX_WAITFLAGSLISTBOX;
 	static const UINT IGNOREFLAGSLISTBOX_CY = CY_WAITFLAGSLISTBOX;
 
+	static const UINT IGNOREWEAPONSLABEL_X = MOVETYPELISTBOX_X;
+	static const UINT IGNOREWEAPONSLABEL_Y = MOVETYPELISTBOX_Y + MOVETYPELISTBOX_CY + CY_SPACE;
+
 	static const UINT COLORLISTBOX_X = X_DIRECTIONLISTBOX2;
 	static const UINT COLORLISTBOX_Y = Y_DIRECTIONLISTBOX;
 	static const UINT COLORLISTBOX_CX = CX_DIRECTIONLISTBOX2;
-	static const UINT COLORLISTBOX_CY = 12 * LIST_LINE_HEIGHT + 4;
+	static const UINT COLORLISTBOX_CY = 17 * LIST_LINE_HEIGHT + 4;
 
 	static const UINT ORBAGENTLISTBOX_X = X_ACTIONLISTBOX + CX_ACTIONLISTBOX + CX_SPACE;
 	static const UINT ORBAGENTLISTBOX_Y = Y_ACTIONLISTBOX;
@@ -1326,7 +1329,12 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const int X_IMAGEOVERLAYTEXT = X_IMAGELABEL;
 	static const int Y_IMAGEOVERLAYTEXT = Y_IMAGELABEL + CY_IMAGELABEL;
 	static const UINT CX_IMAGEOVERLAYTEXT = CX_TEXT;
-	static const UINT CY_IMAGEOVERLAYTEXT = 284;
+	static const UINT CY_IMAGEOVERLAYTEXT = CY_ACTIONLISTBOX;
+
+	//Positions for on off box 3
+	onOffListBox3Positions.insert({ CCharacterCommand::CC_GameEffect, {X_ONOFFLISTBOX3, Y_ONOFFLISTBOX3} });
+	onOffListBox3Positions.insert({ CCharacterCommand::CC_Behavior, {X_ONOFFLISTBOX3, Y_IMPERATIVELISTBOX + CY_BEHAVIORLISTBOX + CY_SPACE} });
+	onOffListBox3Positions.insert({ CCharacterCommand::CC_WaitForOpenTile, {X_ONOFFLISTBOX3, IGNOREWEAPONSLABEL_Y + CY_WAITLABEL + CY_SPACE / 2} });
 
 	ASSERT(!this->pAddCommandDialog);
 
@@ -1643,7 +1651,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 
 	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_IGNOREFLAGS_LABEL, IGNOREFLAGSLISTBOX_X, Y_WAITLABEL,
 		CX_WAITLABEL, CY_WAITLABEL, F_Small, g_pTheDB->GetMessageText(MID_Ignore)));
-	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_IGNOREWEAPONS_LABEL, X_SOUNDEFFECTLABEL, X_SOUNDEFFECTLABEL,
+	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_IGNOREWEAPONS_LABEL, IGNOREWEAPONSLABEL_X, IGNOREWEAPONSLABEL_Y,
 		CX_WAITLABEL, CY_WAITLABEL, F_Small, g_pTheDB->GetMessageText(MID_IgnoreWeapons)));
 
 	this->pBuildItemsListBox = new CListBoxWidget(TAG_BUILDITEMLISTBOX,
@@ -1663,7 +1671,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBuildMarkerListBox->SelectLine(0);
 
 	this->pNaturalTargetTypesListBox = new CListBoxWidget(TAG_NATURAL_TARGET_TYPES,
-		X_ITEMLISTBOX, Y_ITEMLISTBOX, CX_ITEMLISTBOX, CY_ITEMLISTBOX);
+		X_ITEMLISTBOX, Y_ITEMLISTBOX, CX_ITEMLISTBOX, 4 * LIST_LINE_HEIGHT + 4);
 	this->pAddCommandDialog->AddWidget(this->pNaturalTargetTypesListBox);
 	this->pNaturalTargetTypesListBox->SetHotkeyItemSelection(true);
 	this->pNaturalTargetTypesListBox->AddItem(ScriptFlag::RegularMonster, g_pTheDB->GetMessageText(MID_TargetRegularMonster));
@@ -1755,7 +1763,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pWeaponListBox->SelectLine(0);
 
 	this->pWeaponListBox2 = new CListBoxWidget(TAG_WEAPON_LISTBOX2,
-		X_WEAPON_LISTBOX, Y_WEAPON_LISTBOX, CX_WEAPON_LISTBOX, CY_WEAPON_LISTBOX);
+		X_WEAPON_LISTBOX, Y_WEAPON_LISTBOX, CX_WEAPON_LISTBOX, CY_WEAPON_LISTBOX - 2 * LIST_LINE_HEIGHT);
 	this->pAddCommandDialog->AddWidget(this->pWeaponListBox2);
 	this->pWeaponListBox2->AddItem(WT_Sword, g_pTheDB->GetMessageText(MID_WeaponSword));
 	this->pWeaponListBox2->AddItem(WT_Pickaxe, g_pTheDB->GetMessageText(MID_WeaponPickaxe));
@@ -1843,7 +1851,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pVarCompListBox->SelectLine(0);
 
 	this->pVarCompListBox2 = new CListBoxWidget(TAG_VARCOMPLIST2,
-		X_VARCOMPLIST, Y_VARCOMPLIST, CX_VARCOMPLIST, CY_VARCOMPLIST);
+		X_VARCOMPLIST, Y_VARCOMPLIST, CX_VARCOMPLIST, CY_VARCOMPLIST - LIST_LINE_HEIGHT);
 	this->pAddCommandDialog->AddWidget(this->pVarCompListBox2);
 	this->pVarCompListBox2->AddHotkey(SDLK_RETURN, TAG_OK);
 	this->pVarCompListBox2->AddItem(ScriptVars::Equals, g_pTheDB->GetMessageText(MID_VarEquals));
@@ -5852,6 +5860,15 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		CWidget *pWidget = this->pAddCommandDialog->GetWidget(*labels);
 		ASSERT(pWidget);
 		pWidget->Show();
+	}
+
+	//Place on off box three, which can be in various places.
+	//This is preferable to adding more on off boxes
+	if (onOffListBox3Positions.count(dwSelectedItem) != 0) {
+		CWidget* pWidget = this->pAddCommandDialog->GetWidget(TAG_ONOFFLISTBOX3);
+		ASSERT(pWidget);
+		pair<UINT, UINT> position = onOffListBox3Positions[dwSelectedItem];
+		pWidget->Move(position.first, position.second);
 	}
 
 	//Set name of loaded sound file, if any.

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -1331,10 +1331,22 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CY_IMAGEOVERLAYTEXT = CY_ACTIONLISTBOX;
 
 	//Positions for on off box 3
-	onOffListBox3Positions.insert({ CCharacterCommand::CC_SetNPCAppearance, {KEEPBEHAVIORLABEL_X, Y_ONOFFLISTBOX} });
-	onOffListBox3Positions.insert({ CCharacterCommand::CC_GameEffect, {X_ONOFFLISTBOX3, Y_ONOFFLISTBOX3} });
-	onOffListBox3Positions.insert({ CCharacterCommand::CC_Behavior, {X_ONOFFLISTBOX3, Y_IMPERATIVELISTBOX + CY_BEHAVIORLISTBOX + CY_SPACE} });
-	onOffListBox3Positions.insert({ CCharacterCommand::CC_WaitForOpenTile, {X_ONOFFLISTBOX3, IGNOREWEAPONSLABEL_Y + CY_WAITLABEL + CY_SPACE / 2} });
+	onOffListBox3Positions.insert(std::make_pair<UINT, pair<UINT, UINT>>(
+		CCharacterCommand::CC_SetNPCAppearance,
+		std::make_pair<UINT, UINT>(KEEPBEHAVIORLABEL_X, Y_ONOFFLISTBOX))
+	);
+	onOffListBox3Positions.insert(std::make_pair<UINT, pair<UINT, UINT>>(
+		CCharacterCommand::CC_GameEffect,
+		std::make_pair<UINT, UINT>(X_ONOFFLISTBOX3, Y_ONOFFLISTBOX3))
+	);
+	onOffListBox3Positions.insert(std::make_pair<UINT, pair<UINT, UINT>>(
+		CCharacterCommand::CC_Behavior,
+		std::make_pair<UINT, UINT>(X_ONOFFLISTBOX3, Y_IMPERATIVELISTBOX + CY_BEHAVIORLISTBOX + CY_SPACE))
+	);
+	onOffListBox3Positions.insert(std::make_pair<UINT, pair<UINT, UINT>>(
+		CCharacterCommand::CC_WaitForOpenTile,
+		std::make_pair<UINT, UINT>(X_ONOFFLISTBOX3, IGNOREWEAPONSLABEL_Y + CY_WAITLABEL + CY_SPACE / 2))
+	);
 
 	ASSERT(!this->pAddCommandDialog);
 

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -1145,10 +1145,20 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CX_VARTEXTLABEL = 190;
 	static const UINT CY_VARTEXTLABEL = CY_WAITLABEL;
 
+	static const int X_VARVALUELABEL = X_WAITLABEL;
+	static const UINT CY_VARVALUELABEL = CY_WAITLABEL;
+	static const int Y_VARVALUELABEL = Y_GOTOLABELTEXT + CY_GOTOLABELTEXT + CY_SPACE / 2;
+	static const UINT CX_VARVALUELABEL = 100;
+
+	static const int X_VARVALUE = X_VARVALUELABEL;
+	static const int Y_VARVALUE = Y_VARVALUELABEL + CY_VARVALUELABEL;
+	static const UINT CX_VARVALUE = CX_GOTOLABELTEXT;
+	static const UINT CY_VARVALUE = 30;
+
 	static const UINT CX_VARLISTBOX = 280;
 	static const UINT CY_VARLISTBOX = 18*LIST_LINE_HEIGHT+4;
 	static const int X_VARLISTBOX = X_EVENTLISTBOX;
-	static const int Y_VARLISTBOX = Y_TEXT + CY_TEXT + CY_SPACE;
+	static const int Y_VARLISTBOX = Y_VARVALUE + CY_VARVALUE + CY_SPACE;
 
 	static const int X_VARADD = X_VARLISTBOX + CX_VARLISTBOX + CX_SPACE/2;
 	static const int Y_VARADD = Y_VARLISTBOX;
@@ -1169,16 +1179,6 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const int Y_VARCOMPLIST = Y_VAROPLIST;
 	static const int CX_VARCOMPLIST = CX_VAROPLIST;
 	static const int CY_VARCOMPLIST = 7*LIST_LINE_HEIGHT + 4;
-
-	static const int X_VARVALUELABEL = X_VAROPLIST + CX_VAROPLIST + CX_SPACE/2;
-	static const UINT CY_VARVALUELABEL = CY_WAITLABEL;
-	static const int Y_VARVALUELABEL = Y_VAROPLIST;
-	static const UINT CX_VARVALUELABEL = 100;
-
-	static const int X_VARVALUE = X_VARVALUELABEL;
-	static const int Y_VARVALUE = Y_VARVALUELABEL + CY_VARVALUELABEL;
-	static const UINT CX_VARVALUE = 90;
-	static const UINT CY_VARVALUE = 30;
 
 	//Others
 	static const int X_GRAPHICLISTBOX2 = X_EVENTLISTBOX;
@@ -1851,7 +1851,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pVarCompListBox->SelectLine(0);
 
 	this->pVarCompListBox2 = new CListBoxWidget(TAG_VARCOMPLIST2,
-		X_VARCOMPLIST, Y_VARCOMPLIST, CX_VARCOMPLIST, CY_VARCOMPLIST - LIST_LINE_HEIGHT);
+		X_VARVALUE, Y_VARLISTBOX, CX_VARCOMPLIST, CY_VARCOMPLIST - LIST_LINE_HEIGHT);
 	this->pAddCommandDialog->AddWidget(this->pVarCompListBox2);
 	this->pVarCompListBox2->AddHotkey(SDLK_RETURN, TAG_OK);
 	this->pVarCompListBox2->AddItem(ScriptVars::Equals, g_pTheDB->GetMessageText(MID_VarEquals));

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -174,16 +174,15 @@ const UINT TAG_IMAGEOVERLAYTEXT = 890;
 const UINT TAG_WEAPON_FLAGBOX = 883;
 const UINT TAG_BEHAVIOR_LISTBOX = 882;
 const UINT TAG_REMAINS_LISTBOX = 881;
-const UINT TAG_ONOFFLISTBOX4 = 880;
-const UINT TAG_KEEPBEHAVIOR_LABEL = 879;
-const UINT TAG_MOVETYPELISTBOX = 878;
-const UINT TAG_IGNOREFLAGSLISTBOX = 877;
-const UINT TAG_IGNOREWEAPONS_LABEL = 876;
-const UINT TAG_IGNOREFLAGS_LABEL = 875;
-const UINT TAG_COLOR_LISTBOX = 874;
-const UINT TAG_WEAPON_LISTBOX2 = 873;
-const UINT TAG_VARCOMPLIST2 = 872;
-const UINT TAG_ORBAGENTLIST = 871;
+const UINT TAG_KEEPBEHAVIOR_LABEL = 880;
+const UINT TAG_MOVETYPELISTBOX = 879;
+const UINT TAG_IGNOREFLAGSLISTBOX = 878;
+const UINT TAG_IGNOREWEAPONS_LABEL = 877;
+const UINT TAG_IGNOREFLAGS_LABEL = 876;
+const UINT TAG_COLOR_LISTBOX = 875;
+const UINT TAG_WEAPON_LISTBOX2 = 874;
+const UINT TAG_VARCOMPLIST2 = 873;
+const UINT TAG_ORBAGENTLIST = 872;
 
 const UINT MAX_TEXT_LABEL_SIZE = 100;
 
@@ -411,7 +410,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	, pDefaultScriptCommandsListBox(NULL)
 	, pScriptDialog(NULL)
 	, pDirectionListBox2(NULL), pDirectionListBox3(NULL)
-	, pOnOffListBox3(NULL), pOnOffListBox4(NULL)
+	, pOnOffListBox3(NULL)
 	, pVisualEffectsListBox(NULL)
 	, pActionListBox(NULL), pEventListBox(NULL)
 	, pSpeakerListBox(NULL), pMoodListBox(NULL)
@@ -1186,7 +1185,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CX_GRAPHICLISTBOX2 = 250;
 	static const UINT CY_GRAPHICLISTBOX2 = CY_ACTIONLISTBOX;
 
-	static const int ONOFFLISTBOX4_X = X_GRAPHICLISTBOX2 + CX_GRAPHICLISTBOX2 + CX_SPACE;
+	static const int KEEPBEHAVIORLABEL_X = X_GRAPHICLISTBOX2 + CX_GRAPHICLISTBOX2 + CX_SPACE;
 
 	static const int X_GLOBALSCRIPTLISTBOX = X_GRAPHICLISTBOX2;
 	static const int Y_GLOBALSCRIPTLISTBOX = Y_GRAPHICLISTBOX2;
@@ -1332,6 +1331,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT CY_IMAGEOVERLAYTEXT = CY_ACTIONLISTBOX;
 
 	//Positions for on off box 3
+	onOffListBox3Positions.insert({ CCharacterCommand::CC_SetNPCAppearance, {KEEPBEHAVIORLABEL_X, Y_ONOFFLISTBOX} });
 	onOffListBox3Positions.insert({ CCharacterCommand::CC_GameEffect, {X_ONOFFLISTBOX3, Y_ONOFFLISTBOX3} });
 	onOffListBox3Positions.insert({ CCharacterCommand::CC_Behavior, {X_ONOFFLISTBOX3, Y_IMPERATIVELISTBOX + CY_BEHAVIORLISTBOX + CY_SPACE} });
 	onOffListBox3Positions.insert({ CCharacterCommand::CC_WaitForOpenTile, {X_ONOFFLISTBOX3, IGNOREWEAPONSLABEL_Y + CY_WAITLABEL + CY_SPACE / 2} });
@@ -1562,14 +1562,8 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pOnOffListBox3->AddItem(1, g_pTheDB->GetMessageText(MID_On));
 	this->pOnOffListBox3->SelectLine(0);
 
-	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_KEEPBEHAVIOR_LABEL, ONOFFLISTBOX4_X, Y_DIRECTIONLABEL,
+	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_KEEPBEHAVIOR_LABEL, KEEPBEHAVIORLABEL_X, Y_DIRECTIONLABEL,
 		CX_DIRECTIONLABEL, CY_DIRECTIONLABEL, F_Small, g_pTheDB->GetMessageText(MID_KeepBehaviors)));
-	this->pOnOffListBox4 = new CListBoxWidget(TAG_ONOFFLISTBOX4,
-		ONOFFLISTBOX4_X, Y_ONOFFLISTBOX, CX_ONOFFLISTBOX, CY_ONOFFLISTBOX);
-	this->pAddCommandDialog->AddWidget(this->pOnOffListBox4);
-	this->pOnOffListBox4->AddItem(0, g_pTheDB->GetMessageText(MID_Off));
-	this->pOnOffListBox4->AddItem(1, g_pTheDB->GetMessageText(MID_On));
-	this->pOnOffListBox4->SelectLine(0);
 
 	//Stealth list box.
 	this->pStealthListBox = new CListBoxWidget(TAG_STEALTHLISTBOX,
@@ -5504,7 +5498,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_TEXT2, TAG_INPUTLISTBOX, TAG_IMAGEOVERLAYTEXT,
 		TAG_VARNAMETEXTINPUT, TAG_GRAPHICLISTBOX3, TAG_WAITFORITEMLISTBOX, TAG_BUILDMARKERITEMLISTBOX,
 		TAG_NATURAL_TARGET_TYPES, TAG_WEAPON_FLAGBOX, TAG_BEHAVIOR_LISTBOX, TAG_REMAINS_LISTBOX,
-		TAG_ONOFFLISTBOX4, TAG_MOVETYPELISTBOX, TAG_IGNOREFLAGSLISTBOX, TAG_COLOR_LISTBOX, TAG_WEAPON_LISTBOX2,
+		TAG_MOVETYPELISTBOX, TAG_IGNOREFLAGSLISTBOX, TAG_COLOR_LISTBOX, TAG_WEAPON_LISTBOX2,
 		TAG_VARCOMPLIST2, TAG_ORBAGENTLIST
 	};
 
@@ -5524,7 +5518,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT VARSET[] =        {TAG_VARNAMETEXTINPUT, TAG_VARADD, TAG_VARREMOVE, TAG_VARLIST, TAG_VAROPLIST, TAG_VARVALUE, 0};
 	static const UINT VARGET[] =        {TAG_VARNAMETEXTINPUT, TAG_VARLIST, TAG_VARCOMPLIST, TAG_VARVALUE, 0};
 	static const UINT GRAPHIC[] =       {TAG_GRAPHICLISTBOX3, 0};
-	static const UINT NPC_GRAPHIC[] =   {TAG_GRAPHICLISTBOX3, TAG_ONOFFLISTBOX4, 0};
+	static const UINT NPC_GRAPHIC[] =   {TAG_GRAPHICLISTBOX3, TAG_ONOFFLISTBOX3, 0};
 	static const UINT PLAYER_GRAPHIC[] ={TAG_GRAPHICLISTBOX2, 0};
 	static const UINT MOVEREL[] =       {TAG_ONOFFLISTBOX, TAG_ONOFFLISTBOX2, TAG_MOVERELX, TAG_MOVERELY, 0};
 	static const UINT IMPERATIVE[] =    {TAG_IMPERATIVELISTBOX, 0};
@@ -6775,7 +6769,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		break;
 		case CCharacterCommand::CC_SetNPCAppearance:
 			this->pCommand->x = this->pAddCommandGraphicListBox->GetSelectedItem();
-			this->pCommand->y = this->pOnOffListBox4->GetSelectedItem();
+			this->pCommand->y = this->pOnOffListBox3->GetSelectedItem();
 			AddCommand();
 		break;
 
@@ -7335,7 +7329,7 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 		break;
 		case CCharacterCommand::CC_SetNPCAppearance:
 			this->pAddCommandGraphicListBox->SelectItem(this->pCommand->x);
-			this->pOnOffListBox4->SelectItem(this->pCommand->y);
+			this->pOnOffListBox3->SelectItem(this->pCommand->y);
 		break;
 
 		case CCharacterCommand::CC_SetPlayerWeapon:

--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -186,7 +186,7 @@ private:
 	CListBoxWidget *pDefaultScriptCommandsListBox;
 	CRenameDialogWidget *pScriptDialog;
 	CListBoxWidget *pDirectionListBox2, *pDirectionListBox3;
-	CListBoxWidget *pOnOffListBox3, * pOnOffListBox4;
+	CListBoxWidget *pOnOffListBox3;
 	CListBoxWidget *pVisualEffectsListBox;
 	CListBoxWidget *pActionListBox;
 	CListBoxWidget *pEventListBox;

--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -212,6 +212,8 @@ private:
 	CListBoxWidget* pColorListBox;
 	CListBoxWidget* pOrbAgentListBox;
 
+	map<UINT, pair<UINT, UINT>> onOffListBox3Positions;
+
 	CCharacter *pCharacter;       //character being edited
 	COMMANDPTR_VECTOR commands,  //copy of commands for character being edited
 			commandBuffer; //cut/copied commands for pasting


### PR DESCRIPTION
Compared to the available screen space, the dialog for adding script commands is quite small. This can be fixed by making that dialog larger:
![image](https://github.com/CaravelGames/drod/assets/5825138/b322f27c-f563-4ce4-83c1-06e590980f39)

Since the dialog is being enlarged, the UI for variable-related commands has been rearranged, to move the value input box and increase its size. This is helpful when writing assignments using script primitives:
![image](https://github.com/CaravelGames/drod/assets/5825138/02d1894c-5e08-49b7-a8ba-3678b967b4ae)

Behind the scenes, the third on/off listbox has been upgraded to be dynamically positioned, as its fixed position no longer worked for all commands that used it. This allowed the fourth on/off listbox to be removed, as it only existed to have a control at its specific location. (Possibly more widgets could become dynamically placed but that is outside of the scope for this PR.)