### PR TITLE
RPG WIN32: Convert bad line ending to good ones when importing uni file

### DIFF
--- a/drodrpg/DRODUtil/Util3_0.cpp
+++ b/drodrpg/DRODUtil/Util3_0.cpp
@@ -733,6 +733,19 @@ const
   const WCHAR wszNameTagStart[] = {{'M'},{'I'},{'D'},{'_'},{0}};
   char szNameTag[MAXLEN_NAMETAG + 1];
 
+#ifdef WIN32
+	// We need crlf line ends, at least for Windows builds.
+	// This ensures we get them if the file has lr line ends
+	WSTRING::size_type pos = 0;
+	while ((pos = wideSource.find(L"\n", pos)) != string::npos)
+	{
+		if (wideSource.at(pos - 1) != L'\r')
+			wideSource.insert(pos, L"\r");
+
+		pos++;
+	}
+#endif
+
   const WCHAR* pSeek = wideSource.c_str();
   const WCHAR* pStop = pSeek + wideSource.size();
   const WCHAR *pTagStart;


### PR DESCRIPTION
This is #440 for the RPG version of DRODUtil. As before the conversion is only done for WIN32 builds, but if it was discovered that the problem exists on other platforms, a similar fix can be made.