### PR TITLE
Redraw room when outside state is changed

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1889,7 +1889,8 @@ void CRoomWidget::SyncWeather(CCueEvents& CueEvents)
 	bWeatherSame &= (this->cFogLayer == (BYTE)roomWeather.wFog);
 	bWeatherSame &= (this->wSnow == roomWeather.wSnow);
 	bWeatherSame &= (this->rain == roomWeather.rain);
-	bWeatherSame &= (this->bOutside == roomWeather.bOutside);
+	bool bOutsideSame = (this->bOutside == roomWeather.bOutside);
+	bWeatherSame &= bOutsideSame;
 	bWeatherSame &= (this->bLightning == roomWeather.bLightning);
 	bWeatherSame &= (this->bClouds == roomWeather.bClouds);
 	bWeatherSame &= (this->bSkipLightfade == roomWeather.bSkipLightfade);
@@ -1899,6 +1900,11 @@ void CRoomWidget::SyncWeather(CCueEvents& CueEvents)
 
 	GetWeather();
 	LoadSkyImage(this->pRoom);
+
+	if (!bOutsideSame) {
+		ResetForPaint();
+		Paint();
+	}
 }
 
 //*****************************************************************************


### PR DESCRIPTION
If the `_Weather` var is used to change if a room is outside, the room will require a full redraw to account for cloud shadows and sky reflections in water.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=44130