### PR TITLE
Add script command to reset _MyScript variables

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -4327,6 +4327,7 @@ const
 		case CCharacterCommand::CC_IfElseIf:
 		case CCharacterCommand::CC_IfEnd:
 		case CCharacterCommand::CC_Return:
+		case CCharacterCommand::CC_ResetOverrides:
 		break;
 
 		default: break;
@@ -4466,6 +4467,7 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 			case CCharacterCommand::CC_WorldMapImage:
 			case CCharacterCommand::CC_ChallengeCompleted:
 			case CCharacterCommand::CC_Return:
+			case CCharacterCommand::CC_ResetOverrides:
 				if (bLastWasIfCondition || wLogicNestDepth)
 					wstr += wszQuestionMark;	//questionable If condition
 				break;
@@ -4748,6 +4750,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_PushTile, g_pTheDB->GetMessageText(MID_PushTile));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Question, g_pTheDB->GetMessageText(MID_Question));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Return, g_pTheDB->GetMessageText(MID_ReturnCommand));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ResetOverrides, g_pTheDB->GetMessageText(MID_ResetOverrides));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_RoomLocationText, g_pTheDB->GetMessageText(MID_RoomLocationText));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetNPCAppearance, g_pTheDB->GetMessageText(MID_SetNPCAppearance));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetMovementType, g_pTheDB->GetMessageText(MID_SetMovementType));
@@ -5447,6 +5450,7 @@ void CCharacterDialogWidget::SetCommandColor(
 		break;
 		case CCharacterCommand::CC_VarSet:
 		case CCharacterCommand::CC_VarSetAt:
+		case CCharacterCommand::CC_ResetOverrides:
 			pListBox->SetItemColorAtLine(line, FullRed);
 		break;
 		case CCharacterCommand::CC_Wait: 
@@ -5671,7 +5675,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		ORBAGENTS,          //CC_LinkOrb
 		NO_WIDGETS,         //CC_WaitForBuilding
 		BUILD_MARKER_ITEMS, //CC_WaitForBuildType
-		BUILD_MARKER_ITEMS  //CC_WaitForNotBuildType
+		BUILD_MARKER_ITEMS, //CC_WaitForNotBuildType
+		NO_WIDGETS          //CC_ResetOverrides
 	};
 
 	static const UINT NUM_LABELS = 32;
@@ -5820,7 +5825,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_LinkOrb
 		NO_LABELS,          //CC_WaitForBuilding
 		NO_LABELS,          //CC_WaitForBuildType
-		NO_LABELS           //CC_WaitForNotBuildType
+		NO_LABELS,          //CC_WaitForNotBuildType
+		NO_LABELS           //CC_ResetOverrides
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -6911,6 +6917,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		case CCharacterCommand::CC_LogicalWaitOr:
 		case CCharacterCommand::CC_LogicalWaitXOR:
 		case CCharacterCommand::CC_LogicalWaitEnd:
+		case CCharacterCommand::CC_ResetOverrides:
 			AddCommand();
 		break;
 
@@ -7397,6 +7404,7 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 		case CCharacterCommand::CC_LogicalWaitXOR:
 		case CCharacterCommand::CC_LogicalWaitEnd:
 		case CCharacterCommand::CC_WaitForBuilding:
+		case CCharacterCommand::CC_ResetOverrides:
 			break;
 
 		//Deprecated commands.
@@ -7706,6 +7714,7 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 	case CCharacterCommand::CC_LogicalWaitOr:
 	case CCharacterCommand::CC_LogicalWaitXOR:
 	case CCharacterCommand::CC_LogicalWaitEnd:
+	case CCharacterCommand::CC_ResetOverrides:
 	break;
 
 	case CCharacterCommand::CC_CutScene:
