### PR TITLE
Remove grid style option for puzzle mode

### DIFF
--- a/DROD/GridEffect.cpp
+++ b/DROD/GridEffect.cpp
@@ -33,13 +33,10 @@
 
 #include <BackEndLib/Assert.h>
 
-const UINT CGridEffect::wGridStylesCount = 4;
-
 //********************************************************************************
 CGridEffect::CGridEffect(
 //Params:
 	CWidget *pSetWidget,    //(in)   Should be a room widget.
-	const UINT wGridStyle,  //(in)   Size of the grid
 	const Uint8 uOpacity)   //(in)   Grid's opacity
 	: CEffect(pSetWidget, (UINT)-1, EGRID),
 	wTileNo(TI_GRID_OVERLAY),
@@ -53,20 +50,8 @@ CGridEffect::CGridEffect(
 	SDL_Rect OwnerRect;
 	pSetWidget->GetRect(OwnerRect);
 	this->dirtyRects.push_back(OwnerRect);
-
-	this->wTileNo = GetTileImageForGridStyle(wGridStyle);
 }
 
-//********************************************************************************
-UINT CGridEffect::GetTileImageForGridStyle(const UINT wGridStyle)
-{
-	switch (wGridStyle) {
-		case 2: return TI_GRID_OVERLAY_2;
-		case 3: return TI_GRID_OVERLAY_3;
-		case 4: return TI_GRID_OVERLAY_4;
-		default: return TI_GRID_OVERLAY;
-	}
-}
 //********************************************************************************
 bool CGridEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 //Returns: true if effect should continue, or false if effect is done.

--- a/DROD/GridEffect.h
+++ b/DROD/GridEffect.h
@@ -33,18 +33,13 @@ class CRoomWidget;
 class CGridEffect : public CEffect
 {
 public:
-	CGridEffect(CWidget *pSetWidget, const UINT wGridStyle, const Uint8 uOpacity);
-
-	static const UINT wGridStylesCount;
+	CGridEffect(CWidget *pSetWidget, const Uint8 uOpacity);
 
 protected:
 	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
 	virtual void Draw(SDL_Surface& destSurface);
 
 private:
-
-	UINT GetTileImageForGridStyle(const UINT wGridStyle);
-
 	CRoomWidget *pRoomWidget;
 	UINT wTileNo;
 	Uint8 uOpacity;

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -2283,7 +2283,7 @@ void CRoomWidget::ShowPuzzleMode(const bool bVal)
 	if (bVal)
 	{
 		if (this->puzzleModeOptions.GetShowGrid()) {
-			CGridEffect* pEffect = new CGridEffect(this, this->puzzleModeOptions.wGridStyle, this->puzzleModeOptions.uGridOpacity);
+			CGridEffect* pEffect = new CGridEffect(this, this->puzzleModeOptions.uGridOpacity);
 			pEffect->RequestRetainOnClear(true);
 			AddLastLayerEffect(pEffect);
 		}

--- a/DROD/TileImageConstants.h
+++ b/DROD/TileImageConstants.h
@@ -3147,10 +3147,6 @@
 #define TI_ROCKGOLEM_2_NW   2880
 #define TI_ROCKGOLEM_BRKN_2 2881
 
-#define TI_GRID_OVERLAY_2   2882
-#define TI_GRID_OVERLAY_3   2883
-#define TI_GRID_OVERLAY_4   2884
-
-static const UINT TI_COUNT = 2885;
+static const UINT TI_COUNT = 2882;
 
 #endif //...#ifndef TILEIMAGECONSTANTS_H

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -96,5 +96,4 @@ namespace Settings
 	DEF(PuzzleMode_VisibilityHideWeather);
 
 	DEF(PuzzleMode_GridOpacity);
-	DEF(PuzzleMode_GridStyle);
 }

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -96,7 +96,6 @@ namespace Settings
 	DEF(PuzzleMode_VisibilityHideWeather);
 
 	DEF(PuzzleMode_GridOpacity);
-	DEF(PuzzleMode_GridStyle);
 }
 
 #undef DEF

