### PR TITLE
RPG: Additional character customisation utilities

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1898,6 +1898,7 @@ void CCharacterDialogWidget::OnClick(
 
 			if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
 				this->pCharacter->wProcessSequence = this->pCharOptionsDialog->GetProcessSequence();
+				this->pCharacter->SetColor(this->pCharOptionsDialog->GetColor());
 			}
 
 			Paint();
@@ -2870,6 +2871,7 @@ void CCharacterDialogWidget::EditDefaultScriptForCustomNPC()
 
 				if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
 					pChar->ExtraVars.SetVar(ParamProcessSequenceStr, this->pCharOptionsDialog->GetProcessSequence());
+					pChar->ExtraVars.SetVar(ColorStr, this->pCharOptionsDialog->GetColor());
 				}
 
 				Paint();

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1899,6 +1899,7 @@ void CCharacterDialogWidget::OnClick(
 			if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
 				this->pCharacter->wProcessSequence = this->pCharOptionsDialog->GetProcessSequence();
 				this->pCharacter->SetColor(this->pCharOptionsDialog->GetColor());
+				this->pCharacter->SetCustomSpeechColor(this->pCharOptionsDialog->GetSpeechColor());
 			}
 
 			Paint();
@@ -2872,6 +2873,7 @@ void CCharacterDialogWidget::EditDefaultScriptForCustomNPC()
 				if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
 					pChar->ExtraVars.SetVar(ParamProcessSequenceStr, this->pCharOptionsDialog->GetProcessSequence());
 					pChar->ExtraVars.SetVar(ColorStr, this->pCharOptionsDialog->GetColor());
+					pChar->ExtraVars.SetVar(ParamSpeechColorStr, this->pCharOptionsDialog->GetSpeechColor());
 				}
 
 				Paint();

--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -60,6 +60,28 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 	this->pColorTextBox->AddHotkey(SDLK_RETURN, TAG_SAVE);
 	AddWidget(this->pColorTextBox);
 
