### PR TITLE
RPG: Include plain floor types in right-click subtitle

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1341,11 +1341,6 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 			mid = GetPressurePlateMID(pPlate ? pPlate->eType : OT_NORMAL);
 		}
 		break;
-		case T_FLOOR: case T_FLOOR_ALT: case T_FLOOR_M: case T_FLOOR_ROAD:
-		case T_FLOOR_GRASS: case T_FLOOR_DIRT: case T_FLOOR_IMAGE:
-			//Don't add extra text for plain floor.
-			mid = 0;
-		break;
 		default: mid = TILE_MID[oTile]; break;
 	}
 


### PR DESCRIPTION
Currently, the right-click tooltip does not show the "plain" floor types. While they usually do not have game logic associated with them, it is possible for character scripts to treat them as logically different.

Noting these floor types can therefore be useful. It also gives a conformation that a tile contains no functional floor types that may be obscured by monsters or items.