--- a/drod/PuzzleModeOptions.h
+++ b/drod/PuzzleModeOptions.h
@@ -35,7 +35,6 @@
 struct PuzzleModeOptions {
 	PuzzleModeOptions() :
 		bIsEnabled(false),
-		wGridStyle(1),
 		uGridOpacity(128),
 		bHideAnimations(false),
 		bHideBuildMarkers(false),
@@ -50,7 +49,6 @@ struct PuzzleModeOptions {
 	PuzzleModeOptions(CDbPackedVars& playerSettings) {
 		this->bIsEnabled = false;
 
-		this->wGridStyle = playerSettings.GetVar(Settings::PuzzleMode_GridStyle, 1);
 		this->uGridOpacity = playerSettings.GetVar(Settings::PuzzleMode_GridOpacity, (Uint8)128);
 
 		this->bHideAnimations = playerSettings.GetVar(Settings::PuzzleMode_VisibilityHideAnimations, false);
@@ -70,7 +68,7 @@ struct PuzzleModeOptions {
 	bool GetHideLighting() const { return this->bIsEnabled && this->bHideLighting; }
 	bool GetHideWeather() const { return this->bIsEnabled && this->bHideWeather; }
 
-	bool GetShowGrid() const { return this->bIsEnabled && this->wGridStyle > 0 && this->uGridOpacity > 0; }
+	bool GetShowGrid() const { return this->bIsEnabled && this->uGridOpacity > 0; }
 
 	bool GetShowEvilEyeBeams() const { return this->bIsEnabled && this->bShowEvilEyeBeams; }
 	bool GetShowReverseEvilEyeBeams() const { return this->bIsEnabled && this->bShowReverseEvilEyeBeams; }
@@ -80,7 +78,6 @@ struct PuzzleModeOptions {
 
 	bool bIsEnabled;
 
-	UINT wGridStyle;
 	Uint8 uGridOpacity;
 
 private:

--- a/drod/PuzzleModeOptionsDialogWidget.cpp
+++ b/drod/PuzzleModeOptionsDialogWidget.cpp
@@ -39,7 +39,6 @@
 #include <DRODLib/SettingsKeys.h>
 
  //NOTE: tag #'s should not conflict with other widgets on screen
-const UINT TAG_GRID_STYLE = 2100;
 const UINT TAG_GRID_OPACITY = 2101;
 
 const UINT TAG_VISIBILITY_SPIDERS = 2102;
@@ -94,24 +93,14 @@ CPuzzleModeOptionsDialogWidget::CPuzzleModeOptionsDialogWidget(
 	static const int GRID_FRAME_X = CX_SPACE;
 	static const int GRID_FRAME_Y = HEADER_BOTTOM;
 	static const int GRID_FRAME_W = HALF_W;
-	static const int GRID_FRAME_H = CY_STANDARD_SLIDER * 2 + CY_SPACE * 3;
-
-	static const int GRID_STYLE_LABEL_X = CX_SPACE;
-	static const int GRID_STYLE_LABEL_Y = CY_SPACE;
-	static const int GRID_STYLE_LABEL_W = FRAME_HALF_W;
-	static const int GRID_STYLE_LABEL_H = CY_STANDARD_SLIDER;
-	static const int GRID_STYLE_LABEL_BOTTOM = GRID_STYLE_LABEL_Y + GRID_STYLE_LABEL_H + CY_SPACE;
-	static const int GRID_STYLE_SLIDER_X = CX_SPACE * 2 + FRAME_HALF_W;
-	static const int GRID_STYLE_SLIDER_Y = CY_SPACE;
-	static const int GRID_STYLE_SLIDER_W = FRAME_HALF_W;
-	static const int GRID_STYLE_SLIDER_H = CY_STANDARD_SLIDER;
+	static const int GRID_FRAME_H = CY_STANDARD_SLIDER + CY_SPACE * 2;
 
 	static const int GRID_OPACITY_LABEL_X = CX_SPACE;
-	static const int GRID_OPACITY_LABEL_Y = GRID_STYLE_LABEL_BOTTOM;
+	static const int GRID_OPACITY_LABEL_Y = CY_SPACE;
 	static const int GRID_OPACITY_LABEL_W = FRAME_HALF_W;
 	static const int GRID_OPACITY_LABEL_H = CY_STANDARD_SLIDER;
 	static const int GRID_OPACITY_SLIDER_X = CX_SPACE * 2 + FRAME_HALF_W;
-	static const int GRID_OPACITY_SLIDER_Y = GRID_STYLE_LABEL_BOTTOM;
+	static const int GRID_OPACITY_SLIDER_Y = CY_SPACE;
 	static const int GRID_OPACITY_SLIDER_W = FRAME_HALF_W;
 	static const int GRID_OPACITY_SLIDER_H = CY_STANDARD_SLIDER;
 
@@ -191,16 +180,6 @@ CPuzzleModeOptionsDialogWidget::CPuzzleModeOptionsDialogWidget(
 			GRID_FRAME_X, GRID_FRAME_Y, GRID_FRAME_W, GRID_FRAME_H,
 			g_pTheDB->GetMessageText(MID_PuzzleModeOption_Frame_GridOptions));
 		AddWidget(pFrameWidget);
-
-		pLabelWidget = new CLabelWidget(0L,
-			GRID_STYLE_LABEL_X, GRID_STYLE_LABEL_Y, GRID_STYLE_LABEL_W, GRID_STYLE_LABEL_H,
-			F_Small, g_pTheDB->GetMessageText(MID_PuzzleModeOption_GridStyle));
-		pFrameWidget->AddWidget(pLabelWidget);
-		pSliderWidget = new CSliderWidget(TAG_GRID_STYLE,
-			GRID_STYLE_SLIDER_X, GRID_STYLE_SLIDER_Y, GRID_STYLE_SLIDER_W, GRID_STYLE_SLIDER_H,
-			0, 5);
-		pSliderWidget->SetDrawTickMarks(true);
-		pFrameWidget->AddWidget(pSliderWidget);
 
 		pLabelWidget = new CLabelWidget(0L,
 			GRID_OPACITY_LABEL_X, GRID_OPACITY_LABEL_Y, GRID_OPACITY_LABEL_W, GRID_OPACITY_LABEL_H,
@@ -302,9 +281,6 @@ bool CPuzzleModeOptionsDialogWidget::SetForActivate()
 	COptionButtonWidget* pOptionWidget = NULL;
 
 	{ // GRID STYLE
-		pSliderWidget = DYN_CAST(CSliderWidget*, CWidget*, GetWidget(TAG_GRID_STYLE));
-		pSliderWidget->SetValue(settings.GetVar(Settings::PuzzleMode_GridStyle, 1U));
-
 		pSliderWidget = DYN_CAST(CSliderWidget*, CWidget*, GetWidget(TAG_GRID_OPACITY));
 		pSliderWidget->SetValue(settings.GetVar(Settings::PuzzleMode_GridOpacity, (Uint8)128));
 	}
@@ -357,9 +333,6 @@ void CPuzzleModeOptionsDialogWidget::OnDeactivate()
 	COptionButtonWidget* pOptionWidget = NULL;
 
 	{ // GRID STYLE
-		pSliderWidget = DYN_CAST(CSliderWidget*, CWidget*, GetWidget(TAG_GRID_STYLE));
-		settings.SetVar(Settings::PuzzleMode_GridStyle, (UINT)pSliderWidget->GetValue());
-		
 		pSliderWidget = DYN_CAST(CSliderWidget*, CWidget*, GetWidget(TAG_GRID_OPACITY));
 		settings.SetVar(Settings::PuzzleMode_GridOpacity, (Uint8)pSliderWidget->GetValue());
 	}


### PR DESCRIPTION
The grid style option doesn't work because it needs graphics, but none were ever supplied. It is also unclear what "grid style" is meant to be, as the comment for in it `GridEffect` says "size of the grid". Due to this is it is probably best to remove it. (The strings have to remain to preserve the MID ordering)

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=44932