### PR TITLE
RPG: Improve tile description for equipment

### DIFF
--- a/BackEndLib/Wchar.cpp
+++ b/BackEndLib/Wchar.cpp
@@ -41,6 +41,7 @@ const WCHAR wszOpenAngle[] =    { We('<'),We(0) };
 const WCHAR wszCloseAngle[] =   { We('>'),We(0) };
 const WCHAR wszColon[] =        { We(':'),We(0) };
 const WCHAR wszComma[] =        { We(','),We(0) };
+const WCHAR wszCommaSpace[] =   { We(','),We(' '),We(0) };
 #ifdef WIN32
 const WCHAR wszCRLF[] =         { We('\r'),We('\n'),We(0) };
 #else

--- a/BackEndLib/Wchar.h
+++ b/BackEndLib/Wchar.h
@@ -79,7 +79,7 @@ typedef std::basic_string<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR> 
 
 //Some common small strings.  Larger strings are localizable and should be kept in database.
 extern const WCHAR wszAmpersand[], wszAsterisk[], wszOpenAngle[], wszCloseAngle[], wszColon[],
-	wszComma[], wszCRLF[], wszDollarSign[], wszElipsis[], wszEmpty[], wszEqual[],
+	wszComma[], wszCommaSpace[], wszCRLF[], wszDollarSign[], wszElipsis[], wszEmpty[], wszEqual[],
 	wszExclamation[], wszForwardSlash[], wszHyphen[], wszParentDir[],
 	wszPercent[], wszPeriod[], wszPoundSign[], wszPlus[], wszQuestionMark[], wszQuote[],
 	wszLeftBracket[], wszRightBracket[], wszLeftParen[], wszRightParen[],

--- a/drodrpg/DROD/DROD.2019.vcxproj
+++ b/drodrpg/DROD/DROD.2019.vcxproj
@@ -559,6 +559,7 @@
     <ClCompile Include="EditRoomWidget.cpp" />
     <ClCompile Include="EditSelectScreen.cpp" />
     <ClCompile Include="EntranceSelectDialogWidget.cpp" />
+    <ClCompile Include="EquipmentDescription.cpp" />
     <ClCompile Include="ExplosionEffect.cpp" />
     <ClCompile Include="FaceWidget.cpp" />
     <ClCompile Include="GameScreen.cpp" />
@@ -631,6 +632,7 @@
     <ClInclude Include="EditRoomWidget.h" />
     <ClInclude Include="EditSelectScreen.h" />
     <ClInclude Include="EntranceSelectDialogWidget.h" />
