### PR TITLE
Add support for custom speech color

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -2283,6 +2283,7 @@ void CCharacterDialogWidget::OnClick(
 
 			if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE){
 				this->pCharacter->wProcessSequence = this->pCharOptionsDialog->GetProcessSequence();
+				this->pCharacter->SetCustomSpeechColor(this->pCharOptionsDialog->GetSpeechColor());
 			}
 			
 			Paint();
@@ -3253,6 +3254,7 @@ void CCharacterDialogWidget::EditDefaultScriptForCustomNPC()
 
 				if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE){
 					pChar->ExtraVars.SetVar(ParamProcessSequenceStr, this->pCharOptionsDialog->GetProcessSequence());
+					pChar->ExtraVars.SetVar(ParamSpeechColorStr, this->pCharOptionsDialog->GetSpeechColor());
 				}
 				
 				Paint();

--- a/DROD/CharacterOptionsWidget.cpp
+++ b/DROD/CharacterOptionsWidget.cpp
@@ -49,11 +49,33 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 	AddWidget(new CLabelWidget(0L, X_TITLE, Y_TITLE,
 		CX_TITLE, CY_TITLE, F_Header, g_pTheDB->GetMessageText(MID_CharOptionsTitle)));
 
+	AddWidget(new CLabelWidget(0L, X_SPEECHCOLORLABEL, Y_SPEECHCOLORLABEL,
+		CX_SPEECHCOLORLABEL, CY_SEQUENCELABEL, F_Small, g_pTheDB->GetMessageText(MID_CustomSpeechColor)));
+
 	AddWidget(new CLabelWidget(0L, X_SEQUENCELABEL, Y_SEQUENCELABEL,
 		CX_SEQUENCELABEL, CY_SEQUENCELABEL, F_Small, g_pTheDB->GetMessageText(MID_ProcessingSequenceDesc)));
 
 	AddWidget(new CLabelWidget(0L, X_SEQUENCEHELP, Y_SEQUENCEHELP,
 		CX_SEQUENCEHELP, CY_SEQUENCEHELP, F_Small, g_pTheDB->GetMessageText(MID_SetProcessingSequenceDescription)));
+
+	this->pSpeechColorRedTextBox = new CTextBoxWidget(0L, X_SPEECHCOLORTEXT_RED, Y_SPEECHCOLORTEXT, 
+		CX_SPEECHCOLORTEXT, CY_STANDARD_TBOX, SPEECHCOLOR_MAX_LENGTH);
+	this->pSpeechColorGreenTextBox = new CTextBoxWidget(0L, X_SPEECHCOLORTEXT_GREEN, Y_SPEECHCOLORTEXT, 
+		CX_SPEECHCOLORTEXT, CY_STANDARD_TBOX, SPEECHCOLOR_MAX_LENGTH);
+	this->pSpeechColorBlueTextBox = new CTextBoxWidget(0L, X_SPEECHCOLORTEXT_BLUE, Y_SPEECHCOLORTEXT, 
+		CX_SPEECHCOLORTEXT, CY_STANDARD_TBOX, SPEECHCOLOR_MAX_LENGTH);
+
+	this->pSpeechColorRedTextBox->SetDigitsOnly(true);
+	this->pSpeechColorGreenTextBox->SetDigitsOnly(true);
+	this->pSpeechColorBlueTextBox->SetDigitsOnly(true);
+
+	this->pSpeechColorRedTextBox->SetAllowNegative(false);
+	this->pSpeechColorGreenTextBox->SetAllowNegative(false);
+	this->pSpeechColorBlueTextBox->SetAllowNegative(false);
+
+	AddWidget(this->pSpeechColorRedTextBox);
+	AddWidget(this->pSpeechColorGreenTextBox);
+	AddWidget(this->pSpeechColorBlueTextBox);
 
 	this->pSequenceTextBox = new CTextBoxWidget(0L, X_SEQUENCETEXT, Y_SEQUENCETEXT,
 		CX_SEQUENCETEXT, CY_SEQUENCETEXT, PROCESSING_SEQUENCE_MAX_LENGTH, TAG_OK);
@@ -75,6 +97,8 @@ void CCharacterOptionsDialog::SetCharacter(
 	_itoW(pCharacter->wProcessSequence, temp, 10, bufferLength);
 
 	this->pSequenceTextBox->SetText(temp);
+
+	SetSpeechColorTexts(pCharacter->GetCustomSpeechColor());
 }
 
 //*****************************************************************************
