### PR TITLE
Use correct weapon type in Fegundo ashes ObjectFell event

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -5171,7 +5171,7 @@ void CCurrentGame::FegundoToAsh(CMonster *pMonster, CCueEvents &CueEvents)
 		{
 			case T_PIT: case T_PIT_IMAGE:
 				CueEvents.Add(CID_ObjectFell, new CMoveCoordEx2(wX, wY,
-					S, M_OFFSET + M_FEGUNDOASHES, 0), true);
+					S, M_OFFSET + M_FEGUNDOASHES, -2), true);
 			break;
 			case T_WATER: case T_SHALLOW_WATER:
 				CueEvents.Add(CID_Splash, new CCoord(wX,wY), true);


### PR DESCRIPTION
When fegundo ashes would generated over a pit by `CCurrentGame::FegundoToAsh`, they are not, and an `ObjectFell` event is created. A weapon type can be specified for falling objects, but the wrong type is given for ashes created this way. A value of -2 for "no weapon" should be used, or a sword will be drawn falling alongside the ashes.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45973