### PR TITLE
RPG: Fix color getting in CCharacter::ResolveLogicalIdentity

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5007,7 +5007,7 @@ void CCharacter::ResolveLogicalIdentity(CDbHold *pHold)
 
 				if (this->commands.empty()) {
 					this->wProcessSequence = this->pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
-					this->color = this->pCustomChar->ExtraVars.GetVar(ColorStr, this->wProcessSequence);
+					this->color = this->pCustomChar->ExtraVars.GetVar(ColorStr, this->color);
 					this->customSpeechColor = this->pCustomChar->ExtraVars.GetVar(ParamSpeechColorStr, this->customSpeechColor);
 				}
 			}


### PR DESCRIPTION
The processing sequence was being used as the fallback value instead of the character's existing color value.