### PR TITLE
RPG: Invisible Inspectable imperative

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4050,6 +4050,8 @@ void CCharacterDialogWidget::PopulateImperativeListBox(const bool bDefaultScript
 	this->pImperativeListBox->AddItem(ScriptFlag::ShowStatChanges, g_pTheDB->GetMessageText(MID_ShowStatChanges));
 	this->pImperativeListBox->AddItem(ScriptFlag::GhostDisplay, g_pTheDB->GetMessageText(MID_NPCGhostDisplay));
 	this->pImperativeListBox->AddItem(ScriptFlag::NoGhostDisplay, g_pTheDB->GetMessageText(MID_NPCNoGhostDisplay));
+	this->pImperativeListBox->AddItem(ScriptFlag::InvisibleInspectable, g_pTheDB->GetMessageText(MID_InvisibleInspectable));
+	this->pImperativeListBox->AddItem(ScriptFlag::NoInvisibleInspectable, g_pTheDB->GetMessageText(MID_NotInvisibleInspectable));
 	this->pImperativeListBox->AddItem(ScriptFlag::RestartScriptOnRoomEntrance, g_pTheDB->GetMessageText(MID_RestartScriptOnRoomEntrance));
 	this->pImperativeListBox->AddItem(ScriptFlag::NoRestartScriptOnRoomEntrance, g_pTheDB->GetMessageText(MID_NoRestartScriptOnRoomEntrance));
 	this->pImperativeListBox->AddItem(ScriptFlag::RunOnCombat, g_pTheDB->GetMessageText(MID_RunOnCombat));

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -249,6 +249,7 @@ public:
 			const bool bMoveInProgress=false);
 	void				FadeToLightLevel(const UINT wNewLight);
 	void           FinishMoveAnimation() {this->dwCurrentDuration = this->dwMoveDuration;}
+	WSTRING        GetInvisibleCharacterInfo(const UINT wX, const UINT wY) const;
 	void           GetSquareRect(UINT wCol, UINT wRow, SDL_Rect &SquareRect) const;
 	static UINT    GetKeyMID(const UINT param);
 	static UINT    GetOrbMID(const UINT type);

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -101,6 +101,7 @@ const UINT MAX_ANSWERS = 9;
 #define DefeatedStr "Defeated"
 #define ShowStatChangesStr "SStatChanges"
 #define GhostImageStr "GhostImage"
+#define InvisibleInspectableStr "InvisibleInspectable"
 #define SwordStr "Sword"
 #define RestartScriptOnEntranceStr "RestartOnEntrance"
 #define GlobalStr "Global"
