### PR TITLE
Downgrade SDL2_ttf version

### DIFF
--- a/CompilingDrod_Win.md
+++ b/CompilingDrod_Win.md
@@ -40,7 +40,7 @@ The game requires the following libraries. Different versions may potentially be
  -  `lpng-1512` => https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.12/lpng1512.zip
  -  `metakit-2.4.9.7` => https://github.com/jnorthrup/metakit/archive/master.zip
  -  `sdl2-2.26.1` => https://github.com/libsdl-org/SDL/releases/download/release-2.26.1/SDL2-2.26.1.zip
- -  `sdl-ttf-2.20.1` => https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.20.1/SDL2_ttf-devel-2.20.1-VC.zip
+ -  `sdl-ttf-2.0.14` => https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip
  -  `zlib` => http://www.zlib.net/fossils/zlib-1.2.11.tar.gz
 
 You need the DLLs from the following libraries to go into the same dir with your built drod.exe:

--- a/Scripts/InstallDependencies.win32.vs2013.py
+++ b/Scripts/InstallDependencies.win32.vs2013.py
@@ -54,7 +54,7 @@ if DepsToBuild == "all":
 		'lpng-1512',
 		'metakit-2.4.9.7',
 		SdlName,
-		'sdl-ttf-2.20.1',
+		'sdl-ttf-2.0.14',
 		'zlib'
 	]
 
@@ -359,16 +359,17 @@ dependencies = {
 			'SDL2-2.26.1/VisualC/Win32/Release/SDL2.dll': 'Release'
 		}
 	},
-	'sdl-ttf-2.20.1': {
-		'urls': ['https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.20.1/SDL2_ttf-devel-2.20.1-VC.zip'],
+	'sdl-ttf-2.0.14': {
+		'urls': ['https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip'],
 		'include': {
-			'SDL2_ttf-2.20.1/include': ''
+			'SDL2_ttf-2.0.14/include': ''
 		},
 		'libs': {
-			'SDL2_ttf-2.20.1/lib/x86/SDL2_ttf.lib': ['Debug', 'Release']
+			'SDL2_ttf-2.0.14/lib/x86/SDL2_ttf.lib': ['Debug', 'Release']
 		},
 		'dlls': {
-			'SDL2_ttf-2.20.1/lib/x86/SDL2_ttf.dll': ['Debug', 'Release']
+			'SDL2_ttf-2.0.14/lib/x86/SDL2_ttf.dll': ['Debug', 'Release'],
+			'SDL2_ttf-2.0.14/lib/x86/libfreetype-6.dll': ['Debug', 'Release']
 		}
 	},
 	'zlib': {


### PR DESCRIPTION
Upgrading to later versions of the `SDL2_ttf` library causes a bunch of problems with text drawing. No one is sure how to fix it, so for now I will downgrade back to 20.0.14, which also reintroduces the `libfreetype-6` dependency.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45902