@@ -87,6 +111,38 @@ void CCharacterOptionsDialog::SetCharacter(
 	_itoW(pCharacter->ExtraVars.GetVar(ParamProcessSequenceStr, SPD_CHARACTER), temp, 10, bufferLength);
 
 	this->pSequenceTextBox->SetText(temp);
+
+	SetSpeechColorTexts(pCharacter->ExtraVars.GetVar(ParamSpeechColorStr, 0));
+}
+
+//*****************************************************************************
+void CCharacterOptionsDialog::SetSpeechColorTexts(UINT color)
+{
+	UINT r = (color >> 16) & 255;
+	UINT g = (color >> 8) & 255;
+	UINT b = color & 255;
+
+	const UINT bufferLength = SPEECHCOLOR_MAX_LENGTH + 1; // Added space for null-termination
+	WCHAR temp[bufferLength];
+
+	_itoW(r, temp, 10, bufferLength);
+	this->pSpeechColorRedTextBox->SetText(temp);
+	_itoW(g, temp, 10, bufferLength);
+	this->pSpeechColorGreenTextBox->SetText(temp);
+	_itoW(b, temp, 10, bufferLength);
+	this->pSpeechColorBlueTextBox->SetText(temp);
+}
+
+//*****************************************************************************
+UINT CCharacterOptionsDialog::GetSpeechColor()
+{
+	UINT r = min((UINT)this->pSpeechColorRedTextBox->GetNumber(), 255);
+	UINT g = min((UINT)this->pSpeechColorGreenTextBox->GetNumber(), 255);
+	UINT b = min((UINT)this->pSpeechColorBlueTextBox->GetNumber(), 255);
+
+	UINT value = (r << 16) + (g << 8) + b;
+
+	return value;
 }
 
 //*****************************************************************************

--- a/DROD/CharacterOptionsWidget.h
+++ b/DROD/CharacterOptionsWidget.h
@@ -46,31 +46,47 @@ public:
 
 	CCharacterOptionsDialog();
 
+	CTextBoxWidget* pSpeechColorRedTextBox;
+	CTextBoxWidget* pSpeechColorBlueTextBox;
+	CTextBoxWidget* pSpeechColorGreenTextBox;
 	CTextBoxWidget *pSequenceTextBox;
 
 	void SetCharacter(const CCharacter *pCharacter);
 	void SetCharacter(HoldCharacter *pCharacter);
+	UINT GetSpeechColor();
 	UINT GetProcessSequence();
 
 protected:
 	virtual void OnKeyDown(const UINT dwTagNo, const SDL_KeyboardEvent &Key);
 
 private:
+	void SetSpeechColorTexts(UINT color);
+
 	static const UINT CY_SPACE = 15;
 	static const UINT CX_SPACE = 15;
 
 	static const int CX_DIALOG = 400;
-	static const int CY_DIALOG = 420;
+	static const int CY_DIALOG = 467;
 
 	static const int CX_TITLE = 200;
 	static const int CY_TITLE = CY_LABEL_FONT_HEADER;
 	static const int X_TITLE = (CX_DIALOG - CX_TITLE) / 2;
 	static const int Y_TITLE = CY_SPACE;
 
+	static const int CX_SPEECHCOLORLABEL = 150;
+	static const int X_SPEECHCOLORLABEL = CX_SPACE;
+	static const int Y_SPEECHCOLORLABEL = Y_TITLE + CY_TITLE + CY_SPACE;
+
+	static const int CX_SPEECHCOLORTEXT = 45;
+	static const int X_SPEECHCOLORTEXT_RED = X_SPEECHCOLORLABEL + CX_SPEECHCOLORLABEL + CX_SPACE;
+	static const int X_SPEECHCOLORTEXT_GREEN = X_SPEECHCOLORTEXT_RED + CX_SPEECHCOLORTEXT + CX_SPACE / 2;
+	static const int X_SPEECHCOLORTEXT_BLUE = X_SPEECHCOLORTEXT_GREEN + CX_SPEECHCOLORTEXT + CX_SPACE / 2;
+	static const int Y_SPEECHCOLORTEXT = Y_SPEECHCOLORLABEL;
+
 	static const int CX_SEQUENCELABEL = 150;
 	static const int CY_SEQUENCELABEL = CY_STANDARD_BUTTON;
 	static const int X_SEQUENCELABEL = CX_SPACE;
