### PR TITLE
RPG: Improve quick travel logic

### DIFF
--- a/drodrpg/DRODLib/Swordsman.cpp
+++ b/drodrpg/DRODLib/Swordsman.cpp
@@ -209,8 +209,9 @@ bool CSwordsman::IsOpenMove(const UINT wX, const UINT wY, const int dx, const in
 	const UINT oTile = room.GetOSquare(wNewX, wNewY);
 	if (IsTileObstacle(oTile))
 	{
-		if (!(bIsDoor(oTile) && (bIsEntityFlying(this->wAppearance) ||
-				bIsDoor(room.GetOSquare(wX, wY))))) //may walk along door tops or fly onto them
+		if (!(bIsDoor(oTile) && bIsDoor(room.GetOSquare(wX, wY))) && //may walk along door tops
+			 !(bIsWater(oTile) && CanWalkOnWater()) && //can cross water tiles
+			 !(bIsPit(oTile) && bIsEntityFlying(wAppearance))) //can fly over pit
 			return false;
 	}
 


### PR DESCRIPTION
A few improvements to the quick travel to room edge algorithm:

- Allow pathing over water if the player can move on water
- Allow pathing over pits if the player can move on pits
- Remove logic that treats closed doors as always passable for flying player.