+	AddWidget(new CLabelWidget(0L, SPEECHCOLORLABEL_X, SPEECHCOLORLABEL_Y,
+		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_CustomSpeechColor)));
+
+	this->pSpeechColorRedTextBox = new CTextBoxWidget(0L, SPEECHCOLORTEXTRED_X, SPEECHCOLORTEXT_Y,
+		SPEECHCOLORTEXT_CX, SEQUENCETEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
+	this->pSpeechColorGreenTextBox = new CTextBoxWidget(0L, SPEECHCOLORTEXTGREEN_X, SPEECHCOLORTEXT_Y,
+		SPEECHCOLORTEXT_CX, SEQUENCETEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
+	this->pSpeechColorBlueTextBox = new CTextBoxWidget(0L, SPEECHCOLORTEXTBLUE_X, SPEECHCOLORTEXT_Y,
+		SPEECHCOLORTEXT_CX, SEQUENCETEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
+
+	this->pSpeechColorRedTextBox->SetDigitsOnly(true);
+	this->pSpeechColorGreenTextBox->SetDigitsOnly(true);
+	this->pSpeechColorBlueTextBox->SetDigitsOnly(true);
+
+	this->pSpeechColorRedTextBox->SetAllowNegative(false);
+	this->pSpeechColorGreenTextBox->SetAllowNegative(false);
+	this->pSpeechColorBlueTextBox->SetAllowNegative(false);
+
+	AddWidget(this->pSpeechColorRedTextBox);
+	AddWidget(this->pSpeechColorGreenTextBox);
+	AddWidget(this->pSpeechColorBlueTextBox);
+
 	AddWidget(new CLabelWidget(0L, SEQUENCELABEL_X, SEQUENCELABEL_Y,
 		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequence)));
 
@@ -88,6 +110,8 @@ void CCharacterOptionsDialog::SetCharacter(
 
 	_itoW(pCharacter->getColor(), temp, 10, bufferLength);
 	this->pColorTextBox->SetText(temp);
+
+	SetSpeechColorTexts(pCharacter->GetCustomSpeechColor());
 }
 
 //*****************************************************************************
@@ -102,11 +126,43 @@ void CCharacterOptionsDialog::SetCharacter(
 
 	_itoW(pCharacter->ExtraVars.GetVar(ColorStr, 0), temp, 10, bufferLength);
 	this->pColorTextBox->SetText(temp);
+
+	SetSpeechColorTexts(pCharacter->ExtraVars.GetVar(ParamSpeechColorStr, 0));
+}
+
+//*****************************************************************************
+void CCharacterOptionsDialog::SetSpeechColorTexts(UINT color)
+{
+	UINT r = (color >> 16) & 255;
+	UINT g = (color >> 8) & 255;
+	UINT b = color & 255;
+
+	const UINT bufferLength = SPEECHCOLOR_MAX_LENGTH + 1; // Added space for null-termination
+	WCHAR temp[bufferLength];
+
+	_itoW(r, temp, 10, bufferLength);
+	this->pSpeechColorRedTextBox->SetText(temp);
+	_itoW(g, temp, 10, bufferLength);
+	this->pSpeechColorGreenTextBox->SetText(temp);
+	_itoW(b, temp, 10, bufferLength);
+	this->pSpeechColorBlueTextBox->SetText(temp);
 }
 
 //*****************************************************************************
 UINT CCharacterOptionsDialog::GetColor(){
 	return (UINT)this->pColorTextBox->GetNumber();
+}
+
+//*****************************************************************************
+UINT CCharacterOptionsDialog::GetSpeechColor()
+{
+	UINT r = min((UINT)this->pSpeechColorRedTextBox->GetNumber(), 255);
+	UINT g = min((UINT)this->pSpeechColorGreenTextBox->GetNumber(), 255);
+	UINT b = min((UINT)this->pSpeechColorBlueTextBox->GetNumber(), 255);
+
+	UINT value = (r << 16) + (g << 8) + b;
+
+	return value;
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -49,6 +49,16 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 	AddWidget(new CLabelWidget(0L, TITLE_X, TITLE_Y,
 		TITLE_CX, TITLE_CY, F_Header, g_pTheDB->GetMessageText(MID_CharOptionsTitle)));
 
+	AddWidget(new CLabelWidget(0L, COLORLABEL_X, COLORLABEL_Y,
+		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_VarMonsterColor)));
+
+	this->pColorTextBox = new CTextBoxWidget(0L, COLORTEXT_X, COLORTEXT_Y,
+		SEQUENCETEXT_CX, SEQUENCETEXT_CY, COLOR_MAX_LENGTH, TAG_OK);
+
+	this->pColorTextBox->SetDigitsOnly(true);
+	this->pColorTextBox->SetAllowNegative(false);
+	this->pColorTextBox->AddHotkey(SDLK_RETURN, TAG_SAVE);
+	AddWidget(this->pColorTextBox);
 
 	AddWidget(new CLabelWidget(0L, SEQUENCELABEL_X, SEQUENCELABEL_Y,
 		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequence)));
@@ -74,8 +84,10 @@ void CCharacterOptionsDialog::SetCharacter(
 	WCHAR temp[bufferLength];
 
 	_itoW(pCharacter->wProcessSequence, temp, 10, bufferLength);
-
 	this->pSequenceTextBox->SetText(temp);
+
+	_itoW(pCharacter->getColor(), temp, 10, bufferLength);
+	this->pColorTextBox->SetText(temp);
 }
 
 //*****************************************************************************
@@ -86,8 +98,15 @@ void CCharacterOptionsDialog::SetCharacter(
 	WCHAR temp[bufferLength];
 
 	_itoW(pCharacter->ExtraVars.GetVar(ParamProcessSequenceStr, 9999), temp, 10, bufferLength);
-
 	this->pSequenceTextBox->SetText(temp);
+
+	_itoW(pCharacter->ExtraVars.GetVar(ColorStr, 0), temp, 10, bufferLength);
+	this->pColorTextBox->SetText(temp);
+}
+
+//*****************************************************************************
+UINT CCharacterOptionsDialog::GetColor(){
+	return (UINT)this->pColorTextBox->GetNumber();
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -34,29 +34,30 @@
 CCharacterOptionsDialog::CCharacterOptionsDialog(
 //Constructor.
 )
-: CDialogWidget(0L, 0, 0, CCharacterOptionsDialog::CX_DIALOG, CCharacterOptionsDialog::CY_DIALOG, false)
+: CDialogWidget(0L, 0, 0, CCharacterOptionsDialog::DIALOG_CX, CCharacterOptionsDialog::DIALOG_CY, false)
 {
 	AddWidget(new CButtonWidget(TAG_SAVE,
-		X_SAVE, Y_SAVE,
-		CX_SAVE, CY_SAVE,
+		SAVE_X, SAVE_Y,
+		SAVE_CX, SAVE_CY,
 		g_pTheDB->GetMessageText(MID_Save)));
 
 	AddWidget(new CButtonWidget(CCharacterOptionsDialog::TAG_CANCEL,
-		CCharacterOptionsDialog::X_CANCEL, CCharacterOptionsDialog::Y_CANCEL,
-		CCharacterOptionsDialog::CX_CANCEL, CCharacterOptionsDialog::CY_CANCEL,
+		CCharacterOptionsDialog::CANCEL_X, CCharacterOptionsDialog::CANCEL_Y,
+		CCharacterOptionsDialog::CANCEL_CX, CCharacterOptionsDialog::CANCEL_CY,
 		g_pTheDB->GetMessageText(MID_Cancel)));
 
-	AddWidget(new CLabelWidget(0L, X_TITLE, Y_TITLE,
-		CX_TITLE, CY_TITLE, F_Header, g_pTheDB->GetMessageText(MID_CharOptionsTitle)));
+	AddWidget(new CLabelWidget(0L, TITLE_X, TITLE_Y,
+		TITLE_CX, TITLE_CY, F_Header, g_pTheDB->GetMessageText(MID_CharOptionsTitle)));
 
-	AddWidget(new CLabelWidget(0L, X_SEQUENCELABEL, Y_SEQUENCELABEL,
-		CX_SEQUENCELABEL, CY_SEQUENCELABEL, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequence)));
 
-	AddWidget(new CLabelWidget(0L, X_SEQUENCEHELP, Y_SEQUENCEHELP,
-		CX_SEQUENCEHELP, CY_SEQUENCEHELP, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequenceDescription)));
+	AddWidget(new CLabelWidget(0L, SEQUENCELABEL_X, SEQUENCELABEL_Y,
+		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequence)));
 
-	this->pSequenceTextBox = new CTextBoxWidget(0L, X_SEQUENCETEXT, Y_SEQUENCETEXT,
-		CX_SEQUENCETEXT, CY_SEQUENCETEXT, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);
+	AddWidget(new CLabelWidget(0L, SEQUENCEHELP_X, SEQUENCEHELP_Y,
+		SEQUENCEHELP_CX, SEQUENCEHELP_CY, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequenceDescription)));
+
+	this->pSequenceTextBox = new CTextBoxWidget(0L, SEQUENCETEXT_X, SEQUENCETEXT_Y,
+		SEQUENCETEXT_CX, SEQUENCETEXT_CY, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);
 
 	this->pSequenceTextBox->SetDigitsOnly(true);
 	this->pSequenceTextBox->SetAllowNegative(false);

--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -50,10 +50,10 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 		TITLE_CX, TITLE_CY, F_Header, g_pTheDB->GetMessageText(MID_CharOptionsTitle)));
 
 	AddWidget(new CLabelWidget(0L, COLORLABEL_X, COLORLABEL_Y,
-		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_VarMonsterColor)));
+		LABEL_CX, LABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_VarMonsterColor)));
 
 	this->pColorTextBox = new CTextBoxWidget(0L, COLORTEXT_X, COLORTEXT_Y,
-		SEQUENCETEXT_CX, SEQUENCETEXT_CY, COLOR_MAX_LENGTH, TAG_OK);
+		TEXT_CX, TEXT_CY, COLOR_MAX_LENGTH, TAG_OK);
 
 	this->pColorTextBox->SetDigitsOnly(true);
 	this->pColorTextBox->SetAllowNegative(false);
