### PR TITLE
Improve safety when importing data

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1863,8 +1863,10 @@ MESSAGE_ID CDbXML::ImportXML(
 	LOGCONTEXT("CDbXML::ImportXML");
 
 	ASSERT(pBuffer);
-	if (!pBuffer->uncompressedSize)
+	if (!pBuffer->uncompressedSize) {
+		bImportComplete = true;
 		return MID_ImportSuccessful;   //nothing to import
+	}
 	ASSERT(pBuffer->isPopulated());
 
 	Import_Init();

--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1895,6 +1895,9 @@ MESSAGE_ID CDbXML::ImportXML(
 
 		Import_ParseRecords(pBuffer);
 
+		importBuf.closeStream();
+		VERIFY(importBuf.initStream() == MID_Success);
+
 		//Free parser.
 		XML_ParserFree(parser);
 		parser = NULL;


### PR DESCRIPTION
The import buffer is not explicitly reinitialized after records are parsed in `CDbXML`. This can cause a strange issue where if the user is asked to confirm an import, the import will succeed at doing nothing, as the game thinks there is nothing to import, even if the buffer still has data. We should do the reinitialization in the buffer version of `ImportXML`.

In some situations, hold importing will end with in a successful state due to the import buffer not having compressed data. However, it can be the case that some import data remains in the buffer, and will not be cleared. To prevent this, mark the import as complete in this situation.

Thread(?): https://forum.caravelgames.com/viewtopic.php?TopicID=45985