### PR TITLE
Add TileGrid and Repeat image overlay commands

### DIFF
--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -94,6 +94,7 @@ CImageOverlayEffect::CImageOverlayEffect(
 	, angle(0), scale(ORIGINAL_SCALE)
 	, jitter(0)
 	, xTile(0), yTile(0)
+	, repetitions(0), xRepeatOffset(0), yRepeatOffset(0)
 	, index(UINT(-1))
 	, loopIteration(0), maxLoops(0)
 	, startOfNextEffect(dwStartTime)
@@ -247,6 +248,11 @@ void CImageOverlayEffect::Draw(SDL_Surface& destSurface)
 bool CImageOverlayEffect::IsImageDrawn()
 {
 	return this->drawAlpha > 0 && PositionDisplayInsideRect(this->drawSourceRect, this->drawDestinationRect, this->drawX, this->drawY);
+}
+
+bool CImageOverlayEffect::IsRepeated() const
+{
+	return (this->repetitions > 0 && (this->xRepeatOffset != 0 || this->yRepeatOffset != 0));
 }
 
 bool CImageOverlayEffect::IsTiled() const
@@ -576,6 +582,14 @@ void CImageOverlayEffect::StartNextCommand()
 	}
 	break;
 
+	case ImageOverlayCommand::Repeat: {
+		this->repetitions = max(0, val);
+		this->xRepeatOffset = command.val[1];
+		this->yRepeatOffset = command.val[2];
+		this->bPrepareAlteredImage = true;
+	}
+	break;
+
 	case ImageOverlayCommand::Rotate:
 		this->executionState.startAngle = this->angle;
 		this->executionState.remainingTime = this->executionState.duration = max(0, command.val[1]);
@@ -829,6 +843,7 @@ bool CImageOverlayEffect::IsInstantCommand(const ImageOverlayCommand::IOC comman
 		case ImageOverlayCommand::DisplayRect:
 		case ImageOverlayCommand::DisplayRectModify:
 		case ImageOverlayCommand::DisplaySize:
+		case ImageOverlayCommand::Repeat:
 		case ImageOverlayCommand::Rotate:
 		case ImageOverlayCommand::Scale:
 		case ImageOverlayCommand::SetAlpha:

--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -189,9 +189,6 @@ void CImageOverlayEffect::PrepareDrawProperties()
 	}
 
 	this->pOwnerWidget->GetRect(this->drawDestinationRect);
-
-	this->drawX = this->x;
-	this->drawY = this->y;
 	this->drawSourceRect = this->sourceClipRect;
 
 	if (this->pTiledSurface) {

--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -232,15 +232,7 @@ void CImageOverlayEffect::Draw(SDL_Surface& destSurface)
 		pSrcSurface = this->pImageSurface;
 
 	if (this->drawDestinationRect.w > 0 && this->drawDestinationRect.h > 0) {
-		const bool bSurfaceAlpha = !this->pImageSurface->format->Amask && this->alpha < 255;
-		if (bSurfaceAlpha) {
-			EnableSurfaceBlending(pSrcSurface, this->drawAlpha);
-			SDL_BlitSurface(pSrcSurface, &this->drawSourceRect, &destSurface, &this->drawDestinationRect);
-			DisableSurfaceBlending(pSrcSurface);
-		}
-		else {
-			g_pTheBM->BlitAlphaSurfaceWithTransparency(this->drawSourceRect, pSrcSurface, this->drawDestinationRect, &destSurface, this->drawAlpha);
-		}
+		g_pTheBM->BlitAlphaSurfaceWithTransparency(this->drawSourceRect, pSrcSurface, this->drawDestinationRect, &destSurface, this->drawAlpha);
 	}
 }
 

--- a/DROD/ImageOverlayEffect.h
+++ b/DROD/ImageOverlayEffect.h
@@ -88,6 +88,7 @@ private:
 	bool CanLoop() const;
 	inline bool IsCommandQueueFinished() const;
 	bool IsImageDrawn();
+	bool IsTiled() const;
 	void PrepareDrawProperties();
 	void StartNextCommand();
 	void FinishCommand(const ImageOverlayCommand& command, const CommandExecution& ce);
@@ -104,9 +105,11 @@ private:
 
 	void PrepareAlteredImage();
 
+	SDL_Surface* TileSurface(SDL_Surface* pSurface);
+
 	long drawSequence;
 
-	SDL_Surface *pImageSurface, *pAlteredSurface;
+	SDL_Surface *pImageSurface, *pAlteredSurface, *pTiledSurface;
 	bool bPrepareAlteredImage;
 
 	int x, y; // Real position of the image
@@ -114,6 +117,7 @@ private:
 	int angle;
 	int scale;
 	int jitter;
+	int xTile, yTile;
 	SDL_Rect sourceClipRect;
 
 	// Properties used for the drawing

--- a/DROD/ImageOverlayEffect.h
+++ b/DROD/ImageOverlayEffect.h
@@ -81,6 +81,8 @@ protected:
 private:
 	bool AdvanceState(const UINT wDeltaTime);
 
+	void DrawRepeated(SDL_Surface* srcSurface, SDL_Surface* destSurface);
+
 	Uint32 UpdateCommand(const ImageOverlayCommand& command, CommandExecution& ce, const Uint32 dwRemainingTime);
 	Uint32 UpdateParallelCommands(const Uint32 dwDeltaTime);
 	bool IsCurrentCommandFinished() const;

--- a/DROD/ImageOverlayEffect.h
+++ b/DROD/ImageOverlayEffect.h
@@ -88,6 +88,7 @@ private:
 	bool CanLoop() const;
 	inline bool IsCommandQueueFinished() const;
 	bool IsImageDrawn();