@@ -61,14 +61,14 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 	AddWidget(this->pColorTextBox);
 
 	AddWidget(new CLabelWidget(0L, SPEECHCOLORLABEL_X, SPEECHCOLORLABEL_Y,
-		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_CustomSpeechColor)));
+		LABEL_CX, LABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_CustomSpeechColor)));
 
 	this->pSpeechColorRedTextBox = new CTextBoxWidget(0L, SPEECHCOLORTEXTRED_X, SPEECHCOLORTEXT_Y,
-		SPEECHCOLORTEXT_CX, SEQUENCETEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
+		SPEECHCOLORTEXT_CX, TEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
 	this->pSpeechColorGreenTextBox = new CTextBoxWidget(0L, SPEECHCOLORTEXTGREEN_X, SPEECHCOLORTEXT_Y,
-		SPEECHCOLORTEXT_CX, SEQUENCETEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
+		SPEECHCOLORTEXT_CX, TEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
 	this->pSpeechColorBlueTextBox = new CTextBoxWidget(0L, SPEECHCOLORTEXTBLUE_X, SPEECHCOLORTEXT_Y,
-		SPEECHCOLORTEXT_CX, SEQUENCETEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
+		SPEECHCOLORTEXT_CX, TEXT_CY, SPEECHCOLOR_MAX_LENGTH, TAG_OK);
 
 	this->pSpeechColorRedTextBox->SetDigitsOnly(true);
 	this->pSpeechColorGreenTextBox->SetDigitsOnly(true);
@@ -83,13 +83,13 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 	AddWidget(this->pSpeechColorBlueTextBox);
 
 	AddWidget(new CLabelWidget(0L, SEQUENCELABEL_X, SEQUENCELABEL_Y,
-		SEQUENCELABEL_CX, SEQUENCELABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequence)));
+		LABEL_CX, LABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequence)));
 
 	AddWidget(new CLabelWidget(0L, SEQUENCEHELP_X, SEQUENCEHELP_Y,
 		SEQUENCEHELP_CX, SEQUENCEHELP_CY, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequenceDescription)));
 
 	this->pSequenceTextBox = new CTextBoxWidget(0L, SEQUENCETEXT_X, SEQUENCETEXT_Y,
-		SEQUENCETEXT_CX, SEQUENCETEXT_CY, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);
+		TEXT_CX, TEXT_CY, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);
 
 	this->pSequenceTextBox->SetDigitsOnly(true);
 	this->pSequenceTextBox->SetAllowNegative(false);

--- a/drodrpg/DROD/CharacterOptionsWidget.h
+++ b/drodrpg/DROD/CharacterOptionsWidget.h
@@ -45,10 +45,12 @@ public:
 
 	CCharacterOptionsDialog();
 
+	CTextBoxWidget *pColorTextBox;
 	CTextBoxWidget *pSequenceTextBox;
 
 	void SetCharacter(const CCharacter *pCharacter);
 	void SetCharacter(HoldCharacter *pCharacter);
+	UINT GetColor();
 	UINT GetProcessSequence();
 
 protected:
@@ -59,17 +61,24 @@ private:
 	static const UINT SPACE_CX = 15;
 
 	static const int DIALOG_CX = 400;
-	static const int DIALOG_CY = 230;
+	static const int DIALOG_CY = 330;
 
 	static const int TITLE_CX = 200;
 	static const int TITLE_CY = 30;
 	static const int TITLE_X = (DIALOG_CX - TITLE_CX) / 2;
 	static const int TITLE_Y = SPACE_CY;
 
+	static const int COLORLABEL_CX = 150;
+	static const int COLORLABEL_X = SPACE_CX;
+	static const int COLORLABEL_Y = TITLE_Y + TITLE_CY + SPACE_CY;
+
+	static const int COLORTEXT_X = COLORLABEL_X + COLORLABEL_CX + SPACE_CX;
+	static const int COLORTEXT_Y = COLORLABEL_Y;
+
 	static const int SEQUENCELABEL_CX = 150;
 	static const int SEQUENCELABEL_CY = CY_STANDARD_BUTTON;
 	static const int SEQUENCELABEL_X = SPACE_CX;
-	static const int SEQUENCELABEL_Y = TITLE_Y + TITLE_CY + SPACE_CY;
+	static const int SEQUENCELABEL_Y = COLORLABEL_Y + TITLE_CY + SPACE_CY;
 
 	static const int SEQUENCEHELP_CX = 370;
 	static const int SEQUENCEHELP_CY = 270;
@@ -91,6 +100,7 @@ private:
 	static const int CANCEL_X = DIALOG_CX / 2 + SPACE_CX / 2;
 	static const int CANCEL_Y = DIALOG_CY - SAVE_CY - SPACE_CY;
 
+	static const int COLOR_MAX_LENGTH = 6;
 	static const int PROCESSING_SEQUENCE_MAX_LENGTH = 9;
 };
 

--- a/drodrpg/DROD/CharacterOptionsWidget.h
+++ b/drodrpg/DROD/CharacterOptionsWidget.h
@@ -67,7 +67,12 @@ private:
 	static const UINT SPACE_CX = 15;
 
 	static const int DIALOG_CX = 400;
-	static const int DIALOG_CY = 330;
+	static const int DIALOG_CY = 300;
+
+	static const int LABEL_CX = 150;
+	static const int LABEL_CY = CY_STANDARD_BUTTON;
+	static const int TEXT_CX = 150;
+	static const int TEXT_CY = CY_STANDARD_BUTTON;
 
 	static const int TITLE_CX = 200;
 	static const int TITLE_CY = 30;
@@ -91,19 +96,15 @@ private:
 	static const int SPEECHCOLORTEXTBLUE_X = SPEECHCOLORTEXTGREEN_X + SPEECHCOLORTEXT_CX + SPACE_CX/2;
 	static const int SPEECHCOLORTEXT_Y = SPEECHCOLORLABEL_Y;
 
