### PR TITLE
Fix display of subtitle with text duration of zero

### DIFF
--- a/FrontEndLib/SubtitleEffect.cpp
+++ b/FrontEndLib/SubtitleEffect.cpp
@@ -240,6 +240,17 @@ void CSubtitleEffect::SetOffset(const int nX, const int nY)
 }
 
 //*****************************************************************************
+bool CSubtitleEffect::Update(const UINT wDeltaTime)
+{
+	this->dwTimeElapsed += wDeltaTime;
+
+	if (dwTextDuration && this->dwTimeElapsed >= this->dwDuration)
+		return false;
+
+	return this->Update(wDeltaTime, dwTimeElapsed);
+}
+
+//*****************************************************************************
 void CSubtitleEffect::GetTextWidthHeight(
 //Gets width and height of text as it is drawn within label.
 //

--- a/FrontEndLib/SubtitleEffect.h
+++ b/FrontEndLib/SubtitleEffect.h
@@ -78,6 +78,8 @@ public:
 	void           SetOffset(const int nX, const int nY);
 	void           SetMaxWidth(const UINT width) {this->maxWidth = width;}
 
+	virtual bool   Update(const UINT wDeltaTime); // Updates the state of the effect without drawing it
+
 	bool           bAttachedCoord;   //whether pCoord should be deleted on destruction
 
 


### PR DESCRIPTION
Without this fix, room lock indicator will disappear when effects are updated.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45938