### PR TITLE
Block player movement onto master and win walls when room lock is active

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -6136,7 +6136,7 @@ void CCurrentGame::ProcessPlayer(
 					CueEvents.Add(CID_HitObstacle, new CMoveCoord(destX, destY, wMoveO), true);
 			break;
 			case T_WALL_M:
-				if (!this->bHoldMastered)
+				if (!IsMasterWallPassable())
 				{
 					//Player hit "master wall" and couldn't go through.
 					//Don't allow this move to be made.
@@ -6146,7 +6146,7 @@ void CCurrentGame::ProcessPlayer(
 				goto CheckFLayer;
 			break;
 			case T_WALL_WIN:
-				if (!this->bHoldCompleted)
+				if (!IsHoldCompleteWallPassable())
 				{
 					//Player hit "hold completion wall" and couldn't go through.
 					//Don't allow this move to be made.

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -235,6 +235,8 @@ public:
 	bool     IsCurrentRoomExplored() const;
 	bool     IsCutScenePlaying() const {return this->dwCutScene && !this->swordsman.wPlacingDoubleType;}
 	bool     IsDemoRecording() const {return this->bIsDemoRecording;}
+	bool     IsHoldCompleteWallPassable() const { return this->bHoldCompleted && !this->bRoomExitLocked; }
+	bool     IsMasterWallPassable() const { return this->bHoldMastered && !this->bRoomExitLocked; }
 	bool     IsMusicStyleFrozen() const {return this->bMusicStyleFrozen;}
 	bool     IsNewRoom() const {return this->bIsNewRoom;}
 	bool     IsPlayerAnsweringQuestions() const {return this->UnansweredQuestions.size() != 0;}

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2399,8 +2399,8 @@ bool CDbRoom::CanPlayerMoveOnThisElement(const UINT wAppearance, const UINT wTil
 			if (!(bIsPit(wTileNo) || bIsWater(wTileNo) ||
 					bIsFloor(wTileNo) || bIsOpenDoor(wTileNo) ||
 					bIsStairs(wTileNo) || bIsTunnel(wTileNo) || bIsPlatform(wTileNo) ||
-					(wTileNo == T_WALL_M && this->pCurrentGame && this->pCurrentGame->bHoldMastered) ||
-					(wTileNo == T_WALL_WIN && this->pCurrentGame && this->pCurrentGame->bHoldCompleted)
+					(wTileNo == T_WALL_M && this->pCurrentGame && this->pCurrentGame->IsMasterWallPassable()) ||
+					(wTileNo == T_WALL_WIN && this->pCurrentGame && this->pCurrentGame->IsHoldCompleteWallPassable())
 					))
 				return false;
 		break;
@@ -2413,8 +2413,8 @@ bool CDbRoom::CanPlayerMoveOnThisElement(const UINT wAppearance, const UINT wTil
 					bIsStairs(wTileNo) || bIsTunnel(wTileNo) || bIsPlatform(wTileNo) ||
 					(bIsShallowWater(wTileNo) &&
 					this->pCurrentGame->swordsman.GetWaterTraversalState() >= WTrv_CanWade) ||
-					(wTileNo == T_WALL_M && this->pCurrentGame && this->pCurrentGame->bHoldMastered) ||
-					(wTileNo == T_WALL_WIN && this->pCurrentGame && this->pCurrentGame->bHoldCompleted)
+					(wTileNo == T_WALL_M && this->pCurrentGame && this->pCurrentGame->IsMasterWallPassable()) ||
+					(wTileNo == T_WALL_WIN && this->pCurrentGame && this->pCurrentGame->IsHoldCompleteWallPassable())
 					))
 				return false;
 		break;


### PR DESCRIPTION
Since stepping on master walls and hold complete walls invalidates a room demo, it would be helpful to have a way to avoid that. Room lock already exists to prevent unfortunate moves, so it can be expanded to prevent more of them.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=34068