-	static const int SEQUENCELABEL_CX = 150;
-	static const int SEQUENCELABEL_CY = CY_STANDARD_BUTTON;
 	static const int SEQUENCELABEL_X = SPACE_CX;
 	static const int SEQUENCELABEL_Y = SPEECHCOLORLABEL_Y + TITLE_CY + SPACE_CY;
 
 	static const int SEQUENCEHELP_CX = 370;
 	static const int SEQUENCEHELP_CY = 270;
 	static const int SEQUENCEHELP_X = SPACE_CX;
-	static const int SEQUENCEHELP_Y = SEQUENCELABEL_Y + SEQUENCELABEL_CY + SPACE_CY;
+	static const int SEQUENCEHELP_Y = SEQUENCELABEL_Y + LABEL_CY + SPACE_CY;
 
-	static const int SEQUENCETEXT_CX = 130;
-	static const int SEQUENCETEXT_CY = CY_STANDARD_BUTTON;
-	static const int SEQUENCETEXT_X = SEQUENCELABEL_X + SEQUENCELABEL_CX + SPACE_CX;
+	static const int SEQUENCETEXT_X = SEQUENCELABEL_X + LABEL_CX + SPACE_CX;
 	static const int SEQUENCETEXT_Y = SEQUENCELABEL_Y;
 
 	static const int SAVE_CX = 100;

--- a/drodrpg/DROD/CharacterOptionsWidget.h
+++ b/drodrpg/DROD/CharacterOptionsWidget.h
@@ -55,41 +55,41 @@ protected:
 	virtual void OnKeyDown(const UINT dwTagNo, const SDL_KeyboardEvent &Key);
 
 private:
-	static const UINT CY_SPACE = 15;
-	static const UINT CX_SPACE = 15;
+	static const UINT SPACE_CY = 15;
+	static const UINT SPACE_CX = 15;
 
-	static const int CX_DIALOG = 400;
-	static const int CY_DIALOG = 230;
+	static const int DIALOG_CX = 400;
+	static const int DIALOG_CY = 230;
 
-	static const int CX_TITLE = 200;
-	static const int CY_TITLE = 30;
-	static const int X_TITLE = (CX_DIALOG - CX_TITLE) / 2;
-	static const int Y_TITLE = CY_SPACE;
+	static const int TITLE_CX = 200;
+	static const int TITLE_CY = 30;
+	static const int TITLE_X = (DIALOG_CX - TITLE_CX) / 2;
+	static const int TITLE_Y = SPACE_CY;
 
-	static const int CX_SEQUENCELABEL = 150;
-	static const int CY_SEQUENCELABEL = CY_STANDARD_BUTTON;
-	static const int X_SEQUENCELABEL = CX_SPACE;
-	static const int Y_SEQUENCELABEL = Y_TITLE + CY_TITLE + CY_SPACE;
+	static const int SEQUENCELABEL_CX = 150;
+	static const int SEQUENCELABEL_CY = CY_STANDARD_BUTTON;
+	static const int SEQUENCELABEL_X = SPACE_CX;
+	static const int SEQUENCELABEL_Y = TITLE_Y + TITLE_CY + SPACE_CY;
 
-	static const int CX_SEQUENCEHELP = 370;
-	static const int CY_SEQUENCEHELP = 270;
-	static const int X_SEQUENCEHELP = CX_SPACE;
-	static const int Y_SEQUENCEHELP = Y_SEQUENCELABEL + CY_SEQUENCELABEL + CY_SPACE;
+	static const int SEQUENCEHELP_CX = 370;
+	static const int SEQUENCEHELP_CY = 270;
+	static const int SEQUENCEHELP_X = SPACE_CX;
+	static const int SEQUENCEHELP_Y = SEQUENCELABEL_Y + SEQUENCELABEL_CY + SPACE_CY;
 
-	static const int CX_SEQUENCETEXT = 130;
-	static const int CY_SEQUENCETEXT = CY_STANDARD_BUTTON;
-	static const int X_SEQUENCETEXT = X_SEQUENCELABEL + CX_SEQUENCELABEL + CX_SPACE;
-	static const int Y_SEQUENCETEXT = Y_SEQUENCELABEL;
+	static const int SEQUENCETEXT_CX = 130;
+	static const int SEQUENCETEXT_CY = CY_STANDARD_BUTTON;
+	static const int SEQUENCETEXT_X = SEQUENCELABEL_X + SEQUENCELABEL_CX + SPACE_CX;
+	static const int SEQUENCETEXT_Y = SEQUENCELABEL_Y;
 
-	static const int CX_SAVE = 100;
-	static const int CY_SAVE = CY_STANDARD_BUTTON;
-	static const int X_SAVE = CX_DIALOG / 2 - CX_SAVE - CX_SPACE / 2;
-	static const int Y_SAVE = CY_DIALOG - CY_SAVE - CY_SPACE;
+	static const int SAVE_CX = 100;
+	static const int SAVE_CY = CY_STANDARD_BUTTON;
+	static const int SAVE_X = DIALOG_CX / 2 - SAVE_CX - SPACE_CX / 2;
+	static const int SAVE_Y = DIALOG_CY - SAVE_CY - SPACE_CY;
 
-	static const int CX_CANCEL = 100;
-	static const int CY_CANCEL = CY_STANDARD_BUTTON;
-	static const int X_CANCEL = CX_DIALOG / 2 + CX_SPACE / 2;
-	static const int Y_CANCEL = CY_DIALOG - CY_SAVE - CY_SPACE;
+	static const int CANCEL_CX = 100;
+	static const int CANCEL_CY = CY_STANDARD_BUTTON;
+	static const int CANCEL_X = DIALOG_CX / 2 + SPACE_CX / 2;
+	static const int CANCEL_Y = DIALOG_CY - SAVE_CY - SPACE_CY;
 
 	static const int PROCESSING_SEQUENCE_MAX_LENGTH = 9;
 };

