### PR TITLE
RPG: Fix numpad controls not being correctly expanded

### DIFF
--- a/drodrpg/DROD/SettingsScreen.cpp
+++ b/drodrpg/DROD/SettingsScreen.cpp
@@ -135,29 +135,6 @@ const UINT TAG_MENU = 1093;
 const UINT CX_MESSAGE = 370;
 const UINT CY_MESSAGE = 120;
 
-//************************************************************************************
-MESSAGE_ID KeyToMID(const SDL_Keycode nKey) {
-	switch (nKey) {
-		case SDLK_KP_DIVIDE: return MID_KEY_KP_DIVIDE;
-		case SDLK_KP_MULTIPLY: return MID_KEY_KP_MULTIPLY;
-		case SDLK_KP_MINUS: return MID_KEY_KP_MINUS;
-		case SDLK_KP_PLUS: return MID_KEY_KP_PLUS;
-		case SDLK_KP_ENTER: return MID_KEY_KP_ENTER;
-		case SDLK_KP_1: return MID_KEY_KP1;
-		case SDLK_KP_2: return MID_KEY_KP2;
-		case SDLK_KP_3: return MID_KEY_KP3;
-		case SDLK_KP_4: return MID_KEY_KP4;
-		case SDLK_KP_5: return MID_KEY_KP5;
-		case SDLK_KP_6: return MID_KEY_KP6;
-		case SDLK_KP_7: return MID_KEY_KP7;
-		case SDLK_KP_8: return MID_KEY_KP8;
-		case SDLK_KP_9: return MID_KEY_KP9;
-		case SDLK_KP_0: return MID_KEY_KP0;
-		case SDLK_KP_PERIOD: return MID_KEY_KP_PERIOD;
-		default: return static_cast<MESSAGE_ID>((long) MID_UNKNOWN + nKey);
-	}
-}
-
 //
 //Protected methods.
 //

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -902,7 +902,7 @@ WSTRING CCurrentGame::getTextForInputCommandKey(InputCommands::DCMD id) const
 	const InputCommands::DCMD eCommand = InputCommands::DCMD(
 			settings.GetVar(InputCommands::COMMANDNAME_ARRAY[id], 0));
 
-	return g_pTheDB->GetMessageText(MID_UNKNOWN + eCommand);
+	return g_pTheDB->GetMessageText(KeyToMID(eCommand));
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/GameConstants.cpp
+++ b/drodrpg/DRODLib/GameConstants.cpp
@@ -108,4 +108,31 @@ namespace InputCommands
 
 		return DCMD_NotFound;
 	}
+
+	MESSAGE_ID KeyToMID(const SDL_Keycode nKey)
+	{
+		switch (nKey) {
+		case SDLK_KP_DIVIDE: return MID_KEY_KP_DIVIDE;
+		case SDLK_KP_MULTIPLY: return MID_KEY_KP_MULTIPLY;
+		case SDLK_KP_MINUS: return MID_KEY_KP_MINUS;
+		case SDLK_KP_PLUS: return MID_KEY_KP_PLUS;
+		case SDLK_KP_ENTER: return MID_KEY_KP_ENTER;
+		case SDLK_KP_1: return MID_KEY_KP1;
+		case SDLK_KP_2: return MID_KEY_KP2;
+		case SDLK_KP_3: return MID_KEY_KP3;
+		case SDLK_KP_4: return MID_KEY_KP4;
+		case SDLK_KP_5: return MID_KEY_KP5;
+		case SDLK_KP_6: return MID_KEY_KP6;
+		case SDLK_KP_7: return MID_KEY_KP7;
+		case SDLK_KP_8: return MID_KEY_KP8;
+		case SDLK_KP_9: return MID_KEY_KP9;
+		case SDLK_KP_0: return MID_KEY_KP0;
+		case SDLK_KP_PERIOD: return MID_KEY_KP_PERIOD;
+		case SDLK_LEFT: return MID_KEY_LEFT;
+		case SDLK_RIGHT: return MID_KEY_RIGHT;
+		case SDLK_UP: return MID_KEY_UP;
+		case SDLK_DOWN: return MID_KEY_DOWN;
+		default: return static_cast<MESSAGE_ID>((long)MID_UNKNOWN + nKey);
+		}
+	}
 }

--- a/drodrpg/DRODLib/GameConstants.h
+++ b/drodrpg/DRODLib/GameConstants.h
@@ -27,10 +27,13 @@
 #ifndef GAMECONSTANTS_H
 #define GAMECONSTANTS_H
 
+#include <BackEndLib/MessageIDs.h>
 #include <BackEndLib/Types.h>
 #include <BackEndLib/UtilFuncs.h>
 #include <BackEndLib/Wchar.h>
 #include <BackEndLib/Ports.h>
+
+#include <SDL.h>
 
 //Global app parameters.
 extern const char szCompanyName[];
@@ -120,6 +123,8 @@ namespace InputCommands
 	extern const UINT COMMAND_MIDS[DCMD_Count];
 
 	extern DCMD getCommandIDByVarName(const WSTRING& wtext);
+
+	extern MESSAGE_ID KeyToMID(const SDL_Keycode nKey);
 }
 
 //Returns: whether the command is a movement in a compass direction

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -777,6 +777,28 @@ as play progresses.  Others are altered solely through script commands.
   altered.
 </p>
 
+<p><a name="playerinputvars"><b>List of player command input variables</b></a></p>
+  Predefined variable names may be provided in texts to output the player's current key binding for the respective command as text. To do this, provide a variable name of the form "$_CMD_&lt;key&gt;$", where &lt;key&gt; is one of the following:
+<ul>
+<li>MoveNorthwest</li>
+<li>MoveNorth</li>
+<li>MoveNortheast</li>
+<li>MoveWest</li>
+<li>Wait</li>
+<li>MoveEast</li>
+<li>MoveSouthwest</li>
+<li>MoveSouth</li>
+<li>MoveSoutheast</li>
+<li>SwingClockwise</li>
+<li>SwingCounterclockwise</li>
+<li>Restart</li>
+<li>Undo</li>
+<li>Battle</li>
+<li>UseAccessory</li>
+<li>Lock</li>
+<li>UseCommand</li>
+</ul>
+
 <p><a name="branchingexamples"><b>Examples of branching code structures:</b></a></p>
 <ol>
   <li><a name="singlecodebranch">A single code branch:</a><br />


### PR DESCRIPTION
Numpad controls are not expanded into the correct strings when using the predefined control vars. They require special handling. This handling exists in `SettingsScreen.cpp`, and has been moved to `GameConstants` to make it available in other places.

The predefined control vars have also been added to the script help files.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45962