### PR TITLE
RPG: Preserve old behaviour for 50 percent damage beam

### DIFF
--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -2376,7 +2376,15 @@ bool CMonster::GetNextGaze(
 					if (!beamVal)
 						return false; // no damage, blocks gaze
 
-					UINT delta = player.CalcDamage(beamVal);
+					UINT delta = 0;
+					if (beamVal == 50) {
+						// Backwards compatibility - CalcDamage rounds up, old way rounds down
+						PlayerStats& ps = player.st;
+						delta = ps.HP / (player.IsHasted() ? 4 : 2);
+					} else {
+						delta = player.CalcDamage(beamVal);
+					}
+
 					if (!delta)
 						delta = 1;
 					player.DecHealth(CueEvents, delta, CID_MonsterKilledPlayer);


### PR DESCRIPTION
It was noticed that previously, the default damage for Aumtlich beams was rounded down if the player had an odd HP value, but the change to support customising the damage caused it be rounded up. This could have undesirable effects on existing level sets, so a special case has been added to preserve the old behaviour for beams halfing HP.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45830