### PR TITLE
Add metakit as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "metakit"]
+	path = metakit
+	url = https://github.com/CaravelGames/metakit

--- a/Scripts/InstallDependencies.win32.vs2013.py
+++ b/Scripts/InstallDependencies.win32.vs2013.py
@@ -310,26 +310,17 @@ dependencies = {
 		}
 	},
 	'metakit-2.4.9.7': {
-		'urls': ['https://github.com/jnorthrup/metakit/archive/master.zip'],
-		'builds': [
-			{
-				'sln': 'metakit-master/win/msvc70/mksrc.sln',
-				'configs': [
-					['Debug', '/project', 'mkbug.vcxproj', '/projectconfig', 'Debug'],
-					['Release', '/project', 'mkbug.vcxproj', '/projectconfig', 'Release']
-				]
-			}
-		],
+		'urls': ['https://github.com/CaravelGames/metakit/releases/download/2.4.9.7/caravel-metakit-2.4.9.7.zip'],
 		"include": {
-			"metakit-master/include/mk4.h": "",
-			"metakit-master/include/mk4dll.h": "",
-			"metakit-master/include/mk4io.h": "",
-			"metakit-master/include/mk4str.h": "",
-			"metakit-master/include/mk4.inl": ""
+			"caravel-metakit-2.4.9.7/include/mk4.h": "",
+			"caravel-metakit-2.4.9.7/include/mk4dll.h": "",
+			"caravel-metakit-2.4.9.7/include/mk4io.h": "",
+			"caravel-metakit-2.4.9.7/include/mk4str.h": "",
+			"caravel-metakit-2.4.9.7/include/mk4.inl": ""
 		},
 		'libs': {
-			'metakit-master/builds/mk4vc70s_d.lib': 'Debug',
-			'metakit-master/builds/mk4vc70s.lib': 'Release'
+			'caravel-metakit-2.4.9.7/libs/mk4vc70s_d.lib': 'Debug',
+			'caravel-metakit-2.4.9.7/libs/mk4vc70s.lib': 'Release'
 		}
 	},
 	SdlName: {

--- a/Scripts/InstallDependencies.win32.vs2013.py
+++ b/Scripts/InstallDependencies.win32.vs2013.py
@@ -321,6 +321,7 @@ dependencies = {
 		'libs': {
 			'caravel-metakit-2.4.9.7/libs/mk4vc70s_d.lib': 'Debug',
 			'caravel-metakit-2.4.9.7/libs/mk4vc70s.lib': 'Release'
+			'caravel-metakit-2.4.9.7/libs/mklib.pdb': ['Debug', 'Release']
 		}
 	},
 	SdlName: {

--- a/Scripts/InstallDependencies.win32.vs2013.py
+++ b/Scripts/InstallDependencies.win32.vs2013.py
@@ -16,13 +16,13 @@ from pprint import pprint
 def overrideOptions():
 	global DevEnvPath,DepsToBuild,IgnoreBuilds
 
-	DevEnvPath = 'C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\Common7\\IDE\\devenv.com'
-	#DevEnvPath = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\Common7\\IDE\\devenv.com'
+	#DevEnvPath = 'C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\Common7\\IDE\\devenv.com'
+	DevEnvPath = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\Common7\\IDE\\devenv.com'
 	IgnoreBuilds = 0 # Set this to 0 to skip the build step
 	DepsToBuild = "all" # Change it to array of lib names to build and copy only the specific ones
 
 #### DEFAULT OPTIONS ####
-DevEnvPath = 'C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\Common7\\IDE\\devenv.com'
+DevEnvPath = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\Common7\\IDE\\devenv.com'
 IgnoreBuilds = 0
 DepsToBuild = "all"
 


### PR DESCRIPTION
This PR adds the [Caravel fork](https://github.com/CaravelGames/metakit) of metakit as a submodule of the repository. Additionally, it updates the Windows dependency script to fetch a pre-built version of the metakit library, which matches the previous metakit that was being fetched and built.

See #545 for why this has been done. In short, metakit repos have a tendency to be unreliable.