--- a/drodrpg/DROD/CharacterOptionsWidget.h
+++ b/drodrpg/DROD/CharacterOptionsWidget.h
@@ -46,17 +46,23 @@ public:
 	CCharacterOptionsDialog();
 
 	CTextBoxWidget *pColorTextBox;
+	CTextBoxWidget *pSpeechColorRedTextBox;
+	CTextBoxWidget *pSpeechColorBlueTextBox;
+	CTextBoxWidget *pSpeechColorGreenTextBox;
 	CTextBoxWidget *pSequenceTextBox;
 
 	void SetCharacter(const CCharacter *pCharacter);
 	void SetCharacter(HoldCharacter *pCharacter);
 	UINT GetColor();
+	UINT GetSpeechColor();
 	UINT GetProcessSequence();
 
 protected:
 	virtual void OnKeyDown(const UINT dwTagNo, const SDL_KeyboardEvent &Key);
 
 private:
+	void SetSpeechColorTexts(UINT color);
+
 	static const UINT SPACE_CY = 15;
 	static const UINT SPACE_CX = 15;
 
@@ -75,10 +81,20 @@ private:
 	static const int COLORTEXT_X = COLORLABEL_X + COLORLABEL_CX + SPACE_CX;
 	static const int COLORTEXT_Y = COLORLABEL_Y;
 
+	static const int SPEECHCOLORLABEL_CX = 150;
+	static const int SPEECHCOLORLABEL_X = SPACE_CX;
+	static const int SPEECHCOLORLABEL_Y = COLORLABEL_Y + TITLE_CY + SPACE_CY;
+
+	static const int SPEECHCOLORTEXT_CX = 45;
+	static const int SPEECHCOLORTEXTRED_X = SPEECHCOLORLABEL_X + SPEECHCOLORLABEL_CX + SPACE_CX;
+	static const int SPEECHCOLORTEXTGREEN_X = SPEECHCOLORTEXTRED_X + SPEECHCOLORTEXT_CX + SPACE_CX/2;
+	static const int SPEECHCOLORTEXTBLUE_X = SPEECHCOLORTEXTGREEN_X + SPEECHCOLORTEXT_CX + SPACE_CX/2;
+	static const int SPEECHCOLORTEXT_Y = SPEECHCOLORLABEL_Y;
+
 	static const int SEQUENCELABEL_CX = 150;
 	static const int SEQUENCELABEL_CY = CY_STANDARD_BUTTON;
 	static const int SEQUENCELABEL_X = SPACE_CX;
-	static const int SEQUENCELABEL_Y = COLORLABEL_Y + TITLE_CY + SPACE_CY;
+	static const int SEQUENCELABEL_Y = SPEECHCOLORLABEL_Y + TITLE_CY + SPACE_CY;
 
 	static const int SEQUENCEHELP_CX = 370;
 	static const int SEQUENCEHELP_CY = 270;
@@ -101,6 +117,7 @@ private:
 	static const int CANCEL_Y = DIALOG_CY - SAVE_CY - SPACE_CY;
 
 	static const int COLOR_MAX_LENGTH = 6;
+	static const int SPEECHCOLOR_MAX_LENGTH = 3;
 	static const int PROCESSING_SEQUENCE_MAX_LENGTH = 9;
 };
 

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -2022,6 +2022,7 @@ void CEditRoomScreen::ApplyPlayerSettings()
 
 	//Set room editing options.
 	this->bAutoSave = pCurrentPlayer->Settings.GetVar(Settings::AutoSave, true);
+	this->pRoomWidget->characterPreview = pCurrentPlayer->Settings.GetVar(Settings::CharacterPreview, false);
 
 	COptionButtonWidget *pOptionButton = static_cast<COptionButtonWidget *>(
 			GetWidget(TAG_SHOWERRORS));
@@ -2963,6 +2964,9 @@ void CEditRoomScreen::OnKeyDown(
 		}
 		break;
 */
