### PR TITLE
Initialize nCustomColor in TileImageBlitParams copy constructor

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -269,6 +269,7 @@ TileImageBlitParams::TileImageBlitParams(const TileImageBlitParams& rhs)
 	, nAddColor(rhs.nAddColor)
 	, bCastShadowsOnTop(rhs.bCastShadowsOnTop)
 	, appliedDarkness(rhs.appliedDarkness)
+	, nCustomColor(rhs.nCustomColor)
 { }
 
 bool TileImageBlitParams::CropRectToTileDisplayArea(SDL_Rect& BlitRect)


### PR DESCRIPTION
`nCustomColor` needs to be included in the copy constructor for `TileImageBlitParams`, as currently it will end up with junk values when the object is copied. The most immediate symptom of this is that it causes weapons to flash random colours.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45957