+    <ClInclude Include="EquipmentDescription.h" />
     <ClInclude Include="ExplosionEffect.h" />
     <ClInclude Include="FaceWidget.h" />
     <ClInclude Include="GameScreen.h" />

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -1,0 +1,235 @@
+// $Id: EquipmentDescription.cpp $
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2007, 2023
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#include "EquipmentDescription.h"
+
+#include "../DRODLib/Character.h"
+#include "../DRODLib/Db.h"
+#include "../DRODLib/RoomData.h"
+
+ //*****************************************************************************
+WSTRING EquipmentDescription::GetPredefinedAccessoryAbility(UINT type)
+//Returns: string with text of the accessory's ability, or empty string if none
+{
+	switch (type) {
+	case AccessoryType::LuckyGold: return g_pTheDB->GetMessageText(MID_BehaviorLuckyGR);
+	case AccessoryType::XPDoubler: return g_pTheDB->GetMessageText(MID_DoubleXP);
+	default: return L"";
+	}
+}
+
+//*****************************************************************************
+WSTRING EquipmentDescription::GetPredefinedShieldAbility(UINT type)
+//Returns: string with text of the shield's ability, or empty string if none
+{
+	WSTRING wstr;
+
+	if (!(type == ShieldType::WoodenShield ||
+		type == ShieldType::OremiteShield ||
+		type == ShieldType::ArmorSlot)) {
+		wstr += g_pTheDB->GetMessageText(MID_BehaviorMetal);
+	}
+
+	return wstr;
+}
+
+//*****************************************************************************
+WSTRING EquipmentDescription::GetPredefinedWeaponAbility(
+	UINT type, WSTRING separator)
+//Returns: string with text of the sword's ability, or empty string if none
+{
+	WSTRING wstr;
+
+	if (type == SwordType::WoodenBlade || type == SwordType::WeaponSlot) {
+		//These swords have no abilties
+		return wstr;
+	}
+
+	//All swords with abilites are also metal
+	wstr += g_pTheDB->GetMessageText(MID_BehaviorMetal);
+
+	switch (type) {
+		case SwordType::GoblinSword: {
+			wstr += separator;
+			wstr += g_pTheDB->GetMessageText(MID_BehaviorGoblinWeakness);
+		}
+		break;
+		case SwordType::ReallyBigSword: {
+			wstr += separator;
+			wstr += g_pTheDB->GetMessageText(MID_BehaviorBeamBlock);
+		}
+		break;
+		case SwordType::LuckySword: {
+			wstr += separator;
+			wstr += g_pTheDB->GetMessageText(MID_BehaviorLuckyGR);
+		}
+		break;
+		case SwordType::SerpentSword: {
+			wstr += separator;
+			wstr += g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness);
+		}
+		break;
+		case SwordType::BriarSword: {
+			wstr += separator;
+			wstr += g_pTheDB->GetMessageText(MID_BehaviorBriarCut);
+		}
+		break;
+		default: break;
+	}
+
+	return wstr;
+}
+
+//*****************************************************************************
+WSTRING EquipmentDescription::GetEquipmentAbility(
+	const CCharacter* pCharacter,
+	ScriptFlag::EquipmentType equipType,
+	WSTRING separator)
+//Returns: string with text of custom equipment ability, or empty string if none
+{
+	ASSERT(CCharacterCommand::IsRealEquipmentType(equipType));
+
+	WSTRING text;
+	bool goblinWeakness = false, serpentWeakness = false, customWeakness = false;
+	bool needSeparator = false;
+
+	//Armor does not grant strong hit
+	if (equipType != ScriptFlag::EquipmentType::Armor) {
+		goblinWeakness = pCharacter->HasGoblinWeakness();
+		serpentWeakness = pCharacter->HasSerpentWeakness();
+		customWeakness = pCharacter->HasCustomWeakness();
+	}
+
+	if (pCharacter->IsMetal())
+	{
+		text += g_pTheDB->GetMessageText(MID_BehaviorMetal);
+		needSeparator = true;
+	}
+	if (goblinWeakness)
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_BehaviorGoblinWeakness);
+		needSeparator = true;
+	}
+	if (serpentWeakness)
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness);
+		needSeparator = true;
+	}
+	if (customWeakness)
+	{
+		if (needSeparator)
+			text += separator;
+		text += WCSReplace(
+			g_pTheDB->GetMessageText(MID_StrongAgainstAspect),
+			wszStringToken,
+			pCharacter->GetCustomWeakness()
+		);
+		needSeparator = true;
+	}
+	if (pCharacter->HasRayBlocking())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_BehaviorBeamBlock);
+		needSeparator = true;
+	}
+	if (pCharacter->CanCutBriar())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_BehaviorBriarCut);
+		needSeparator = true;
+	}
+	if (pCharacter->IsLuckyGR())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_BehaviorLuckyGR);
+		needSeparator = true;
+	}
+	if (pCharacter->IsLuckyXP())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_DoubleXP);
+		needSeparator = true;
+	}
+	if (pCharacter->CanAttackFirst())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_AttackFirst);
+		needSeparator = true;
+	}
+	if (pCharacter->CanAttackLast())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_AttackLast);
+		needSeparator = true;
+	}
+	if (pCharacter->RemovesSword())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_RemovesSword);
+		needSeparator = true;
+	}
+	if (pCharacter->TurnToFacePlayerWhenFighting())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_BehaviorSurprisedBehind);
+		needSeparator = true;
+	}
+	if (pCharacter->HasNoEnemyDefense())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_NoEnemyDefense);
+		needSeparator = true;
+	}
+	if (pCharacter->HasCustomDescription()) {
+		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
+
+		for (size_t i = 0; i < descriptions.size(); ++i) {
+			WSTRING description = descriptions[i];
+			if (description.empty()) continue;
+
+			if (needSeparator)
+				text += separator;
+
+			text += description;
+			needSeparator = true;
+		}
+	}
+
+	return text;
+}

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -37,7 +37,7 @@ WSTRING EquipmentDescription::GetPredefinedAccessoryAbility(UINT type)
 	switch (type) {
 	case AccessoryType::LuckyGold: return g_pTheDB->GetMessageText(MID_BehaviorLuckyGR);
 	case AccessoryType::XPDoubler: return g_pTheDB->GetMessageText(MID_DoubleXP);
-	default: return L"";
+	default: return WSTRING();
 	}
 }
 