+		case SDLK_F6:
+			this->pRoomWidget->characterPreview = !this->pRoomWidget->characterPreview;
+		break;
 		case SDLK_F7:
 			if (!SetState(ES_PLACING)) break;
 			if (Key.keysym.mod & KMOD_CTRL)

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -70,6 +70,7 @@ CEditRoomWidget::CEditRoomWidget(
 	, eEditState(ES_PLACING)
 	, pLevelEntrances(NULL)
 	, wOX(NO_BOLT), wOY(NO_BOLT)
+	, characterPreview(false)
 	, pPlotted(NULL)
 {
 }
@@ -1285,9 +1286,10 @@ void CEditRoomWidget::DrawCharacter(
 	const bool /*bMoveInProgress*/)
 {
 	const bool bAlt = (SDL_GetModState() & KMOD_ALT) != 0;
+	const bool preview = (bAlt != characterPreview);
 	const UINT wIdentity = pCharacter->GetIdentity();
 	UINT wFrameIndex = this->pTileImages[this->pRoom->ARRAYINDEX(pCharacter->wX, pCharacter->wY)].animFrame % ANIMATION_FRAMES;
-	if (wIdentity != M_NONE && IsAnimated() && bAlt)
+	if (wIdentity != M_NONE && IsAnimated() && preview)
 	{
 		//Draw NPC's actual in-game image.
 		ASSERT(wIdentity < MONSTER_COUNT ||

--- a/drodrpg/DROD/EditRoomWidget.h
+++ b/drodrpg/DROD/EditRoomWidget.h
@@ -122,6 +122,8 @@ public:
 	MonsterSegment monsterSegment;   //long monster being plotted
 	CCoordIndex    swords;           //double swords in room
 
+	bool           characterPreview; //automatic preview of scripted characters
+
 protected:
 	virtual  ~CEditRoomWidget();
 

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -671,20 +671,18 @@ CSubtitleEffect* CRoomWidget::AddSubtitle(
 		color = SpeakerColor[getSpeakerType((MONSTERTYPE)wIdentity)];
 	}
 
-/*
-	//Background color for citizens matches their station-type color.
-	CCitizen *pCitizen = dynamic_cast<CCitizen*>(pCoord);
-	if (pCitizen)
+	//Check for custom speech color
+	CCharacter *pCharacter = dynamic_cast<CCharacter*>(pCoord);
+	if (pCharacter)
 	{
-		const int colorIndex = pCitizen->StationType();
-		if (colorIndex >= 0)
+		const int colorIndex = pCharacter->GetCustomSpeechColor();
+		if (colorIndex)
 		{
-			color.byt1 = Uint8((1.0 + lightMap[0][colorIndex]) * 127.5); //half-saturated
-			color.byt2 = Uint8((1.0 + lightMap[1][colorIndex]) * 127.5);
-			color.byt3 = Uint8((1.0 + lightMap[2][colorIndex]) * 127.5);
+			color.byt1 = Uint8((colorIndex >> 16) & 255);
+			color.byt2 = Uint8((colorIndex >> 8) & 255);
+			color.byt3 = Uint8(colorIndex & 255);
 		}
 	}
-*/
 
 	//Speaker text effect.
 	CSubtitleEffect *pSubtitle = new CSubtitleEffect(this, pCoord,
@@ -699,7 +697,6 @@ CSubtitleEffect* CRoomWidget::AddSubtitle(
 
 	//If entity speaking is an invisible NPC script, then don't offset the speech
 	//coords to avoid drawing over the entity.
-	CCharacter *pCharacter = dynamic_cast<CCharacter*>(pCoord);
 	if (pCharacter)
 	{
 		if (!pCharacter->bVisible)

--- a/drodrpg/DROD/SettingsScreen.cpp
+++ b/drodrpg/DROD/SettingsScreen.cpp
@@ -126,6 +126,7 @@ const UINT TAG_UPLOADSCORES = 1065;
 
 const UINT TAG_AUTOSAVE = 1070;
 const UINT TAG_ITEMTIPS = 1071;
+const UINT TAG_CHARACTERPREVIEW = 1073;
 
 const UINT TAG_NEWGAMEPROMPT = 1072;
 
@@ -270,7 +271,11 @@ CSettingsScreen::CSettingsScreen()
 	static const int Y_ITEMTIPS = Y_AUTOSAVE + CY_AUTOSAVE;
 	static const UINT CX_ITEMTIPS = CX_AUTOSAVE;
 	static const UINT CY_ITEMTIPS = CY_STANDARD_OPTIONBUTTON;
-	static const UINT CY_EDITOR_FRAME = Y_ITEMTIPS + CY_ITEMTIPS + CY_SPACE;
+	static const int X_CHARACTERPREVIEW = CX_SPACE;
+	static const int Y_CHARACTERPREVIEW = Y_ITEMTIPS + CY_AUTOSAVE;
+	static const UINT CX_CHARACTERPREVIEW = CX_AUTOSAVE;
+	static const UINT CY_CHARACTERPREVIEW = CY_STANDARD_OPTIONBUTTON;
+	static const UINT CY_EDITOR_FRAME = Y_CHARACTERPREVIEW + CY_CHARACTERPREVIEW + CY_SPACE;
 
 	//New game frame and children
 	static const int X_NEWGAME_FRAME = X_EDITOR_FRAME;
@@ -588,6 +593,11 @@ CSettingsScreen::CSettingsScreen()
 	pOptionButton = new COptionButtonWidget(TAG_ITEMTIPS, X_ITEMTIPS,
 					Y_ITEMTIPS, CX_ITEMTIPS, CY_ITEMTIPS,
 					g_pTheDB->GetMessageText(MID_ItemTips), true);
+	pEditorFrame->AddWidget(pOptionButton);
+
+	pOptionButton = new COptionButtonWidget(TAG_CHARACTERPREVIEW, X_CHARACTERPREVIEW,
+		Y_CHARACTERPREVIEW, CX_CHARACTERPREVIEW, CY_CHARACTERPREVIEW,
+		g_pTheDB->GetMessageText(MID_AutoPreviewCharacters), false);
 	pEditorFrame->AddWidget(pOptionButton);
 
 	//New game frame
@@ -1420,6 +1430,10 @@ void CSettingsScreen::UpdateWidgetsFromPlayerData(
 	pOptionButton->SetChecked(settings.GetVar(Settings::ItemTips, true));
 
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_CHARACTERPREVIEW));
+	pOptionButton->SetChecked(settings.GetVar(Settings::CharacterPreview, false));
+
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_DISABLE_MOUSE_MOVEMENT));
 	pOptionButton->SetChecked(settings.GetVar(Settings::DisableMouse, false));
 
@@ -1551,6 +1565,9 @@ void CSettingsScreen::UpdatePlayerDataFromWidgets(
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_ITEMTIPS));
 	settings.SetVar("ItemTips", pOptionButton->IsChecked());
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_CHARACTERPREVIEW));
+	settings.SetVar(Settings::CharacterPreview, pOptionButton->IsChecked());
 
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_DISABLE_MOUSE_MOVEMENT));

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -65,7 +65,6 @@ const UINT MAX_ANSWERS = 9;
 
 #define CustomNameStr "Name"
 
-#define ColorStr "Color"
 #define ParamXStr "XParam"
 #define ParamYStr "YParam"
 #define ParamWStr "WParam"
@@ -5007,6 +5006,7 @@ void CCharacter::ResolveLogicalIdentity(CDbHold *pHold)
 
 				if (this->commands.empty()) {
 					this->wProcessSequence = this->pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
+					this->color = this->pCustomChar->ExtraVars.GetVar(ColorStr, this->wProcessSequence);
 				}
 			}
 			else

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -248,6 +248,7 @@ CCharacter::CCharacter(
 	, bIfBlock(false)
 	, eachAttackLabelIndex(NO_LABEL), eachDefendLabelIndex(NO_LABEL), eachUseLabelIndex(NO_LABEL)
 	, eachVictoryLabelIndex(NO_LABEL)
+	, customSpeechColor(0)
 	, wLastSpeechLineNumber(0)
 
 	, color(0), sword(NPC_DEFAULT_SWORD)
@@ -5007,6 +5008,7 @@ void CCharacter::ResolveLogicalIdentity(CDbHold *pHold)
 				if (this->commands.empty()) {
 					this->wProcessSequence = this->pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
 					this->color = this->pCustomChar->ExtraVars.GetVar(ColorStr, this->wProcessSequence);
+					this->customSpeechColor = this->pCustomChar->ExtraVars.GetVar(ParamSpeechColorStr, this->customSpeechColor);
 				}
 			}
 			else
