### PR TITLE
RPG: Clip sword blit when its previous location is outside room

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -6965,8 +6965,13 @@ void CRoomWidget::DrawPlayer(
 
 	//If sword is not fully in display, draw it clipped.
 	//This is needed when raised at top edge or stepping onto room edge.
-	const bool bClipped = !IS_COLROW_IN_DISP(wSX, wSY) ||
+	bool bClipped = !IS_COLROW_IN_DISP(wSX, wSY) ||
 			 !IS_COLROW_IN_DISP(wSX + nSgnX, wSY + nSgnY);
+	if (!bClipped && this->dwMovementStepsLeft) {
+		UINT prevSX = wSX + (swordsman.wPrevX - swordsman.wX);
+		UINT prevSY = wSY + (swordsman.wPrevY - swordsman.wY);
+		bClipped = !IS_COLROW_IN_DISP(prevSX, prevSY);
+	}
 
 	TileImageBlitParams blit(wSX, wSY, wSwordTI, wXOffset, wYOffset, true, bDrawRaised);
 	blit.nOpacity = nOpacity;


### PR DESCRIPTION
Moving away from a room edge using a tunnel can lead to an assert, as the player's sword may be drawn outside of the room during movement animation.

To fix, clipping should be applied to the sword blit in the case when the player is being animated, and their previous sword position is outside of the room.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45844