### PR TITLE
Count entity type and Count item script commands

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -3588,6 +3588,7 @@ const
 		break;
 		case CCharacterCommand::CC_WaitForEntityType:
 		case CCharacterCommand::CC_WaitForNotEntityType:
+		case CCharacterCommand::CC_CountEntityType:
 		{
 			WSTRING charName = this->pAddCommandGraphicListBox->GetTextForKey(command.flags);
 			wstr += charName.length() ? charName : wszQuestionMark;
@@ -3904,6 +3905,7 @@ const
 		break;
 
 		case CCharacterCommand::CC_WaitForItem:
+		case CCharacterCommand::CC_CountItem:
 			wstr += this->pWaitForItemsListBox->GetTextForKey(command.flags);
 			wstr += wszSpace;
 			wstr += g_pTheDB->GetMessageText(MID_At);
@@ -4798,6 +4800,9 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForRemains, g_pTheDB->GetMessageText(MID_WaitForRemains));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForWeapon, g_pTheDB->GetMessageText(MID_WaitForWeapon));
 
+	this->pActionListBox->AddItem(CCharacterCommand::CC_CountEntityType, g_pTheDB->GetMessageText(MID_CountEntityType));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_CountItem, g_pTheDB->GetMessageText(MID_CountItem));
+
 	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitAnd, g_pTheDB->GetMessageText(MID_LogicalWaitAnd));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitOr, g_pTheDB->GetMessageText(MID_LogicalWaitOr));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_LogicalWaitXOR, g_pTheDB->GetMessageText(MID_LogicalWaitXOR));
@@ -5678,7 +5683,9 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_WIDGETS,         //CC_WaitForBuilding
 		BUILD_MARKER_ITEMS, //CC_WaitForBuildType
 		BUILD_MARKER_ITEMS, //CC_WaitForNotBuildType
-		NO_WIDGETS          //CC_ResetOverrides
+		NO_WIDGETS,         //CC_ResetOverrides
+		GRAPHIC,            //CC_CountEntityType
+		WAIT_FOR_ITEMS      //CC_CountItem
 	};
 
 	static const UINT NUM_LABELS = 32;
@@ -5828,7 +5835,9 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_WaitForBuilding
 		NO_LABELS,          //CC_WaitForBuildType
 		NO_LABELS,          //CC_WaitForNotBuildType
-		NO_LABELS           //CC_ResetOverrides
+		NO_LABELS,          //CC_ResetOverrides
+		NO_LABELS,          //CC_CountEntityType
+		NO_LABELS           //CC_CountItem
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -6240,6 +6249,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		break;
 		case CCharacterCommand::CC_WaitForEntityType:
 		case CCharacterCommand::CC_WaitForNotEntityType:
+		case CCharacterCommand::CC_CountEntityType:
 			this->pCommand->flags = this->pAddCommandGraphicListBox->GetSelectedItem();
 			QueryRect();
 		break;
@@ -6300,6 +6310,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 			break;
 
 		case CCharacterCommand::CC_WaitForItem:
+		case CCharacterCommand::CC_CountItem:
 			this->pCommand->flags = this->pWaitForItemsListBox->GetSelectedItem();
 			QueryRect();
 		break;
@@ -7046,6 +7057,7 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 		break;
 
 		case CCharacterCommand::CC_WaitForItem:
+		case CCharacterCommand::CC_CountItem:
 			this->pWaitForItemsListBox->SelectItem(this->pCommand->flags);
 		break;
 
@@ -7218,6 +7230,7 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 		break;
 		case CCharacterCommand::CC_WaitForEntityType:
 		case CCharacterCommand::CC_WaitForNotEntityType:
+		case CCharacterCommand::CC_CountEntityType:
 			this->pAddCommandGraphicListBox->SelectItem(this->pCommand->flags);
 		break;
 
@@ -7848,6 +7861,7 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 
 	case CCharacterCommand::CC_WaitForEntityType:
 	case CCharacterCommand::CC_WaitForNotEntityType:
+	case CCharacterCommand::CC_CountEntityType:
 		parseMandatoryOption(pCommand->flags, this->pAddCommandGraphicListBox, bFound);
 		skipComma;
 		skipLeftParen;
@@ -7984,6 +7998,7 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 	break;
 
 	case CCharacterCommand::CC_WaitForItem:
+	case CCharacterCommand::CC_CountItem:
 		parseMandatoryOption(pCommand->flags,this->pWaitForItemsListBox,bFound);
 		skipComma;
 		skipLeftParen;