-	static const int Y_SEQUENCELABEL = Y_TITLE + CY_TITLE + CY_SPACE;
+	static const int Y_SEQUENCELABEL = Y_SPEECHCOLORLABEL + CY_STANDARD_BUTTON + CY_SPACE;
 
 	static const int CX_SEQUENCEHELP = 250;
 	static const int CY_SEQUENCEHELP = 270;
@@ -92,6 +108,7 @@ private:
 	static const int X_CANCEL = CX_DIALOG / 2 + CX_SPACE / 2;
 	static const int Y_CANCEL = CY_DIALOG - CY_SAVE - CY_SPACE;
 
+	static const int SPEECHCOLOR_MAX_LENGTH = 3;
 	static const int PROCESSING_SEQUENCE_MAX_LENGTH = 9;
 };
 

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -788,6 +788,19 @@ CSubtitleEffect* CRoomWidget::AddSubtitle(
 		}
 	}
 
+	//Check for custom speech color
+	CCharacter* pCharacter = dynamic_cast<CCharacter*>(pCoord);
+	if (pCharacter)
+	{
+		const int colorIndex = pCharacter->GetCustomSpeechColor();
+		if (colorIndex)
+		{
+			color.byt1 = Uint8((colorIndex >> 16) & 255);
+			color.byt2 = Uint8((colorIndex >> 8) & 255);
+			color.byt3 = Uint8(colorIndex & 255);
+		}
+	}
+
 	//Speaker text effect.
 	CSubtitleEffect *pSubtitle = new CSubtitleEffect(this, pCoord,
 			wStr.c_str(), Black, color, dwDuration);

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -175,6 +175,7 @@ CCharacter::CCharacter(
 	, movementIQ(SmartOmniDirection)
 	, worldMapID(0)
 	, nColor(-1)
+	, customSpeechColor(0)
 
 	, bWaitingForCueEvent(false)
 	, bIfBlock(false)
@@ -6211,7 +6212,10 @@ void CCharacter::ResolveLogicalIdentity(CDbHold *pHold)
 				this->wIdentity = this->pCustomChar->wType;
 
 				if (this->commands.empty()){
-					this->wProcessSequence = this->pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);	
+					this->wProcessSequence = this->pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
+				}
+				if (!this->customSpeechColor) {
+					this->customSpeechColor = this->pCustomChar->ExtraVars.GetVar(ParamSpeechColorStr, this->customSpeechColor);
 				}
 			} else
 				//When character has a dangling reference to a custom character definition
@@ -6689,6 +6693,8 @@ void CCharacter::SetExtraVarsFromMembersWithoutScript(const bool bHoldChar)
 		this->ExtraVars.SetVar(ParamHStr, this->paramH);
 	if (this->paramF != NO_OVERRIDE)
 		this->ExtraVars.SetVar(ParamFStr, this->paramF);
+	if (this->customSpeechColor)
+		this->ExtraVars.SetVar(ParamSpeechColorStr, this->customSpeechColor);
 	this->ExtraVars.SetVar(ParamProcessSequenceStr, this->wProcessSequence);
 
 	//ASSERT(this->dwScriptID);
@@ -6716,6 +6722,7 @@ void CCharacter::SetBaseMembersFromExtraVars()
 	this->paramF = this->ExtraVars.GetVar(ParamFStr, this->paramF);
 
 	this->wProcessSequence = this->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
+	this->customSpeechColor = this->ExtraVars.GetVar(ParamSpeechColorStr, this->customSpeechColor);
 }
 
 //*****************************************************************************

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -74,6 +74,7 @@
 #define ParamHStr "HParam"
 #define ParamFStr "FParam"
 #define ParamProcessSequenceStr "ProcessSequenceParam"
+#define ParamSpeechColorStr "SpeechColorParam"
 
 #define DefaultCustomCharacterName wszEmpty
 #define NoCustomColor -1
@@ -137,6 +138,7 @@ public:
 	virtual bool   HasSword() const;
 
 	WSTRING        GetCustomName() const { return this->customName; }
