### PR TITLE
RPG: Catch attempts to set string predefined vars as numbers

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -722,6 +722,12 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 		}
 		break;
 
+		case (UINT)ScriptVars::P_MONSTER_NAME:
+		case (UINT)ScriptVars::P_MONSTER_CUSTOM_WEAKNESS:
+		case (UINT)ScriptVars::P_MONSTER_CUSTOM_DESCRIPTION:
+			//string vars
+		break;
+
 		//Stat modifications that may display the change as a special effect.
 		default:
 		{


### PR DESCRIPTION
If an architect attempts to set a predefined string var to a number, the game will eventually hit an assert in `CCharacter::setPredefinedVarInt`. Instead of this, the switch statement should be broken out of for these vars.