@@ -58,7 +58,7 @@ WSTRING EquipmentDescription::GetPredefinedShieldAbility(UINT type)
 
 //*****************************************************************************
 WSTRING EquipmentDescription::GetPredefinedWeaponAbility(
-	UINT type, WSTRING separator)
+	UINT type, const WSTRING& separator)
 //Returns: string with text of the sword's ability, or empty string if none
 {
 	WSTRING wstr;
@@ -107,7 +107,7 @@ WSTRING EquipmentDescription::GetPredefinedWeaponAbility(
 WSTRING EquipmentDescription::GetEquipmentAbility(
 	const CCharacter* pCharacter,
 	ScriptFlag::EquipmentType equipType,
-	WSTRING separator)
+	const WSTRING& separator)
 //Returns: string with text of custom equipment ability, or empty string if none
 {
 	ASSERT(CCharacterCommand::IsRealEquipmentType(equipType));
@@ -220,7 +220,7 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
 
 		for (size_t i = 0; i < descriptions.size(); ++i) {
-			WSTRING description = descriptions[i];
+			const WSTRING& description = descriptions[i];
 			if (description.empty()) continue;
 
 			if (needSeparator)

--- a/drodrpg/DROD/EquipmentDescription.h
+++ b/drodrpg/DROD/EquipmentDescription.h
@@ -34,11 +34,11 @@ class EquipmentDescription {
 public:
 	static WSTRING GetPredefinedAccessoryAbility(UINT type);
 	static WSTRING GetPredefinedShieldAbility(UINT type);
-	static WSTRING GetPredefinedWeaponAbility(UINT type, WSTRING separator);
+	static WSTRING GetPredefinedWeaponAbility(UINT type, const WSTRING& separator);
 
 	static WSTRING GetEquipmentAbility(
 		const CCharacter* pCharacter,
 		ScriptFlag::EquipmentType equipType,
-		WSTRING separator
+		const WSTRING& separator
 	);
 };

--- a/drodrpg/DROD/EquipmentDescription.h
+++ b/drodrpg/DROD/EquipmentDescription.h
@@ -1,0 +1,44 @@
+// $Id: EquipmentDescription.h $
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2007, 2023
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#include <BackEndLib/Types.h>
+#include <BackEndLib/Wchar.h>
+#include "../DRODLib/CharacterCommand.h"
+
+//****************************************************************************************
+class CCharacter;
+class EquipmentDescription {
+public:
+	static WSTRING GetPredefinedAccessoryAbility(UINT type);
+	static WSTRING GetPredefinedShieldAbility(UINT type);
+	static WSTRING GetPredefinedWeaponAbility(UINT type, WSTRING separator);
+
+	static WSTRING GetEquipmentAbility(
+		const CCharacter* pCharacter,
+		ScriptFlag::EquipmentType equipType,
+		WSTRING separator
+	);
+};

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -34,6 +34,7 @@
 #include "DrodFontManager.h"
 #include "DrodScreenManager.h"
 #include "DrodSound.h"
+#include "EquipmentDescription.h"
 #include "TileImageCalcs.h"
 #include "TileImageConstants.h"
 
@@ -1761,10 +1762,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 	//Get equipment properties.
 	const PlayerStats& st = this->pCurrentGame->pPlayer->st;
 	int atk=0, def=0;
-	bool bMetal=false, bBeamBlock=false, bBriar=false, bLuckyGR=false,
-		bAttackFirst=false, bAttackLast=false, bRemovesSword=false, bBackstab=false, bNoEnemyDEF=false,
-		bGoblinWeakness=false, bSerpentWeakness=false, bCustomWeakness=false, bLuckyXP=false,
-		bCustomDescription=false;
+	WSTRING ability;
 
 	CCharacter *pCharacter = NULL; //custom equipment
 	switch (eCommand)
@@ -1780,18 +1778,11 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 				if (pCharacter)
 				{
 					def = (int)pCharacter->getDEF();
-					bGoblinWeakness = pCharacter->HasGoblinWeakness();
-					bSerpentWeakness = pCharacter->HasSerpentWeakness();
-					bCustomWeakness = pCharacter->HasCustomWeakness();
+					ability = EquipmentDescription::GetEquipmentAbility(pCharacter, ScriptFlag::Weapon, wszCRLF);
 				}
+			} else {
+				ability = EquipmentDescription::GetPredefinedWeaponAbility(st.sword, wszCRLF);
 			}
-			bMetal = this->pCurrentGame->IsSwordMetal(st.sword);
-			bBeamBlock = this->pCurrentGame->equipmentBlocksGaze(ScriptFlag::Weapon);
-			bBriar = (st.sword == BriarSword);
-			bLuckyGR = this->pCurrentGame->IsLuckyGRItem(ScriptFlag::Weapon);
-			bLuckyXP = this->pCurrentGame->IsLuckyXPItem(ScriptFlag::Weapon);
-			bGoblinWeakness |= (st.sword == GoblinSword);
-			bSerpentWeakness |= (st.sword == SerpentSword);
 		break;
 		case CMD_USE_ARMOR:
 			if (this->pCurrentGame->IsPlayerShieldDisabled())
@@ -1801,13 +1792,13 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 			if (bIsCustomEquipment(st.shield))
 			{
 				pCharacter = this->pCurrentGame->getCustomEquipment(ScriptFlag::Armor);
-				if (pCharacter)
+				if (pCharacter) {
 					atk = (int)pCharacter->getATK();
+					ability = EquipmentDescription::GetEquipmentAbility(pCharacter, ScriptFlag::Armor, wszCRLF);
+				}
+			} else {
+				ability = EquipmentDescription::GetPredefinedShieldAbility(st.shield);
 			}
-			bMetal = this->pCurrentGame->IsShieldMetal(st.shield);
-			bBeamBlock = this->pCurrentGame->equipmentBlocksGaze(ScriptFlag::Armor);
-			bLuckyGR = this->pCurrentGame->IsLuckyGRItem(ScriptFlag::Armor);
-			bLuckyXP = this->pCurrentGame->IsLuckyXPItem(ScriptFlag::Armor);
 		break;
 		case CMD_USE_ACCESSORY:
 			if (this->pCurrentGame->IsPlayerAccessoryDisabled())
@@ -1820,27 +1811,12 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 				{
 					atk = (int)pCharacter->getATK();
 					def = (int)pCharacter->getDEF();
-					bMetal = pCharacter->IsMetal();
-					bBeamBlock = pCharacter->HasRayBlocking();
-					bGoblinWeakness = pCharacter->HasGoblinWeakness();
-					bSerpentWeakness = pCharacter->HasSerpentWeakness();
-					bCustomWeakness = pCharacter->HasCustomWeakness();
+					ability = EquipmentDescription::GetEquipmentAbility(pCharacter, ScriptFlag::Accessory, wszCRLF);
 				}
+			} else {
+				ability = EquipmentDescription::GetPredefinedAccessoryAbility(st.accessory);
 			}
-			bLuckyGR = this->pCurrentGame->IsLuckyGRItem(ScriptFlag::Accessory);
-			bLuckyXP = this->pCurrentGame->IsLuckyXPItem(ScriptFlag::Accessory);
 		break;
-	}
-	//Properties available to custom equipment.
-	if (pCharacter)
-	{
-		bBriar |= pCharacter->CanCutBriar();
-		bAttackFirst |= pCharacter->CanAttackFirst();
-		bAttackLast |= pCharacter->CanAttackLast();
-		bBackstab |= pCharacter->TurnToFacePlayerWhenFighting();
-		bNoEnemyDEF |= pCharacter->HasNoEnemyDefense();
-		bRemovesSword |= pCharacter->RemovesSword();
-		bCustomDescription = pCharacter->HasCustomDescription();
 	}
 
 	//Format as text.