+	UINT           GetCustomSpeechColor() const { return this->customSpeechColor; }
 	void           getCommandParams(const CCharacterCommand& command,
 			UINT& x, UINT& y, UINT& w, UINT& h, UINT& f) const;
 	void           getCommandRect(const CCharacterCommand& command,
@@ -228,6 +230,7 @@ public:
 
 	void           ResolveLogicalIdentity(CDbHold *pHold);
 	virtual void   SetCurrentGame(const CCurrentGame *pSetCurrentGame);
+	virtual void   SetCustomSpeechColor(const UINT color) { this->customSpeechColor = color; }
 	void   SetImperative(const ScriptFlag::Imperative eVal) {this->eImperative = eVal;}
 	virtual void   SetExtraVarsFromMembers(const bool bHoldChar=false);
 	void           SetExtraVarsFromMembersWithoutScript(const bool bHoldChar=false);
@@ -355,6 +358,7 @@ private:
 
 	UINT wLastSpeechLineNumber; //used during language import
 	WSTRING customName; // Custom name for this character, used for any display purpose, empty means use the default character name
+	UINT customSpeechColor; //Value to represent custom speech color. empty means use default color
 
 	//Predefined vars.
 	UINT paramX, paramY, paramW, paramH, paramF; //script-definable script command parameter overrides

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -951,6 +951,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_AvoidFiretraps: strText = "Avoid Firetraps"; break;
 	case MID_AvoidPuffs: strText = "Avoid Puffs"; break;
 	case MID_ResetOverrides: strText = "Reset _MyScript variables"; break;
+	case MID_CustomSpeechColor: strText = "Speech Color (rgb)"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbHolds.cpp
+++ b/DRODLib/DbHolds.cpp
@@ -3882,9 +3882,11 @@ void CDbHold::SaveCharacters(
 
 			//Repack the script, saving any owned data objects.
 			const UINT processingSequence_ = ch.ExtraVars.GetVar(ParamProcessSequenceStr, SPD_CHARACTER);
+			const UINT speechColor_ = ch.ExtraVars.GetVar(ParamSpeechColorStr, 0);
 			ch.ExtraVars.Clear();
 			ch.ExtraVars.SetVar(scriptIDstr, ch.dwScriptID);
 			ch.ExtraVars.SetVar(ParamProcessSequenceStr, processingSequence_);
+			ch.ExtraVars.SetVar(ParamSpeechColorStr, speechColor_);
 			CCharacter::SaveCommands(ch.ExtraVars, *ch.pCommands);
 
 			//Now the working copy of the default script can be cleared.

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2256,6 +2256,7 @@ bool CDbRoom::AddNewGlobalScript(const UINT dwCharID, const bool bProcessMove, C
 	pCharacter->bGlobal = true;
 	pCharacter->dwScriptID = pCustomChar->dwScriptID;
 	pCharacter->wProcessSequence = pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, SPD_CHARACTER);
+	pCharacter->SetCustomSpeechColor(pCustomChar->ExtraVars.GetVar(ParamSpeechColorStr, 0));
 
 	LinkMonster(pNew, false);
 

--- a/Data/Help/1/character.html
+++ b/Data/Help/1/character.html
@@ -65,7 +65,12 @@ script continues to play but it otherwise behaves as if it were not in the room.
 Hint: making a character with a "None" graphic visible will set it to the
 "Citizen" type.</p>
 
-<p><a name="options"><b>Options</b></a> - Click to set the NPC's processing sequence, or the relative order in which the NPC takes its turn in relation to other entities in the room.</p>
+<p><a name="options"><b>Options</b></a> - Click to set the NPC's options:</p>
+<ul>
+<li><b>Speech Color</b>, which controls the color of the character's speech subtitles. Each input takes a value of 0 to 255, and the three values are combined into a single RGB color value. If all inputs are zero, the default subtitle color will be used.</li>
+<li><b>Processing sequence</b>, the relative order in which the NPC takes its turn in relation to other entities in the room.</li>
+</ul>
+
 <p><a name="addcommand"><b>Add Command</b></a> - Click to add another <a href="script.html">command</a>
 to the script.</p>
 <p><a name="deletecommand"><b>Delete Command</b></a> - Deletes the selected commands from the script.  Also

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1844,6 +1844,7 @@ enum MID_CONSTANT {
   MID_Dying = 2062,
   MID_Talking = 2063,
   MID_ResetOverrides = 2070,
+  MID_CustomSpeechColor = 2071,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3289,3 +3289,7 @@ Talking
 [MID_ResetOverrides]
 [eng]
 Reset _MyScript variables
+
+[MID_CustomSpeechColor]
+[eng]
+Speech Color (rgb)


### PR DESCRIPTION
Adds the ability to change a character's speech color, in the same way it was added to RPG 1.3 in #500.