### PR TITLE
Don't try to reimport empty demos or saved games

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1300,13 +1300,17 @@ void CDbXML::ImportSavedGames()
 	const CImportInfo::ImportType importType = info.typeBeingImported;
 	const MESSAGE_ID importState = info.ImportStatus;
 	info.typeBeingImported = CImportInfo::Demo;
-	VERIFY(ImportXML(info.exportedDemos) == MID_ImportSuccessful);
-	info.exportedDemos.resize(0);
+	if (info.exportedDemos.size()) {
+		VERIFY(ImportXML(info.exportedDemos) == MID_ImportSuccessful);
+		info.exportedDemos.resize(0);
+	}
 
 	info.ImportStatus = importState; //ignore import state changes in saved game restoration
 	info.typeBeingImported = CImportInfo::SavedGame;
-	VERIFY(ImportXML(info.exportedSavedGames) == MID_ImportSuccessful);
-	info.exportedSavedGames.resize(0);
+	if (info.exportedSavedGames.size()) {
+		VERIFY(ImportXML(info.exportedSavedGames) == MID_ImportSuccessful);
+		info.exportedSavedGames.resize(0);
+	}
 
 	info.typeBeingImported = importType;
 	info.ImportStatus = importState;


### PR DESCRIPTION
The XML parser doesn't like being given an empty string and will complain about it. Nothing bad happens, but it fills up the error log.

If exported saves or demos are empty, `CDbXML::ImportSavedGames` now skips over reimporting them.