@@ -5413,6 +5415,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->paramH = vars.GetVar(ParamHStr, this->paramH);
 	this->paramF = vars.GetVar(ParamFStr, this->paramF);
 	this->wProcessSequence = vars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
+	this->customSpeechColor = vars.GetVar(ParamSpeechColorStr, this->customSpeechColor);
 
 	//Modifiers
 	this->monsterHPmult = vars.GetVar(MonsterHPMultStr, this->monsterHPmult);
@@ -5563,6 +5566,8 @@ const
 		vars.SetVar(ParamFStr, this->paramF);
 	if (this->wProcessSequence != 9999)
 		vars.SetVar(ParamProcessSequenceStr, this->wProcessSequence);
+	if (this->customSpeechColor)
+		vars.SetVar(ParamSpeechColorStr, this->customSpeechColor);
 
 	// Modifiers
 	if (this->monsterHPmult != 100)

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -58,6 +58,7 @@ using std::vector;
 #define DefaultCustomCharacterName wszEmpty
 #define ParamProcessSequenceStr "ProcessSequenceParam"
 #define ColorStr "Color"
+#define ParamSpeechColorStr "SpeechColorParam"
 
 class CSwordsman;
 struct HoldCharacter;
@@ -122,6 +123,7 @@ public:
 	virtual UINT   getSword() const;
 
 	WSTRING        GetCustomName() const { return this->customName; }
