### PR TITLE
Fix wubba clone hot tile damage

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -713,8 +713,12 @@ bool CCharacter::ResetLevelExits()
 bool CCharacter::OnStabbed(CCueEvents &CueEvents, const UINT /*wX*/, const UINT /*wY*/, WeaponType weaponType)
 //Returns: whether character was killed
 {
+	const bool bIsPushableSafe = this->bPushableByWeapon
+		&& weaponType != WT_Firetrap
+		&& weaponType != WT_FloorSpikes
+		&& weaponType != WT_HotTile;
 	if (this->eImperative == ScriptFlag::Invulnerable || 
-			(this->bPushableByWeapon && weaponType != WT_Firetrap && weaponType != WT_FloorSpikes))
+			bIsPushableSafe)
 		return false;
 
 	CueEvents.Add(CID_MonsterDiedFromStab, this);

--- a/DRODLib/Clone.cpp
+++ b/DRODLib/Clone.cpp
@@ -181,8 +181,8 @@ bool CClone::OnStabbed(CCueEvents& CueEvents, const UINT wX, const UINT wY, Weap
 	const UINT identity = GetIdentity();
 
 	if ((identity == M_WUBBA || identity == M_FLUFFBABY)
-		&& weaponType != WT_Firetrap) {
-		// Wubbas and Puffs can only be killed by Firetrap stabs.
+		&& !(weaponType == WT_Firetrap || weaponType == WT_HotTile)) {
+		// Wubbas and Puffs can only be killed by Firetrap or Hot tile stabs.
 		return false;
 	}
 

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -387,7 +387,7 @@ bool CMonster::CheckForDamage(CCueEvents& CueEvents)
 	if (this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY) == T_HOT)
 	{
 		CCueEvents Ignored;
-		if (OnStabbed(Ignored, this->wX, this->wY))
+		if (OnStabbed(Ignored, this->wX, this->wY, WT_HotTile))
 		{
 			//Add special cue events here instead of inside OnStabbed.
 			CueEvents.Add(CID_MonsterBurned, this);

--- a/DRODLib/PlayerDouble.cpp
+++ b/DRODLib/PlayerDouble.cpp
@@ -100,7 +100,7 @@ bool CArmedMonster::CheckForDamage(CCueEvents& CueEvents)
 		if (!this->pCurrentGame->swordsman.bIsHasted || this->bWaitedOnHotFloorLastTurn)
 		{
 			CCueEvents Ignored;
-			if (OnStabbed(Ignored, this->wX, this->wY))
+			if (OnStabbed(Ignored, this->wX, this->wY, WT_HotTile))
 			{
 				//Add special cue events here instead of inside OnStabbed.
 				CueEvents.Add(CID_MonsterBurned, this);

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -167,8 +167,8 @@ bool CTemporalClone::OnStabbed(
 )
 {
 	if ((this->wIdentity == M_WUBBA || this->wIdentity == M_FLUFFBABY)
-		 && weaponType != WT_Firetrap) {
-		// Wubbas and Puffs can only be killed by Firetrap stabs.
+		&& !(weaponType == WT_Firetrap || weaponType == WT_HotTile)) {
+		// Wubbas and Puffs can only be killed by Firetrap or Hot tile stabs.
 		return false;
 	}
 

--- a/DRODLib/Weapons.h
+++ b/DRODLib/Weapons.h
@@ -33,6 +33,7 @@
 //  Do not change these constant values.
 enum WeaponType
 {
+	WT_HotTile = -5,
 	WT_Firetrap=-4,
 	WT_FloorSpikes=-3,
 	WT_Off=-2,


### PR DESCRIPTION
#421 changed clones to work more like the entities they are based on. However, due to an oversight with the way hot tile damage works, it caused Wubba clones to become immune to hot tiles.

Fixing this requires the addition of a new weapon type to represent hot tile damage (which already exists in 5.2). This allows checks for hot tile damage to be performed in `CClone::OnStabbed`.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45964