### PR TITLE
cast to match integer type

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -2044,7 +2044,7 @@ void CDbXML::Import_TallyRecords(const string& xml) //[in] string containg xml t
 			break;
 		}
 
-		const int bytesRead = min(remainingSize, XML_PARSER_BUFF_SIZE);
+		const int bytesRead = min((int)remainingSize, XML_PARSER_BUFF_SIZE);
 		ASSERT(bytesRead >= 0);
 		ASSERT(bytesRead <= XML_PARSER_BUFF_SIZE);
 		memcpy(buff, pXml, bytesRead);
@@ -2179,7 +2179,7 @@ void CDbXML::Import_ParseRecords(const string& xml) //[in] string containg xml t
 		}
 
 		//Get next chunk of data to parse.
-		const int bytesRead = min(remainingSize, XML_PARSER_BUFF_SIZE);
+		const int bytesRead = min((int)remainingSize, XML_PARSER_BUFF_SIZE);
 		ASSERT(bytesRead >= 0);
 		ASSERT(bytesRead <= XML_PARSER_BUFF_SIZE);
 		memcpy(buff, pXml, bytesRead);


### PR DESCRIPTION
Made the minimal change, though it is probably more correct to fix the declarations for the other values on the lines.