### PR TITLE
Reset character pathing goal after single step move to

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -1596,6 +1596,11 @@ void CCharacter::Process(
 				const bool bAllowTurning = !pw;
 				const bool bStopTurn = GetMovement(wDestX, wDestY, dx, dy, dxFirst, dyFirst, bPathmapping, bAllowTurning);
 
+				if (ph) {
+					//Ensure 'Single Step' recalculates path on each execution.
+					this->goal.wX = UINT(-1);
+				}
+
 				//When pathfinding indicates to not move, 'Single Step' causes script execution to advance on the next turn.
 				if (bStopTurn && !ph)
 					STOP_COMMAND;


### PR DESCRIPTION
Pathfinding characters will not recalculate their paths unless they become invalid, or their goal square changes. This causes unintuitive behaviour when using the Single Step option.

For better and less confusing behaviour, if the `Move To` command is in single step mode, it will make the pathing goal invalid after the movement has been calculated, ensure that subsequent calls will require a new path to be calculated.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45917