+	bool IsRepeated() const;
 	bool IsTiled() const;
 	void PrepareDrawProperties();
 	void StartNextCommand();
@@ -118,6 +119,7 @@ private:
 	int scale;
 	int jitter;
 	int xTile, yTile;
+	int repetitions, xRepeatOffset, yRepeatOffset;
 	SDL_Rect sourceClipRect;
 
 	// Properties used for the drawing

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -273,6 +273,7 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("pmove ")] = ImageOverlayCommand::ParallelMove;
 		commandMap[string("pmoveto")] = ImageOverlayCommand::ParallelMoveTo;
 		commandMap[string("protate")] = ImageOverlayCommand::ParallelRotate;
+		commandMap[string("repeat")] = ImageOverlayCommand::Repeat;
 		commandMap[string("rotate")] = ImageOverlayCommand::Rotate;
 		commandMap[string("scale")] = ImageOverlayCommand::Scale;
 		commandMap[string("setalpha")] = ImageOverlayCommand::SetAlpha;
@@ -361,6 +362,7 @@ bool CImageOverlay::parse(const WSTRING& wtext, ImageOverlayCommands& commands)
 			case ImageOverlayCommand::ParallelMove:
 			case ImageOverlayCommand::MoveTo:
 			case ImageOverlayCommand::ParallelMoveTo:
+			case ImageOverlayCommand::Repeat:
 				//three arguments
 				if (!parseNumber(pText, textLength, pos, val[arg_index++]))
 					return false;

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -280,6 +280,7 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("setx")] = ImageOverlayCommand::SetX;
 		commandMap[string("sety")] = ImageOverlayCommand::SetY;
 		commandMap[string("srcxy")] = ImageOverlayCommand::SrcXY;
+		commandMap[string("tilegrid")] = ImageOverlayCommand::TileGrid;
 	}
 
 	for (CommandMap::const_iterator it=commandMap.begin(); it!=commandMap.end(); ++it) {
@@ -374,6 +375,7 @@ bool CImageOverlay::parse(const WSTRING& wtext, ImageOverlayCommands& commands)
 			case ImageOverlayCommand::ParallelRotate:
 			case ImageOverlayCommand::Rotate:
 			case ImageOverlayCommand::SrcXY:
+			case ImageOverlayCommand::TileGrid:
 				//two arguments
 				if (!parseNumber(pText, textLength, pos, val[arg_index++]))
 					return false;

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -474,6 +474,7 @@ struct ImageOverlayCommand
 		SetX,
 		SetY,
 		SrcXY,
+		TileGrid,
 		TurnDuration,
 		Invalid
 	};

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -467,6 +467,7 @@ struct ImageOverlayCommand
 		ParallelMove,
 		ParallelMoveTo,
 		ParallelRotate,
+		Repeat,
 		Rotate,
 		Scale,
 		SetAlpha,

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -775,6 +775,7 @@ Variables prefixed with "_My" are connected to the state of the NPC, the "_*Imag
 <b>Loop (times)</b> -- loop through the image command list this many times (-1 = infinite)<br />
 <b>(p)Move (x pixels) (y pixels) (ms)</b> -- translate the image's position by the indicated number of pixels over the indicated time interval<br />
 <b>(p)MoveTo (x pixel) (y pixel) (ms)</b> -- move the image from its current position to the indicated screen location over the course of the indicated time interval<br />
+<b>Repeat (repetions, x, y)</b> -- repeat the final image a positive number of times, with each copy offset from the previous image by x and y pixels, including in negative directions.<br />
 <b>(p)Rotate (degrees) (ms)</b> -- rotate the image the indicated amount over the specified time interval<br />
 <b>Scale (percent of original)</b> -- scale the image to the indicated amount<br />
 <b>SetAlpha (0-255)</b> -- set the image's alpha transparency to the indicated value<br />
@@ -782,6 +783,7 @@ Variables prefixed with "_My" are connected to the state of the NPC, the "_*Imag
 <b>SetX (pixel)</b> -- set the image's X coordinate<br />
 <b>SetY (pixel)</b> -- set the image's Y coordinate<br />
 <b>SrcXY (x) (y)</b> - show the source image starting from the indicated pixel position<br />
+<b>TileGrid (w) (h)</b> -- replicate the image in a w by h grid. Tiling is not supported for images that have had rotations applied.<br />
 <br />
 As an example, you can make an image start invisible, fade in, display for a couple seconds, then fade out by providing the following command sequence:<br />
 <br />


### PR DESCRIPTION
Adds support for two additional Image Overlay commands, `TileGrid` and `Repeat`. A fix for the `Jitter` command is also included.

`TileGrid x y` copies the image to create an x by y grid of the image. This is placed onto a new surface, `pTiledSurface`, as positioning of a tiled image is different than for other altered images. Images that have been rotated cannot be tiled, as the current way rotation is applied to images leads to very poor results when tiling.

Example of tiled image:
![image](https://github.com/CaravelGames/drod/assets/5825138/9a59d85c-7bf2-4356-bfeb-c335dd2d55b0)

`Repeat r x y` copies the final image r times, with an offset of x,y applied on each repetition. The offsets can be positive or negative, allowing for repetition in all directions. This works with all image alterations, and repetitions that go outside the boundary of a room are clipped appropriately.

Example of repeated image:
![image](https://github.com/CaravelGames/drod/assets/5825138/ceca60f8-ae3b-42a2-9f7d-4630e08e0d6b)

Help content is included.