@@ -1867,114 +1843,11 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 		text += g_pTheDB->GetMessageText(MID_DEFStat);
 		bNeedCR = true;
 	}
-	if (bMetal)
+	if (!ability.empty())
 	{
 		if (bNeedCR)
 			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_BehaviorMetal);
-		bNeedCR = true;
-	}
-	if (bGoblinWeakness)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_BehaviorGoblinWeakness);
-		bNeedCR = true;
-	}
-	if (bSerpentWeakness)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness);
-		bNeedCR = true;
-	}
-	if (bCustomWeakness)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += WCSReplace(
-			g_pTheDB->GetMessageText(MID_StrongAgainstAspect),
-			wszStringToken,
-			pCharacter->GetCustomWeakness()
-		);
-		bNeedCR = true;
-	}
-	if (bBeamBlock)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_BehaviorBeamBlock);
-		bNeedCR = true;
-	}
-	if (bBriar)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_BehaviorBriarCut);
-		bNeedCR = true;
-	}
-	if (bLuckyGR)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_BehaviorLuckyGR);
-		bNeedCR = true;
-	}
-	if (bLuckyXP)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_DoubleXP);
-		bNeedCR = true;
-	}
-	if (bAttackFirst)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_AttackFirst);
-		bNeedCR = true;
-	}
-	if (bAttackLast)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_AttackLast);
-		bNeedCR = true;
-	}
-	if (bRemovesSword)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_RemovesSword);
-		bNeedCR = true;
-	}
-	if (bBackstab)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_BehaviorSurprisedBehind);
-		bNeedCR = true;
-	}
-	if (bNoEnemyDEF)
-	{
-		if (bNeedCR)
-			text += wszCRLF;
-		text += g_pTheDB->GetMessageText(MID_NoEnemyDefense);
-		bNeedCR = true;
-	}
-	if (bCustomDescription) {
-		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
-
-		for (size_t i = 0; i < descriptions.size(); ++i) {
-			WSTRING description = descriptions[i];
-			if (description.empty()) continue;
-
-			if (bNeedCR)
-				text += wszCRLF;
-
-			text += description;
-			bNeedCR = true;
-		}
+		text += ability;
 	}
 
 	return text;

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -29,6 +29,7 @@
 #include "DrodBitmapManager.h"
 #include "DrodFontManager.h"
 #include "DrodScreen.h"
