### PR TITLE
Fix Move To if logic when character has pathfinding

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -1370,7 +1370,10 @@ void CCharacter::Process(
 							if (!TurnsSlowly())
 								SetOrientation(dxFirst,dyFirst);
 						}
-						break;
+						//Allow if'd command to reach STOP_COMMAND
+						if (!this->bIfBlock) {
+							break;
+						}
 					}
 					STOP_COMMAND;
 				}


### PR DESCRIPTION
It turns out the crash fixed in #544 was also covering up a regression, where If behaviour on `Move To` no longer worked if the character uses a pathfinding imperative.

This is a regression in 5.1.1, so the PR is pointed at the master branch.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45994