+	UINT           GetCustomSpeechColor() const { return this->customSpeechColor; }
 	void           getCommandParams(const CCharacterCommand& command,
 			UINT& x, UINT& y, UINT& w, UINT& h, UINT& f) const;
 	void           getCommandRect(const CCharacterCommand& command,
@@ -197,6 +199,7 @@ public:
 	static void    SaveSpeech(const COMMANDPTR_VECTOR& commands);
 	virtual void   SetColor(const UINT color) { this->color = color; }
 	virtual void   SetCurrentGame(const CCurrentGame *pSetCurrentGame);
+	virtual void   SetCustomSpeechColor(const UINT color) { this->customSpeechColor = color; }
 	virtual void   SetExtraVarsForExport() { PackExtraVars(true); } //include config params and script
 	void           SetExtraVarsFromMembersWithoutScript(CDbPackedVars& vars) const;
 	virtual void   SetMembers(const CDbPackedVars& vars);
@@ -312,6 +315,8 @@ private:
 	int  eachVictoryLabelIndex; //if set, jump script execution here on each combat victory
 
 	WSTRING customName; // Custom name for this character, used for any display purpose, empty means use the default character name
+
+	UINT customSpeechColor; //Value to represent custom speech color. empty means use default color
 
 	UINT wLastSpeechLineNumber; //used during language import
 

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -57,6 +57,7 @@ using std::vector;
 
 #define DefaultCustomCharacterName wszEmpty
 #define ParamProcessSequenceStr "ProcessSequenceParam"
+#define ColorStr "Color"
 
 class CSwordsman;
 struct HoldCharacter;
@@ -194,6 +195,7 @@ public:
 	static void    SaveCommands(CDbPackedVars& ExtraVars, const COMMANDPTR_VECTOR& commands);
 	static void    SaveSpeech(const COMMAND_VECTOR& commands);
 	static void    SaveSpeech(const COMMANDPTR_VECTOR& commands);
+	virtual void   SetColor(const UINT color) { this->color = color; }
 	virtual void   SetCurrentGame(const CCurrentGame *pSetCurrentGame);
 	virtual void   SetExtraVarsForExport() { PackExtraVars(true); } //include config params and script
 	void           SetExtraVarsFromMembersWithoutScript(CDbPackedVars& vars) const;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -776,6 +776,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_FilePendingDeletionSuffix: strText = "(Pending deletion)"; break;
 		case MID_Undelete: strText = "Undelete"; break;
 		case MID_CustomSpeechColor: strText = "Speech Color (rgb)"; break;
+		case MID_AutoPreviewCharacters: strText = "Automatically Preview Characters"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -775,6 +775,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ReplaceFileButton: strText = "Replace"; break;
 		case MID_FilePendingDeletionSuffix: strText = "(Pending deletion)"; break;
 		case MID_Undelete: strText = "Undelete"; break;
+		case MID_CustomSpeechColor: strText = "Speech Color (rgb)"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/SettingsKeys.cpp
+++ b/drodrpg/DRODLib/SettingsKeys.cpp
@@ -43,6 +43,7 @@ namespace Settings
 	DEF(AutoSave);
 	DEF(AutoSaveOptions);
 	DEF(AutoUndoOnDeath);
+	DEF(CharacterPreview);
 	DEF(CloudActivated);
 	DEF(CloudHoldVersion);
 	DEF(CloudHoldDemosVersion);

--- a/drodrpg/DRODLib/SettingsKeys.h
+++ b/drodrpg/DRODLib/SettingsKeys.h
@@ -43,6 +43,7 @@ namespace Settings
 	DEF(AutoSave);
 	DEF(AutoSaveOptions);
 	DEF(AutoUndoOnDeath);
+	DEF(CharacterPreview);
 	DEF(CloudActivated);
 	DEF(CloudHoldVersion);
 	DEF(CloudHoldDemosVersion);

--- a/drodrpg/Data/Help/1/character.html
+++ b/drodrpg/Data/Help/1/character.html
@@ -35,7 +35,12 @@ enters the room.  Otherwise, it will be invisible.  When an NPC is invisible, it
 script continues to play but it otherwise behaves as if it were not in the room.
 Hint: making a character with a "None" graphic visible will set it to the
 "Citizen 1" type.</p>
-<p><a name="charoptions"><b>Options</b></a> - Click to set the NPC's processing sequence, which controls the order of scripts running in a room. Scripts with lower processing sequence values run earlier, and scripts with higher values run later. This does not effect the order in which equipment scripts will be run.</p>
+<p><a name="charoptions"><b>Options</b></a> - Click to set the NPC's options:</p>
+<ul>
+  <li><b>_MyColor</b>, which allows the predefined <a href="script.html#mycolor">_MyColor</a> var to be set for the character. Setting it this way allows it to be used when displaying an NPC's in-game appearance in the editor.</li>
+  <li><b>Speech Color</b>, which controls the color of the character's speech subtitles. Each input takes a value of 0 to 255, and the three values are combined into a single RGB color value. If all inputs are zero, the default subtitle color will be used.</li>
+  <li><b>Processing sequence</b>, which controls the order of scripts running in a room. Scripts with lower processing sequence values run earlier, and scripts with higher values run later. This does not effect the order in which equipment scripts will be run.</li>
+</ul>
 <p><a name="addcommand"><b>Add Command</b></a> - Click to add another <a href="script.html">command</a>
 to the script.</p>
 <p><a name="deletecommand"><b>Delete Command</b></a> - Deletes the selected commands from the script.  Also

--- a/drodrpg/Data/Help/1/character.html
+++ b/drodrpg/Data/Help/1/character.html
@@ -39,7 +39,7 @@ Hint: making a character with a "None" graphic visible will set it to the
 <ul>
   <li><b>_MyColor</b>, which allows the predefined <a href="script.html#mycolor">_MyColor</a> var to be set for the character. Setting it this way allows it to be used when displaying an NPC's in-game appearance in the editor.</li>
   <li><b>Speech Color</b>, which controls the color of the character's speech subtitles. Each input takes a value of 0 to 255, and the three values are combined into a single RGB color value. If all inputs are zero, the default subtitle color will be used.</li>
-  <li><b>Processing sequence</b>, which controls the order of scripts running in a room. Scripts with lower processing sequence values run earlier, and scripts with higher values run later. This does not effect the order in which equipment scripts will be run.</li>
+  <li><b>Processing sequence</b>, which controls the order of scripts running in a room. Scripts with lower processing sequence values run earlier, and scripts with higher values run later. This does not affect the order in which equipment scripts will be run.</li>
 </ul>
 <p><a name="addcommand"><b>Add Command</b></a> - Click to add another <a href="script.html">command</a>
 to the script.</p>

--- a/drodrpg/Data/Help/1/editroom.html
+++ b/drodrpg/Data/Help/1/editroom.html
@@ -325,6 +325,7 @@ include the following:</p>
    Useful for graphic mod development with the game open.</li>
   <li>F4 - assign default player stats when playtesting</li>
   <li>F5 - playtest room</li>
+  <li>F6 - Toggle the display of the in-game appearance of NPCs</li>
   <li>Ctrl-F7 - rotate room clockwise</li>
   <li>F7 - reflect room horizontally</li>
   <li>F8 - reflect room vertically</li>
@@ -337,7 +338,7 @@ include the following:</p>
   <li>Ctrl-Z - undo room edits</li>
   <li>Ctrl-Y - redo room edits</li>
   <li>Ctrl-X,C,V - cut/copy/paste a room region highlighted by a mouse drag</li>
-  <li>Alt - hold down to display the in-game appearance of NPCs</li>
+  <li>Alt - hold down to display or hide the in-game appearance of NPCs</li>
   <li>Enter - pull up CaravelNet chat/console window</li>
 </ul>
 <p>Press &lt;Escape&gt; to return to the <a href="editselect.html">main

--- a/drodrpg/Data/Help/1/settings.html
+++ b/drodrpg/Data/Help/1/settings.html
@@ -46,7 +46,8 @@ automatically" is checked, changes you make to a room in the <a
  href="editroom.html">editor</a> are saved on leaving the room.
 &nbsp;Turn this option off if you want to be prompted before saving any
 room changes. &nbsp;Check "Show item tips" to receive help placing
-special objects in the room. </p>
+special objects in the room. Check "Automatically Preview Characters" to
+default to showing the in-game appearance of NPCs.</p>
 <hr />
 <a href="contents.html">Contents</a>
 </body>

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1515,6 +1515,7 @@ enum MID_CONSTANT {
   MID_CharOptions = 1837,
   MID_ProcessingSequence = 1838,
   MID_ProcessingSequenceDescription = 1839,
+  MID_CustomSpeechColor = 1849,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1175,6 +1175,7 @@ enum MID_CONSTANT {
   MID_ShowScore = 1831,
   MID_NewGames = 1841,
   MID_ConfirmNewGame = 1842,
+  MID_AutoPreviewCharacters = 1850,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/drodrpg/Texts/SettingsScreen.uni
+++ b/drodrpg/Texts/SettingsScreen.uni
@@ -449,3 +449,7 @@ New games
 [MID_ConfirmNewGame]
 [eng]
 Confirm new game
+
+[MID_AutoPreviewCharacters]
+[eng]
+Automatically Preview Characters

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1347,3 +1347,7 @@ Processing Sequence:
 [MID_ProcessingSequenceDescription]
 [eng]
 Scripts with a lower processing sequence value will run before scripts with a higher value.
+
+[MID_CustomSpeechColor]
+[eng]
+Speech Color (rgb)


### PR DESCRIPTION
Three somewhat related features packaged together:

A new setting to make show NPC's in-game appearance the default. When this is active, holding the Alt key will show the generic editor appearance. It can also be toggled in-editor with the F6 key. ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=45910))

To help the above, the `_MyColor` variable can now be preset in the character options dialog. When this is done, the character's altered color can be seen when previewing NPC appearances.

Finally, inputs have been added to the character options dialog to set a custom speech color. The three RGB values are set separately, then combined into a single value for storage. This is because it was the method I was able to get working. ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=35641))