### PR TITLE
Fix import crash when deleting character

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -8315,6 +8315,9 @@ void CDbRoom::ClearMonsters(
 			{
 				case M_CHARACTER:
 				{
+					if (!pCurrentGame)
+						break; //Character can't be a monster enemy without a game
+
 					CCharacter* pDeleteCharacter = DYN_CAST(CCharacter*, CMonster*, pDelete);
 					// Is this character a monster enemy?
 					if (pDeleteCharacter->HasBehavior(ScriptFlag::MonsterTarget) ||


### PR DESCRIPTION
Due to 5.2 changes, importing a hold that contains a character crashes the game.

This happens in `CDbRoom::ClearMonsters`. Due to the addition of character behaviors allow characters to be monster targets, characters with these behaviors need to be removed from the monster enemy list when deleted. This requires the `CMonster` pointer to the character to be cast to `CCharacter` to check for these behaviors. Due to the particulars of how monsters are imported, this cast fails during importing, and the game crashes when trying to access an invalid pointer.

This can be avoided by checking if the room is attached to a game. Characters cannot gain behaviors until their game is set, and this does not happen during importing. Therefore, the check for monster target behaviors can be safely skipped.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45937