@@ -8541,6 +8550,7 @@ WSTRING CCharacterDialogWidget::toText(
 	case CCharacterCommand::CC_LogicalWaitOr:
 	case CCharacterCommand::CC_LogicalWaitXOR:
 	case CCharacterCommand::CC_LogicalWaitEnd:
+	case CCharacterCommand::CC_ResetOverrides:
 	break;
 
 	case CCharacterCommand::CC_CutScene:

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3571,6 +3571,12 @@ void CCharacter::Process(
 			}
 			break;
 
+			case CCharacterCommand::CC_ResetOverrides: {
+				bProcessNextCommand = true;
+				paramX = paramY = paramW = paramH = paramF = NO_OVERRIDE;
+			}
+			break;
+
 			//Deprecated commands
 			case CCharacterCommand::CC_GotoIf:
 			case CCharacterCommand::CC_WaitForHalph:

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -376,6 +376,7 @@ public:
 		CC_WaitForBuilding,     //Wait until build markers are queued in rect (x,y,w,h).
 		CC_WaitForBuildType,    //Wait until build marker type specified in flags is queued in rect (x,y,w,h)
 		CC_WaitForNotBuildType, //Wait until no build marker type specified in flags is queued in rect (x,y,w,h)
+		CC_ResetOverrides,      //Resets command parameter override values to no override
 
 		CC_Count
 	};

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -950,6 +950,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_UseCommandKeyThree: strText = "Special Command 3"; break;
 	case MID_AvoidFiretraps: strText = "Avoid Firetraps"; break;
 	case MID_AvoidPuffs: strText = "Avoid Puffs"; break;
+	case MID_ResetOverrides: strText = "Reset _MyScript variables"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -270,6 +270,7 @@ interacts with its environment.</p>
 </li>
   <li><a name="setvarat"><b>Set var at</b></a> - Allows the <a href="#setvar">Set var</a> command to be invoked with an NPC on another tile. All assignment and parsing will occur as if the target NPC called the Set var command. Thus, its local variables will be used, allowing them to be written or read remotely. This command can also be used an <a href="#if">If</a> condition. The condition is satisfied if the command successfully invokes a variable assignment on an NPC in the target square. Hint: Use this for scripts that rely on the result of a remote variable assignment.
   </li>
+    <li><a name="resetoverrides"><b>Reset _MyScript variables</b></a> - Sets the value of all <a href="myscript.html">_MyScript variables</a> to -9999, so they no longer override command values.</li>
   <li><a name="setshallowwatertraversal"><b>Set shallow water traversal</b>
     </a> - Sets how and under what conditions the player interacts with shallow water terrain.</li>
   <li><a name="gameeffect"><b>Game effect</b>
@@ -682,7 +683,7 @@ You may select these in variable commands to examine or set certain game states.
 	<li><b>_MyX</b> and <b>_MyY</b> - X and Y position of the NPC. Please keep in mind that the change is instanteous, if you need to modify the position in both axes use 'Teleport to' instead, otherwise you risk creating problematic situation when the NPC teleports first in one axis and then in the other.</li>
 	<li><b>_MyO</b> - NPC's current <a href="#valuesorientation">orientation</a>.</li>
 	<li><b>_MyName</b> - Name of this NPC. Used for right-click inspecting and for speech log.</li>
-	<li><b>_MyScript*</b> - Variables used to inject dynamic values into other scripting commands. <a href="#myscript-injection">See this section</a> for explanation on how to use them.</li>
+	<li><b>_MyScript*</b> - Variables used to inject dynamic values into other scripting commands. <a href="myscript.html">See this section</a> for explanation on how to use them.</li>
 	<li><b>_X</b> and <b>_Y</b> - X and Y position of the Player. Can cause the same potential problems as <b>_MyX</b> and <b>_MyY</b>, so use 'Teleport player to' wheen you need to teleport along two axes.</li>
 	<li><b>_O</b> - Player's current <a href="#valuesorientation">orientation</a>.</li>
 	<li><b>_RoomImageX</b> and <b>_RoomImageY</b> - Offset of the custom room image in tiles.</li>

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1843,6 +1843,7 @@ enum MID_CONSTANT {
   MID_WaitForNotBuildType = 2061,
   MID_Dying = 2062,
   MID_Talking = 2063,
+  MID_ResetOverrides = 2070,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3285,3 +3285,7 @@ Dying
 [MID_Talking]
 [eng]
 Talking
+
+[MID_ResetOverrides]
+[eng]
+Reset _MyScript variables


### PR DESCRIPTION
Simple command that sets the value of all _Myscript variables to `NO_OVERRIDE`. Makes things easier for scripters and is probably faster than using `Set Var`.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45934