### PR TITLE
RPG: Update SDL_ttf to version 2.20.1

### DIFF
--- a/CompilingDrod_Win_MSVS2013.md
+++ b/CompilingDrod_Win_MSVS2013.md
@@ -32,7 +32,7 @@ The game requires the following libraries. Different versions may potentially be
  -  `lpng-1512` => https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.12/lpng1512.zip
  -  `metakit-2.4.9.5` => https://github.com/jcw/metakit/archive/2.4.9.5.tar.gz
  -  `sdl2-2.0.5` => https://www.libsdl.org/release/SDL2-2.0.5.zip
- -  `sdl-ttf-2.0.14` => https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip
+ -  `sdl-ttf-2.20.1` => https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.20.1/SDL2_ttf-devel-2.20.1-VC.zip
  -  `zlib` => http://www.zlib.net/fossils/zlib-1.2.11.tar.gz
 
 You need the DLLs from the following libraries:

--- a/FrontEndLib/FontManager.cpp
+++ b/FrontEndLib/FontManager.cpp
@@ -853,7 +853,7 @@ const
 		SDL_SetSurfaceRLE(pText, 1);
 		TTF_SetFontOutline(pFont->pTTFFont, 0);
 		SDL_Surface* p2 = TTF_RenderUNICODE_Blended(pFont->pTTFFont, reinterpret_cast<const Uint16*>(pwczText), pFont->ForeColor);
-		SDL_Rect dest = MAKE_SDL_RECT((pText->w - p2->w)/2, (pText->h - p2->h)/2+1, p2->w, p2->h);
+		SDL_Rect dest = MAKE_SDL_RECT(pFont->wOutlineWidth, pFont->wOutlineWidth - 1, pText->w, pText->h);
 		g_pTheBM->BlitRGBAtoRGBA(p2, NULL, pText, &dest);
 		SDL_FreeSurface(p2);
 	} else if (pFont->bAntiAlias && !bRenderFast) {

--- a/Scripts/InstallDependencies.win32.vs2013.py
+++ b/Scripts/InstallDependencies.win32.vs2013.py
@@ -54,7 +54,7 @@ if DepsToBuild == "all":
 		'lpng-1512',
 		'metakit-2.4.9.7',
 		SdlName,
-		'sdl-ttf-2.0.14',
+		'sdl-ttf-2.20.1',
 		'zlib'
 	]
 
@@ -359,17 +359,16 @@ dependencies = {
 			'SDL2-2.26.1/VisualC/Win32/Release/SDL2.dll': 'Release'
 		}
 	},
-	'sdl-ttf-2.0.14': {
+	'sdl-ttf-2.20.1': {
 		'urls': ['https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip'],
 		'include': {
-			'SDL2_ttf-2.0.14/include': ''
+			'SDL2_ttf-2..20.1/include': ''
 		},
 		'libs': {
-			'SDL2_ttf-2.0.14/lib/x86/SDL2_ttf.lib': ['Debug', 'Release']
+			'SDL2_ttf-2.20.1/lib/x86/SDL2_ttf.lib': ['Debug', 'Release']
 		},
 		'dlls': {
-			'SDL2_ttf-2.0.14/lib/x86/SDL2_ttf.dll': ['Debug', 'Release'],
-			'SDL2_ttf-2.0.14/lib/x86/libfreetype-6.dll': ['Debug', 'Release']
+			'SDL2_ttf-2.20.1/lib/x86/SDL2_ttf.dll': ['Debug', 'Release']
 		}
 	},
 	'zlib': {

--- a/readme.md
+++ b/readme.md
@@ -67,3 +67,10 @@ Music:
  - Modify the [Music] section of Data/drod.ini to apply your selection of music files.
  - To avoid running with any sound or music,
  - run the application with the "nosound" command line parameter.
+
+Fonts:
+ - The game engine supports TrueType fonts (.ttf files)
+ - Fonts can be placed in the Data/Fonts directory.
+ - Fonts for each game are initialized in `DRODFontManager.cpp`.
+ - DROD uses the Tom's New Roman and Epilog fonts, both created by Tom Murphy 7. These fonts can be obtain from http://fonts.tom7.com/.
+ - It is recommended to use the latest version of these fonts when developing, as older versions have visual problems when used with later versions of freetype.


### PR DESCRIPTION
#558 but for the RPG development branch. This updates SDL_ttf to version `2.20.1`, and makes a change in `CFontManager::RenderWord` to fix the drawing of text outlines. See the other PR for much more detail.

The one difference between DROD and DROD RPG is that RPG installations are already using a later version of the Tom's New Roman font, which does not have issues with later versions of freetype.