### PR TITLE
Fix zero-speed characters animation

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -8029,7 +8029,7 @@ void CRoomWidget::DrawCharacter(
 	UINT wSX, wSY;
 	const bool bHasSword = pCharacter->GetSwordCoords(wSX, wSY);
 	UINT wFrame;
-	if (bHasSword || (!bEntityHasSword(wIdentity) && pCharacter->bNoWeapon)) {
+	if (bHasSword || !pCharacter->HasInactiveWeapon()) {
 		wFrame = this->pTileImages[this->pRoom->ARRAYINDEX(pCharacter->wX, pCharacter->wY)].animFrame;
 		if (!IsMonsterTypeAnimated(wIdentity))
 			wFrame = wFrame % ANIMATION_FRAMES;

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -5401,6 +5401,18 @@ bool CCharacter::HasSword() const
 	return CArmedMonster::HasSword();
 }
 
+//*****************************************************************************
+bool CCharacter::HasInactiveWeapon() const
+//Returns: true if the character has a weapon, but it is not currently in use
+{
+	if (!(this->bWeaponOverride || bEntityHasSword(GetResolvedIdentity())))
+		return false;
+
+	if (this->bNoWeapon || this->bWeaponSheathed)
+		return true;
+
+	return false;
+}
 
 //*****************************************************************************
 bool CCharacter::TurnsSlowly() const

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -131,6 +131,7 @@ public:
 	virtual UINT   GetResolvedIdentity() const;
 	UINT           GetNextSpeechID();
 	bool           HasBehavior(ScriptFlag::Behavior behavior) const { return behaviorFlags.count(behavior) == 1; };
+	bool           HasInactiveWeapon() const;
 	bool           HasInstantMovement() const { return HasBehavior(ScriptFlag::Behavior::InstantMovement); }
 	bool           HasSpecialDeath() const;
 	virtual bool   HasSword() const;


### PR DESCRIPTION
#452 tweaked character drawing to improve support for giving weapons to characters with a non-armed base type. However, it turns out this breaks animation for charaters with zero animation speed.

A more robust check has been added to ensure the swordless frame is only used for a character that 1) has a weapon, either through its base type or setting one using `_MyWeapon` and 2) does not have its weapon active, due to it being turned off or sheathed.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45989