### PR TITLE
RPG: Fix crash in CCharacterDialogWidget::ExtractCommandIndent

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -2239,7 +2239,7 @@ void CCharacterDialogWidget::OnKeyDown(
 						line!=selectedLines.end(); ++line)
 				{
 					if (*line < pCommands->size())
-						wstrCommandsText += toText(*pCommands, (*pCommands)[*line], *line);
+						wstrCommandsText += toText(*pCommands, (*pCommands)[*line], pActiveCommandList, *line);
 				}
 				if (!wstrCommandsText.empty())
 					g_pTheSound->PlaySoundEffect(SEID_POTION);
@@ -3636,10 +3636,10 @@ WSTRING CCharacterDialogWidget::GetDataName(const UINT dwID) const
 }
 
 //*****************************************************************************
-UINT CCharacterDialogWidget::ExtractCommandIndent(const UINT wCommandIndex) const
+UINT CCharacterDialogWidget::ExtractCommandIndent(const CListBoxWidget* pCommandList, const UINT wCommandIndex) const
 //Extracts command's indent size from the command listbox text
 {
-	WSTRING wstr = this->pCommandsListBox->GetTextAtLine(wCommandIndex);
+	WSTRING wstr = pCommandList->GetTextAtLine(wCommandIndex);
 
 	UINT i = 0;
 	for (; i < wstr.size(); ++i)
@@ -7003,6 +7003,7 @@ WSTRING CCharacterDialogWidget::toText(
 //Params:
 	const COMMANDPTR_VECTOR& commands,
 	CCharacterCommand* pCommand,   //Command to parse
+	const CListBoxWidget* pCommandList, //Command list to get string from
 	const UINT wCommandIndex)      //Index of the command
 {
 #define concatNum(n) wstr += _itoW(n,temp,10)
@@ -7017,7 +7018,7 @@ WSTRING CCharacterDialogWidget::toText(
 	if (wstrCommandName.empty())
 		return wstr;
 
-	UINT indent = ExtractCommandIndent(wCommandIndex);
+	UINT indent = ExtractCommandIndent(pCommandList, wCommandIndex);
 	wstr.insert(wstr.end(), indent - INDENT_PREFIX_SIZE + 2, W_t(' '));
 	wstr += wstrCommandName;
 	wstr += wszSpace;

--- a/drodrpg/DROD/CharacterDialogWidget.h
+++ b/drodrpg/DROD/CharacterDialogWidget.h
@@ -116,7 +116,7 @@ private:
 			const WCHAR* pText) const;
 	HoldCharacter* GetCustomCharacter();
 	WSTRING GetDataName(const UINT dwID) const;
-	UINT    ExtractCommandIndent(const UINT wCommandIndex) const;
+	UINT    ExtractCommandIndent(const CListBoxWidget* pCommandList, const UINT wCommandIndex) const;
 	void    PrettyPrintCommands(CListBoxWidget* pCommandList, const COMMANDPTR_VECTOR& commands);
 	void AppendGotoDestination(WSTRING& wstr, const COMMANDPTR_VECTOR& commands,
 		const CCharacterCommand& pCommand) const;
@@ -169,7 +169,7 @@ private:
 
 	//For text editing of script commands.
 	CCharacterCommand* fromText(WSTRING text);
-	WSTRING toText(const COMMANDPTR_VECTOR& commands, CCharacterCommand* pCommand, const UINT wCommandIndex);
+	WSTRING toText(const COMMANDPTR_VECTOR& commands, CCharacterCommand* pCommand, const CListBoxWidget* pCommandList, const UINT wCommandIndex);
 
 	CListBoxWidget *pGraphicListBox, *pPlayerGraphicListBox;
 	COptionButtonWidget *pIsVisibleButton;


### PR DESCRIPTION
`CCharacterDialogWidget::ExtractCommandIndent` was always acting on the main command list, even when editing a default script. This meant it would crash during a Ctrl-B copy if the default script being worked on was long than the script in the main command list.

To fix this, the function has been updated to take a command list as an argument, along with `CCharacterDialogWidget::toText`.