### PR TITLE
Fix bad character orientation due to no pathfinding move

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3126,6 +3126,8 @@ bool CCharacter::GetMovement(
 						dx, dy, true);
 			} else {
 				bStopTurn = true;
+				dxFirst = 0;
+				dyFirst = 0;
 			}
 		}
 		break;

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -248,7 +248,7 @@ void CMonster::SetOrientation(
 	ASSERT(abs((int)dyFirst) <= 1);
 	const UINT wNewO = nGetO(dxFirst, dyFirst);
 	ASSERT(IsValidOrientation(wNewO));
-	if (wNewO != NO_ORIENTATION || !HasOrientation())
+	if (IsValidOrientation(wNewO) && (wNewO != NO_ORIENTATION || !HasOrientation()))
 		this->wO = wNewO;
 }
 


### PR DESCRIPTION
If a character has the `MIQ_PathfindOpenOnly` movement type, and no move is available, `CCharacter::GetMovement` will not set values for the `dxFirst` and `dyFirst` arguments. These then get used to try to set an orientation, which ends up being invalid. When the character is next drawn, the game will crash.

To fix, `dxFirst` and `dyFirst` should be set to zero in the no-move case for pathfinding. Additionally, I have tweaked `CMonster::SetOrientation` so that it will not set `wO` to an invalid orientation. This should mean that any future incidents have less catastrophic results.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45994