### PR TITLE
RPG: Allow use of variable expansion in autosave names

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2215,7 +2215,8 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_Autosave:
 			{
 				//Autosave with identifier 'label'.
-				if (pGame->Autosave(command.label))
+				WSTRING saveName = pGame->ExpandText(command.label.c_str(), this);
+				if (pGame->Autosave(saveName))
 					CueEvents.Add(CID_Autosave);
 				bProcessNextCommand = true;
 			}

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -240,7 +240,7 @@ interacts with its environment.</p>
       will store a number.<br />
       <a name="varsintext"><u>Using vars in text</u></a>:
       In variable text assignments,
-	  <a href="#speech">Speech</a>, <a href="#question">Questions</a>
+	  <a href="#autosave">Autosave</a>, <a href="#speech">Speech</a>, <a href="#question">Questions</a>
       (see below), level entrance texts, and scroll text,
       type "$&lt;var name&gt;$" to insert the
       current value of the variable you name at this point in the text.


### PR DESCRIPTION
Allows the use of expanded variables in autosave names. This functions as it does in speech and other text locations.

Related post: http://forum.caravelgames.com/viewtopic.php?TopicID=32862&page=0#441140