### PR TITLE
RPG: Make shields provide doubled DEF against weak monsters

### DIFF
--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -113,36 +113,28 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 	ASSERT(CCharacterCommand::IsRealEquipmentType(equipType));
 
 	WSTRING text;
-	bool goblinWeakness = false, serpentWeakness = false, customWeakness = false;
 	bool needSeparator = false;
-
-	//Armor does not grant strong hit
-	if (equipType != ScriptFlag::EquipmentType::Armor) {
-		goblinWeakness = pCharacter->HasGoblinWeakness();
-		serpentWeakness = pCharacter->HasSerpentWeakness();
-		customWeakness = pCharacter->HasCustomWeakness();
-	}
 
 	if (pCharacter->IsMetal())
 	{
 		text += g_pTheDB->GetMessageText(MID_BehaviorMetal);
 		needSeparator = true;
 	}
-	if (goblinWeakness)
+	if (pCharacter->HasGoblinWeakness())
 	{
 		if (needSeparator)
 			text += separator;
 		text += g_pTheDB->GetMessageText(MID_BehaviorGoblinWeakness);
 		needSeparator = true;
 	}
-	if (serpentWeakness)
+	if (pCharacter->HasSerpentWeakness())
 	{
 		if (needSeparator)
 			text += separator;
 		text += g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness);
 		needSeparator = true;
 	}
-	if (customWeakness)
+	if (pCharacter->HasCustomWeakness())
 	{
 		if (needSeparator)
 			text += separator;

--- a/drodrpg/DRODLib/Combat.cpp
+++ b/drodrpg/DRODLib/Combat.cpp
@@ -354,6 +354,9 @@ int CCombat::getPlayerDEF()
 		if (def > 0)
 			def = 0;
 		this->bMonsterDoesNoDefenseHit = true;
+	} else if (PlayerHasStrongShield(this->pMonster)){
+		// Shield with monster weakness doubles effective defense
+		doubleWithClamp(def);
 	}
 
 	return def;
@@ -434,6 +437,19 @@ bool CCombat::PlayerDoesStrongHit(const CMonster* pMonster) const
 	}
 
 	return false;
+}
+
+//*****************************************************************************
+bool CCombat::PlayerHasStrongShield(const CMonster* pMonster) const
+//Returns: whether player gets x2 DEF against this monster
+{
+	ASSERT(pMonster);
+
+	if (this->pGame->IsPlayerShieldDisabled()) {
+		return false;
+	}
+
+	return this->pGame->IsEquipmentStrongAgainst(pMonster, ScriptFlag::Armor);
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Combat.h
+++ b/drodrpg/DRODLib/Combat.h
@@ -120,6 +120,7 @@ public:
 	bool PlayerCanHarmQueuedMonster() const;
 	CMonster* PlayerCantHarmAQueuedMonster() const;
 	bool PlayerDoesStrongHit(const CMonster* pMonster) const;
+	bool PlayerHasStrongShield(const CMonster* pMonster) const;
 	bool QueueMonster(CMonster* pMonster, const bool bPlayerHitsFirst,
 			const UINT wFromX, const UINT wFromY,
 			const UINT wX, const UINT wY,

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -549,10 +549,10 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
       NPC will generate roach eggs or another monster type when the player engages another monster in combat. The type of monster generated can be controlled by the <b>_MySpawn</b> and <b>_QueenSpawn variables</b>.</li>  
   <li><a name="be_goblin"><u>Goblin Weakness</u></a>:
 	  NPC is weak to goblin blades (i.e. player gets x2 ATK).
-	  Embues custom weapons with goblin blade attribute.</li>
+	  Embues custom equipment with goblin blade attribute. Shields with goblin blade attribue instead provide x2 DEF against attacks from goblin enemies.</li>
   <li><a name="be_wyrm"><u>Wyrm Weakness</u></a>:
 	  NPC is weak to wyrm blades (i.e. player gets x2 ATK).
-	  Embues custom weapons with wyrm blade attribute.</li>
+	  Embues custom equipment with wyrm blade attribute. Shields with wyrm blade attribue instead provide x2 DEF against attacks from wyrm enemies.</li>
   <li><a name="be_metal"><u>Metal</u></a>:
       Metal monsters will be damaged on oremites the same as if on a hot tile.
 	  Embues custom equipment with metal attribute (disabled on oremites).</li>
@@ -827,7 +827,7 @@ The variable names are case-insensitive.
   available choices, numbered in order of appearance.
   A value of 0 indicates no sword.
 </p>
-<p><a name="myweakness"><b>*_MyWeakness</b></a> - Allows a custom weakness to be set for a monster or equipment. A weapon or accessory is strong (i.e. player gets x2 ATK) against a monster if both _MyWeakness values are the same. The comparison is case-sensitive, so for example the values "Eyeball" and "eyeball" would not be considered the same.
+<p><a name="myweakness"><b>*_MyWeakness</b></a> - Allows a custom weakness to be set for a monster or equipment. A weapon or accessory is strong (i.e. player gets x2 ATK) against a monster if both _MyWeakness values are the same. A shield can also be strong against a monster, and will give x2 DEF against attacks from it. The comparison is case-sensitive, so for example the values "Eyeball" and "eyeball" would not be considered the same.
 </p>
 <p><a name="mydescription"><b>*_MyDescription</b></a> - A custom description property that can be set for a monster or equipment. It will be displayed after any behavior descriptors that apply to the character. A semi-colon can be used to split the description into multiple descriptors that will be displayed separately.
 </p>

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -549,10 +549,10 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
       NPC will generate roach eggs or another monster type when the player engages another monster in combat. The type of monster generated can be controlled by the <b>_MySpawn</b> and <b>_QueenSpawn variables</b>.</li>  
   <li><a name="be_goblin"><u>Goblin Weakness</u></a>:
 	  NPC is weak to goblin blades (i.e. player gets x2 ATK).
-	  Embues custom equipment with goblin blade attribute. Shields with goblin blade attribue instead provide x2 DEF against attacks from goblin enemies.</li>
+	  Embues custom equipment with goblin blade attribute. Shields with goblin blade attribute instead provide x2 DEF against attacks from goblin enemies.</li>
   <li><a name="be_wyrm"><u>Wyrm Weakness</u></a>:
 	  NPC is weak to wyrm blades (i.e. player gets x2 ATK).
-	  Embues custom equipment with wyrm blade attribute. Shields with wyrm blade attribue instead provide x2 DEF against attacks from wyrm enemies.</li>
+	  Embues custom equipment with wyrm blade attribute. Shields with wyrm blade attribute instead provide x2 DEF against attacks from wyrm enemies.</li>
   <li><a name="be_metal"><u>Metal</u></a>:
       Metal monsters will be damaged on oremites the same as if on a hot tile.
 	  Embues custom equipment with metal attribute (disabled on oremites).</li>


### PR DESCRIPTION
Makes weakness behaviours and `_MyWeakness` functional on shield items. The player's effective defense is doubled against monsters their shield is strong against (unless that monster has `No enemy defense`). This applies during combat, and when taking damage from monsters that attack outside of combat.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46014