### PR TITLE
RPG: Add item bonus preview effect.

### DIFF
--- a/drodrpg/DROD/DamagePreviewEffect.h
+++ b/drodrpg/DROD/DamagePreviewEffect.h
@@ -34,28 +34,43 @@
 #include <vector>
 
 //****************************************************************************************
-class CMonster;
 class CRoomWidget;
-class CDamagePreviewEffect : public CEffect
+class CBonusPreviewEffect : public CEffect
 {
 public:
-	CDamagePreviewEffect(CWidget *pSetWidget, const CMonster *pMonster);
-	~CDamagePreviewEffect();
+	CBonusPreviewEffect(CWidget* pSetWidget, const UINT wX, const UINT wY, const int value);
+	virtual ~CBonusPreviewEffect();
 
 protected:
+	CBonusPreviewEffect(CWidget* pSetWidget);
 	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
 	virtual void Draw(SDL_Surface& destSurface);
 
-	UINT        wValidTurn;   //game turn this display is valid for
+	UINT         wX, wY;
+	UINT         wValidTurn;   //game turn this display is valid for
 
-	CRoomWidget *  pRoomWidget;
+	CRoomWidget* pRoomWidget;
+
+	SDL_Surface* pTextSurface;
+
+private:
+	void PrepWidgetForValue(const int value);
+};
+
+//****************************************************************************************
+class CMonster;
+class CDamagePreviewEffect : public CBonusPreviewEffect
+{
+public:
+	CDamagePreviewEffect(CWidget *pSetWidget, const CMonster *pMonster);
+
+protected:
+	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
 
 private:
 	void PrepWidget();
 
 	CMonster* pMonster;
-
-	SDL_Surface* pTextSurface;
 };
 
 #endif //...#ifndef DAMAGEPREVIEWEFFECT_H

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -392,6 +392,36 @@ void CRoomWidget::AddDamagePreviews()
 		if (pMonster->IsCombatable())
 			AddLastLayerEffect(new CDamagePreviewEffect(this, pMonster));
 	}
+
+	//Add item stat effects
+	const UINT rows = this->pRoom->wRoomRows;
+	const UINT cols = this->pRoom->wRoomCols;
+	UINT wX, wY;
+	for (wY = 0; wY < rows; ++wY)
+	{
+		for (wX = 0; wX < cols; ++wX)
+		{
+			const UINT tTile = this->pRoom->GetTSquare(wX, wY);
+			switch (tTile)
+			{
+				case T_HEALTH_SM: case T_HEALTH_MED: case T_HEALTH_BIG: case T_HEALTH_HUGE:
+				case T_ATK_UP: case T_ATK_UP3: case T_ATK_UP10:
+				case T_DEF_UP: case T_DEF_UP3: case T_DEF_UP10:
+				{
+					int val;
+					if (this->pCurrentGame) {
+						val = this->pCurrentGame->getItemAmount(tTile);
+					} else {
+						CDbLevel* pLevel = g_pTheDB->Levels.GetByID(this->pRoom->dwLevelID, true);
+						val = (int)(pLevel->getItemAmount(tTile));
+						delete pLevel;
+					}
+					AddLastLayerEffect(new CBonusPreviewEffect(this, wX, wY, val));
+				}
+				break;
+			}
+		}
+	}
 }
 
 //*****************************************************************************


### PR DESCRIPTION
Like the enemy damage preview effect, this change adds a persisting numeric display for pending item bonuses (i.e., health, att/def gems).