@@ -8669,6 +8684,7 @@ WSTRING CCharacterDialogWidget::toText(
 
 	case CCharacterCommand::CC_WaitForEntityType:
 	case CCharacterCommand::CC_WaitForNotEntityType:
+	case CCharacterCommand::CC_CountEntityType:
 	{
 		WSTRING charName = this->pAddCommandGraphicListBox->GetTextForKey(c.flags);
 		wstr += charName.length() ? charName : wszQuestionMark;
@@ -8778,6 +8794,7 @@ WSTRING CCharacterDialogWidget::toText(
 	break;
 
 	case CCharacterCommand::CC_WaitForItem:
+	case CCharacterCommand::CC_CountItem:
 		wstr += this->pWaitForItemsListBox->GetTextForKey(c.flags);
 		wstr += wszComma;
 		concatNumWithComma(c.x);

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4339,7 +4339,7 @@ int CCharacter::CountEntityType(
 				continue;
 			}
 
-			switch (wType) {
+			switch (pMonster->wType) {
 				case M_EYE_ACTIVE:
 				{
 					const CEvilEye* pEvilEye = DYN_CAST(CEvilEye*, CMonster*, pMonster);
@@ -4353,7 +4353,7 @@ int CCharacter::CountEntityType(
 			if (pMonster->wType == M_CHARACTER)
 			{
 				CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
-				if (pCharacter->wLogicalIdentity == wType) {
+				if (pCharacter->wLogicalIdentity == pflags) {
 					++count;
 					continue;
 				}

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -159,6 +159,8 @@ public:
 	int getLocalVarInt(const WSTRING& varName) const;
 	WSTRING getLocalVarString(const WSTRING& varName) const;
 
+	int            CountEntityType(const CCharacterCommand& command, const CDbRoom& room, const CSwordsman& player) const;
+	int            CountTile(const CCharacterCommand& command) const;
 	bool           IsAdderImmune() const { return HasBehavior(ScriptFlag::AdderImmune); }
 	virtual bool   IsAlive() const {return this->bAlive && !this->bReplaced;}
 	virtual bool   IsAttackableTarget() const;

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -377,6 +377,8 @@ public:
 		CC_WaitForBuildType,    //Wait until build marker type specified in flags is queued in rect (x,y,w,h)
 		CC_WaitForNotBuildType, //Wait until no build marker type specified in flags is queued in rect (x,y,w,h)
 		CC_ResetOverrides,      //Resets command parameter override values to no override
+		CC_CountEntityType,     //Count how many entities of a specific type in flag are in rect (x,y,w,h)
+		CC_CountItem,           //Count number of game element (flags) that exist in rect (x,y,w,h).
 
 		CC_Count
 	};

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -952,6 +952,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_AvoidPuffs: strText = "Avoid Puffs"; break;
 	case MID_ResetOverrides: strText = "Reset _MyScript variables"; break;
 	case MID_CustomSpeechColor: strText = "Speech Color (rgb)"; break;
+	case MID_CountEntityType: strText = "Count entity type"; break;
+	case MID_CountItem: strText = "Count item"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbRooms.h
+++ b/DRODLib/DbRooms.h
@@ -245,6 +245,7 @@ public:
 			const int dx, const int dy) const;
 	bool           DoesOrthoSquarePreventDiagonal(const UINT wX, const UINT wY,
 		const int dx, const int dy) const;
+	bool           DoesSquareContainTile(const UINT wX, const UINT wY, const UINT wTileNo) const;
 	bool           DoesSquareContainTeleportationObstacle(const UINT wX, const UINT wY, const UINT wIdentity) const;
 	bool           DoubleCanActivateToken(RoomTokenType type) const;
 

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -389,6 +389,8 @@ the state of the room and wait indefinitely until certain events occur.</p>
 	  <a name="get-entity-direction-no-target"><u>No target</u></a>:  If no entity is found the function returns No orientation. If player is found on the specified position, the player's direction is returned.<br />
       <a name="get-entity-direction-using-in-conditions"><u>Using in conditions</u></a>: This command <b>cannot</b> be used with an <a href="#if">if statements</a>.<br />
 	</li>
+  <li><a name="count-entity-type"><b>Count entity type</b></a> - Counts the number of the given entity type in the specified room region, and stores the result in <b>_ReturnX</b>.</li>
+  <li><a name="count-item"><b>Count item</b></a> - Counts the number of the given game element in the specified room region, and stores the result in <b>_ReturnX</b>.</li>
 </ol>
 
 <p><a name="decision"><b>5.&nbsp;&nbsp;Decision making</b></a> - Use the

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1845,6 +1845,8 @@ enum MID_CONSTANT {
   MID_Talking = 2063,
   MID_ResetOverrides = 2070,
   MID_CustomSpeechColor = 2071,
+  MID_CountEntityType = 2072,
+  MID_CountItem = 2073,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3293,3 +3293,11 @@ Reset _MyScript variables
 [MID_CustomSpeechColor]
 [eng]
 Speech Color (rgb)
+
+[MID_CountEntityType]
+[eng]
+Count entity type
+
+[MID_CountItem]
+[eng]
+Count item


### PR DESCRIPTION
Script commands for counting the amount of things in a room region.

This required a bit of refactoring for the tile counting command, shifting the actual check for a square into the new `CDbRoom::DoesSquareContainTile`. As a side effect, this fixes a bug where variant orbs and plates would not be seen by `Wait for Item` in certain situations.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46007