+#include "EquipmentDescription.h"
 #include "GameScreen.h"
 
 #include "DamagePreviewEffect.h"
@@ -1222,58 +1223,6 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 				mid = GetKeyMID(this->pRoom->GetTParam(wX, wY)); break;
 			case T_SWORD:
 			case T_SHIELD:
-			{
-				const UINT equipmentType = this->pRoom->GetTParam(wX, wY);
-				const bool bIsShield = tTile == T_SHIELD;
-				if (bIsCustomEquipment(equipmentType) && this->pCurrentGame) {
-					const HoldCharacter *pChar = this->pCurrentGame->pHold->GetCharacter(equipmentType);
-					if (pChar) {
-						AppendTextLine(pChar->charNameText.c_str());
-					} else {
-						AppendTextLine(wszQuestionMark);
-					}
-				} else {
-					AppendLine(bIsShield ? GetShieldMID(equipmentType) : GetSwordMID(equipmentType));
-				}
-
-				if (this->pCurrentGame)
-				{
-					const int oldVal = bIsShield ?
-							this->pCurrentGame->getShieldPower(this->pCurrentGame->pPlayer->st.shield) :
-							this->pCurrentGame->getWeaponPower(this->pCurrentGame->pPlayer->st.sword);
-					int newVal = bIsShield ?
-							this->pCurrentGame->getShieldPower(equipmentType) : this->pCurrentGame->getWeaponPower(equipmentType);
-					if (bIsCustomEquipment(equipmentType)) {
-						//Set up the equipment's properties by running its script in a temporary game instance.
-						CMonsterFactory mf;
-						CMonster *pNew = mf.GetNewMonster((MONSTERTYPE)M_CHARACTER);
-						ASSERT(pNew);
-						pNew->wX = pNew->wY = static_cast<UINT>(-1); //not located anywhere in the room area
-						CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pNew);
-						pCharacter->wLogicalIdentity = equipmentType;
-						pCharacter->equipType = bIsShield ? ScriptFlag::Armor : ScriptFlag::Weapon;
-						CCurrentGame *pTempGame = g_pTheDB->GetDummyCurrentGame();
-						*pTempGame = *this->pCurrentGame;
-						pCharacter->SetCurrentGame(pTempGame);
-
-						CCueEvents Ignored;
-						pCharacter->Process(CMD_WAIT, Ignored);
-						newVal = bIsShield ? pCharacter->getDEF() : pCharacter->getATK();
-						delete pTempGame;
-						delete pCharacter;
-					}
-					const int diff = newVal - oldVal;
-					wstr += wszSpace;
-					wstr += wszLeftParen;
-					if (diff >= 0)
-						wstr += wszPlus;
-					wstr += _itoW(diff, temp, 10);
-					wstr += wszRightParen;
-				}
-
-				mid = 0; //don't append another text for this
-				break;
-			}
 			case T_ACCESSORY:
 			{
 				const UINT equipmentType = this->pRoom->GetTParam(wX, wY);
@@ -1285,8 +1234,105 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 						AppendTextLine(wszQuestionMark);
 					}
 				} else {
-					AppendLine(GetAccessoryMID(equipmentType));
+					switch (tTile) {
+						case T_SWORD: AppendLine(GetSwordMID(equipmentType)); break;
+						case T_SHIELD: AppendLine(GetShieldMID(equipmentType)); break;
+						case T_ACCESSORY: AppendLine(GetAccessoryMID(equipmentType)); break;
+					}
 				}