@@ -206,6 +207,7 @@ CCharacter::CCharacter(
 	, wIdentity(M_NONE)
 	, wLogicalIdentity(M_NONE)
 	, bVisible(false)
+	, bInvisibleInspectable(false)
 	, bScriptDone(false), bReplaced(false), bGlobal(false)
 	, bYesNoQuestion(false)
 	, bPlayerTouchedMe(false)
@@ -2590,6 +2592,14 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::PauseOnCombat:
 						this->bExecuteScriptOnCombat = false;
+					break;
+
+					//Whether character name and description are shown when invisible and right-clicked.
+					case ScriptFlag::InvisibleInspectable:
+						this->bInvisibleInspectable = true;
+					break;
+					case ScriptFlag::NoInvisibleInspectable:
+						this->bInvisibleInspectable = false;
 					break;
 
 					default:
@@ -5070,6 +5080,7 @@ void CCharacter::RestartScript()
 	this->bDefeated = false;
 	this->bShowStatChanges = true;
 	this->bGhostImage = false;
+	this->bInvisibleInspectable = false;
 	this->bRestartScriptOnRoomEntrance = false;
 //	this->bGlobal = false; //this flag doesn't get reset -- once a script's in the global list, it stays there
 	this->bExecuteScriptOnCombat = true;
@@ -5389,6 +5400,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bDefeated = vars.GetVar(DefeatedStr, this->bDefeated);
 	this->bShowStatChanges = vars.GetVar(ShowStatChangesStr, this->bShowStatChanges);
 	this->bGhostImage = vars.GetVar(GhostImageStr, this->bGhostImage);
+	this->bInvisibleInspectable = vars.GetVar(InvisibleInspectableStr, this->bInvisibleInspectable);
 	this->bRestartScriptOnRoomEntrance = vars.GetVar(RestartScriptOnEntranceStr, this->bRestartScriptOnRoomEntrance);
 	this->bGlobal = vars.GetVar(GlobalStr, this->bGlobal);
 	this->bExecuteScriptOnCombat = vars.GetVar(ExecuteScriptOnCombatStr, this->bExecuteScriptOnCombat);
@@ -5511,6 +5523,8 @@ const
 		vars.SetVar(ShowStatChangesStr, this->bShowStatChanges);
 	if (this->bGhostImage)
 		vars.SetVar(GhostImageStr, this->bGhostImage);
+	if (this->bInvisibleInspectable)
+		vars.SetVar(InvisibleInspectableStr, this->bInvisibleInspectable);
 	if (this->bRestartScriptOnRoomEntrance)
 		vars.SetVar(RestartScriptOnEntranceStr, this->bRestartScriptOnRoomEntrance);
 	if (this->bGlobal)

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -145,6 +145,7 @@ public:
 	bool           IsEntityAt(const CCharacterCommand& command, const CDbRoom& room, const CSwordsman& player) const;
 	virtual bool   IsFriendly() const;
 	bool           IsGhostImage() const {return this->bGhostImage;}
+	bool           IsInvisibleInspectable() const {return this->bInvisibleInspectable;}
 	bool           IsLuckyGR() const {return this->bLuckyGR;}
 	bool           IsLuckyXP() const {return this->bLuckyXP;}
 	bool           IsMetal() const {return this->bMetal;}
@@ -219,6 +220,7 @@ public:
 	UINT  wIdentity;        //monster type
 	UINT  wLogicalIdentity; //logical ID (might be a hold custom character type)
 	bool  bVisible;         //on screen in room, or not
+	bool  bInvisibleInspectable; //appears in tooltip when invisible
 	bool  bScriptDone;      //true when script has run to completion
 	bool  bReplaced;        //true when script command replaces the character
 									//with a normal monster

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -108,7 +108,9 @@ namespace ScriptFlag
 		RestartScriptOnRoomEntrance=14,   //restart script execution from beginning on room entrance
 		MakeGlobal=15,        //move NPC-script to the global NPC-script list
 		RunOnCombat=16,       //execute script when combat is initiated (default)
-		PauseOnCombat=17      //do not execute any script commands when combat is initiated
+		PauseOnCombat=17,     //do not execute any script commands when combat is initiated,
+		InvisibleInspectable=18, //Appears in right-click tooltip even when invsible
+		NoInvisibleInspectable=19
 	};
 
 	//Behavior patterns for NPCs/monsters.

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -793,6 +793,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarBeam: strText = "_Beam"; break;
 		case MID_AumtlichAbilityPercentage: strText = "Gaze reduces your health by %s percent"; break;
 		case MID_AumtlichAbilityFlatRate: strText = "Gaze reduces your health by %s HP"; break;
+		case MID_InvisibleInspectable: strText = "Invisible inspectable"; break;
+		case MID_NotInvisibleInspectable: strText = "Not invisible inspectable"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1528,6 +1528,8 @@ enum MID_CONSTANT {
   MID_ProcessingSequence = 1838,
   MID_ProcessingSequenceDescription = 1839,
   MID_CustomSpeechColor = 1849,
+  MID_InvisibleInspectable = 1869,
+  MID_NotInvisibleInspectable = 1870,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1359,3 +1359,11 @@ Scripts with a lower processing sequence value will run before scripts with a hi
 [MID_CustomSpeechColor]
 [eng]
 Speech Color (rgb)
+
+[MID_InvisibleInspectable]
+[eng]
+Invisible inspectable
+
+[MID_NotInvisibleInspectable]
+[eng]
+Not invisible inspectable


### PR DESCRIPTION
Similar to the TSS 5.2 imperative in concept, this allows non-visible characters to appear in a square's right-click tooltip. The character's custom description is also included.

Internally, this is a separate step from adding a monster's information to the tooltip. Most of the monster information is not applicable to an invisible character, and it is possible for multiple invisible characters to share a tile.