### PR TITLE
Fix Ctrl-Wait sometimes waiting for 60 turns

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -1553,6 +1553,10 @@ void CGameScreen::OnKeyDown(
 	}
 	if (nCommand != CMD_UNSPECIFIED)
 	{
+		//Sometimes, SDL will send the same input twice. If this happens for long waits, we don't
+		//want two of them to happen. Repeated inputs are counted, so for the first repeat, a
+		//duplicated command is not sent to the engine. This allows the player to chain long waits
+		//purposefully, but not accidentally.
 		if (nCommand == CMD_WAIT && bMacro && Key.repeat == 1) {
 			return;
 		}

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -1553,6 +1553,10 @@ void CGameScreen::OnKeyDown(
 	}
 	if (nCommand != CMD_UNSPECIFIED)
 	{
+		if (nCommand == CMD_WAIT && bMacro && Key.repeat) {
+			return;
+		}
+
 		//Hide mouse cursor while playing.
 		HideCursor();
 

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -1553,7 +1553,7 @@ void CGameScreen::OnKeyDown(
 	}
 	if (nCommand != CMD_UNSPECIFIED)
 	{
-		if (nCommand == CMD_WAIT && bMacro && Key.repeat) {
+		if (nCommand == CMD_WAIT && bMacro && Key.repeat == 1) {
 			return;
 		}
 

--- a/FrontEndLib/EventHandlerWidget.cpp
+++ b/FrontEndLib/EventHandlerWidget.cpp
@@ -543,7 +543,7 @@ void CEventHandlerWidget::Activate_HandleBetweenEvents()
 				//Call keydown and keyup handlers.
 				m_RepeatingKey.type = SDL_KEYDOWN;
 				m_RepeatingKey.state = SDL_PRESSED;
-				m_RepeatingKey.repeat = true;
+				m_RepeatingKey.repeat += 1;
 				if (pSelectedWidget)
 				{
 					pSelectedWidget->HandleKeyDown(m_RepeatingKey);

--- a/FrontEndLib/EventHandlerWidget.cpp
+++ b/FrontEndLib/EventHandlerWidget.cpp
@@ -543,6 +543,7 @@ void CEventHandlerWidget::Activate_HandleBetweenEvents()
 				//Call keydown and keyup handlers.
 				m_RepeatingKey.type = SDL_KEYDOWN;
 				m_RepeatingKey.state = SDL_PRESSED;
+				m_RepeatingKey.repeat = true;
 				if (pSelectedWidget)
 				{
 					pSelectedWidget->HandleKeyDown(m_RepeatingKey);


### PR DESCRIPTION
Keyboard inputs are weird, and this is somehow causing some players to wait 60 turns when they do a Ctrl-Wait instead of 30 turns. This is because two input events are registered by SDL, which causes a macro'd wait command to be sent to the engine twice.

Luckily `FrontEndLib` can tell when a key event is repeated. When a repeated keypress is seen, we can increment its `repeat` value by one. Then in `CGameScreen::OnKeyDown` if we see a macro'd wait command with exactly one repeat, we do not pass it to the engine. This solves the problem.