+
+				if (this->pCurrentGame)
+				{
+					int oldATK = 0, oldDEF = 0, newATK = 0, newDEF = 0;
+					WSTRING ability;
+					ScriptFlag::EquipmentType equipType;
+					UINT currentEquipment;
+					switch (tTile) {
+						case T_SWORD: 
+							equipType = ScriptFlag::Weapon;
+							currentEquipment = this->pCurrentGame->pPlayer->st.sword;
+						break;
+						case T_SHIELD:
+							equipType = ScriptFlag::Armor;
+							currentEquipment = this->pCurrentGame->pPlayer->st.shield;
+						break;
+						case T_ACCESSORY:
+							equipType = ScriptFlag::Accessory;
+							currentEquipment = this->pCurrentGame->pPlayer->st.accessory;
+						break;
+					}
+
+					pCurrentGame->getEquipmentStats(equipType, oldATK, oldDEF);
+					if (bIsCustomEquipment(equipmentType)) {
+						//Set up the equipment's properties by running its script in a temporary game instance.
+						CMonsterFactory mf;
+						CMonster *pNew = mf.GetNewMonster((MONSTERTYPE)M_CHARACTER);
+						ASSERT(pNew);
+						pNew->wX = pNew->wY = static_cast<UINT>(-1); //not located anywhere in the room area
+						CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pNew);
+						pCharacter->wLogicalIdentity = equipmentType;
+						pCharacter->equipType = equipType;
+						CCurrentGame *pTempGame = g_pTheDB->GetDummyCurrentGame();
+						*pTempGame = *this->pCurrentGame;
+						pCharacter->SetCurrentGame(pTempGame);
+
+						CCueEvents Ignored;
+						pCharacter->Process(CMD_WAIT, Ignored);
+						newATK = pCharacter->getATK();
+						newDEF = pCharacter->getDEF();
+						ability = EquipmentDescription::GetEquipmentAbility(pCharacter, equipType, wszCommaSpace);
+						delete pTempGame;
+						delete pCharacter;
+					} else if (tTile == T_SWORD) {
+						ability = EquipmentDescription::GetPredefinedWeaponAbility(equipmentType, wszCommaSpace);
+						newATK = this->pCurrentGame->getPredefinedWeaponPower(equipmentType);
+					} else if (tTile == T_SHIELD) {
+						ability = EquipmentDescription::GetPredefinedShieldAbility(equipmentType);
+						newDEF = this->pCurrentGame->getPredefinedShieldPower(equipmentType);
+					} else if (tTile == T_ACCESSORY) {
+						ability = EquipmentDescription::GetPredefinedAccessoryAbility(equipmentType);
+					}
+
+					const int diffATK = newATK - oldATK;
+					const int diffDEF = newDEF - oldDEF;
+					WSTRING equipText;
+					bool needComma = false;
+
+					if (diffATK != 0 || tTile == T_SWORD) {
+						if (diffATK >= 0)
+							equipText += wszPlus;
+						equipText += _itoW(diffATK, temp, 10);
+						equipText += wszSpace;
+						equipText += g_pTheDB->GetMessageText(MID_ATKStat);
+						needComma = true;
+					}
+					if (diffDEF != 0 || tTile == T_SHIELD) {
+						if (needComma) {
+							equipText += wszCommaSpace;
+						}
+						if (diffDEF >= 0)
+							equipText += wszPlus;
+						equipText += _itoW(diffDEF, temp, 10);
+						equipText += wszSpace;
+						equipText += g_pTheDB->GetMessageText(MID_DEFStat);
+						needComma = true;
+					}
+					if (!ability.empty()) {
+						if (needComma) {
+							equipText += wszCommaSpace;
+						}
+						equipText += ability;
+					}
+
+					if (!equipText.empty()) {
+						wstr += wszSpace;
+						wstr += wszLeftParen;
+						wstr += equipText;
+						wstr += wszRightParen;
+					}
+				}
+
+				mid = 0; //don't append another text for this
 				break;
 			}
 			case T_ORB:

--- a/drodrpg/DROD/drod.2019.vcxproj.filters
+++ b/drodrpg/DROD/drod.2019.vcxproj.filters
@@ -229,6 +229,9 @@
     <ClCompile Include="CommandListBoxWidget.cpp">
       <Filter>Widgets</Filter>
     </ClCompile>
+    <ClCompile Include="EquipmentDescription.cpp">
+      <Filter>General</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Chat.h">
@@ -443,6 +446,9 @@
     </ClInclude>
     <ClInclude Include="CommandListBoxWidget.h">
       <Filter>Widgets</Filter>
+    </ClInclude>
+    <ClInclude Include="EquipmentDescription.h">
+      <Filter>General</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Changes to improve the tooltip for in-room equipment tiles:

- Equipment properties are now shown in addition to stat changes
- When applicable, both ATK and DEF changes are shown, for all equipment types
- As both stat changes are shown, the stat type is shown in the tooltip.
 
This required some refactoring to create common code for describing equipment. For lack of a better place, a new class `EquipmentDescription` has been created, which holds functions to create these strings. There are functions to construct the strings for predefined equipment, and a function for custom equipment. For equipment types that can have multiple properties, a separator can be specified, allowing the function to used for both in-room tooltips and in the side panel.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45811