### PR TITLE
Additional bug fixes

### DIFF
--- a/DRODLib/GameConstants.cpp
+++ b/DRODLib/GameConstants.cpp
@@ -93,7 +93,7 @@ namespace InputCommands
 		keyDefinitions[DCMD_PuzzleModeOptions] = new KeyDefinition(CMD_EXTRA_PUZZLE_MODE_OPTIONS, "Key_PuzzleModeOptions", MID_Command_PuzzleModeOptions, BuildInputKey(SDLK_F3, false, true, false));
 		keyDefinitions[DCMD_ToggleTurnCount] = new KeyDefinition(CMD_EXTRA_TOGGLE_TURN_COUNT, "Key_ToggleTurnCount", MID_Command_ToggleTurnCount, SDLK_F7);
 		keyDefinitions[DCMD_QuickDemoRecord] = new KeyDefinition(CMD_EXTRA_QUICK_DEMO_RECORD, "Key_QuickDemoRecord", MID_Command_QuickDemoRecord, SDLK_F4);
-		keyDefinitions[DCMD_ToggleDemoRecord] = new KeyDefinition(CMD_EXTRA_TOGGLE_DEMO_RECORD, "Key_ToggleDemoRecord", MID_Command_ToggleDemoRecord, SDLK_F5);
+		keyDefinitions[DCMD_ToggleDemoRecord] = new KeyDefinition(CMD_EXTRA_TOGGLE_DEMO_RECORD, "Key_ToggleDemoRecord", MID_Command_ToggleDemoRecord, BuildInputKey(SDLK_F6, false, false, true));
 		keyDefinitions[DCMD_WatchDemos] = new KeyDefinition(CMD_EXTRA_WATCH_DEMOS, "Key_WatchDemos", MID_Command_WatchDemos, SDLK_F6);
 		keyDefinitions[DCMD_ShowHelp] = new KeyDefinition(CMD_EXTRA_SHOW_HELP, "Key_ShowHelp", MID_Command_ShowHelp, SDLK_F1);
 		keyDefinitions[DCMD_Editor_Cut] = new KeyDefinition(CMD_EXTRA_EDITOR_CUT, "Key_Editor_Cut", MID_Command_Editor_Cut, BuildInputKey(SDLK_x, false, false, true));
@@ -102,8 +102,8 @@ namespace InputCommands
 		keyDefinitions[DCMD_Editor_Undo] = new KeyDefinition(CMD_EXTRA_EDITOR_UNDO, "Key_Editor_Undo", MID_Command_Editor_Undo, BuildInputKey(SDLK_z, false, false, true));
 		keyDefinitions[DCMD_Editor_Redo] = new KeyDefinition(CMD_EXTRA_EDITOR_REDO, "Key_Editor_Redo", MID_Command_Editor_Redo, BuildInputKey(SDLK_y, false, false, true));
 		keyDefinitions[DCMD_Editor_PlaytestRoom] = new KeyDefinition(CMD_EXTRA_EDITOR_PLAYTEST_ROOM, "Key_Editor_PlaytestRoom", MID_Command_Editor_PlaytestRoom, SDLK_F5);
-		keyDefinitions[DCMD_Editor_ReflectX] = new KeyDefinition(CMD_EXTRA_EDITOR_REFLECT_X, "Key_Editor_ReflectX", MID_Command_Editor_ReflectX, SDLK_F7);
-		keyDefinitions[DCMD_Editor_ReflectY] = new KeyDefinition(CMD_EXTRA_EDITOR_REFLECT_Y, "Key_Editor_ReflectY", MID_Command_Editor_ReflectY, SDLK_F8);
+		keyDefinitions[DCMD_Editor_ReflectX] = new KeyDefinition(CMD_EXTRA_EDITOR_REFLECT_X, "Key_Editor_ReflectX", MID_Command_Editor_ReflectX, SDLK_F8);
+		keyDefinitions[DCMD_Editor_ReflectY] = new KeyDefinition(CMD_EXTRA_EDITOR_REFLECT_Y, "Key_Editor_ReflectY", MID_Command_Editor_ReflectY, BuildInputKey(SDLK_F8, false, false, true));
 		keyDefinitions[DCMD_Editor_SetFloorImage] = new KeyDefinition(CMD_EXTRA_EDITOR_SET_FLOOR_IMAGE, "Key_Editor_SetFloorImage", MID_Command_Editor_SetFloorImage, SDLK_F9);
 		keyDefinitions[DCMD_Editor_SetOverheadImage] = new KeyDefinition(CMD_EXTRA_EDITOR_SET_OVERHEAD_IMAGE, "Key_Editor_SetOverheadImage", MID_Command_Editor_SetOverheadImage, BuildInputKey(SDLK_F9, true, false, false));
 		keyDefinitions[DCMD_Editor_PrevLevel] = new KeyDefinition(CMD_EXTRA_EDITOR_PREV_LEVEL, "Key_Editor_PrevLevel", MID_Command_Editor_PrevLevel, SDLK_PAGEUP);

--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -668,7 +668,7 @@ bool CSlayer::ConfirmGoal()
 			continue;
 		}
 
-		UINT wTile = room.GetTSquare(wGoalX, wGoalY);
+		UINT wTile = room.GetTSquare(orb->wX, orb->wY);
 		COrbData* pOrb = room.GetOrbAtCoords(orb->wX, orb->wY);
 		//Reject broken or missing orb and remove from orbsToHit
 		if (wTile != T_ORB || !pOrb || pOrb->eType == OT_BROKEN) {

--- a/FrontEndLib/SubtitleEffect.cpp
+++ b/FrontEndLib/SubtitleEffect.cpp
@@ -352,7 +352,7 @@ bool CSubtitleEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 
 	this->drawOpacity = this->opacity;
 
-	if (this->dwDuration != (UINT)-1 && dwTimeElapsed > this->dwTextDuration + dwWaitForNewText)
+	if (this->dwTextDuration && this->dwDuration != (UINT)-1 && dwTimeElapsed > this->dwTextDuration + dwWaitForNewText)
 	{
 		if (g_pTheBM->bAlpha)
 		{


### PR DESCRIPTION
There were some problem with recent bug fixes, which require some more fixing:

- Subtitle effect starting asserting whenever `CSubtitleEffect::Update` was called. This is due to an issue with changing opacity. The opacity changes should be skipped if the text duration is zero. (Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45938)
- Slayer starting rejecting all orbs. This is due to the goal tile being checked instead of the orb tile, leading to incorrect assessment. If the orb tile is checked, things work correctly. (Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45542)
- The new key binding system forbids any command from sharing a key code. However, some default key configurations conflict. New defaults have been set to prevent conflicts. (No thread)