### PR TITLE
RPG: Add Image overlay script command

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.h
+++ b/drodrpg/DROD/CharacterDialogWidget.h
@@ -147,6 +147,7 @@ private:
 	void  QueryXY();
 
 	void  resolveForwardReferences(const COMMANDPTR_VECTOR& newCommands);
+	void  RollbackCommand();
 	void  SelectCharacter();
 	UINT  SelectMediaID(const UINT dwSelectedValue, const CSelectMediaDialogWidget::DATATYPE eType);
 	void  SetBitFlags();

--- a/drodrpg/DROD/DROD.2019.vcxproj
+++ b/drodrpg/DROD/DROD.2019.vcxproj
@@ -565,6 +565,7 @@
     <ClCompile Include="GameScreen.cpp" />
     <ClCompile Include="HoldSelectScreen.cpp" />
     <ClCompile Include="IceMeltEffect.cpp" />
+    <ClCompile Include="ImageOverlayEffect.cpp" />
     <ClCompile Include="LevelStartScreen.cpp" />
     <ClCompile Include="Light.cpp" />
     <ClCompile Include="Main.cpp" />
@@ -639,6 +640,7 @@
     <ClInclude Include="GameScreen.h" />
     <ClInclude Include="HoldSelectScreen.h" />
     <ClInclude Include="IceMeltEffect.h" />
+    <ClInclude Include="ImageOverlayEffect.h" />
     <ClInclude Include="LevelStartScreen.h" />
     <ClInclude Include="Light.h" />
     <ClInclude Include="MapWidget.h" />

--- a/drodrpg/DROD/DemoScreen.cpp
+++ b/drodrpg/DROD/DemoScreen.cpp
@@ -140,6 +140,7 @@ bool CDemoScreen::SetForActivate()
 
 	//Ensure room display is current.
 	this->pRoomWidget->LoadFromCurrentGame(CGameScreen::pCurrentGame);
+	this->pRoomWidget->DisplayPersistingImageOverlays(this->sCueEvents);
 
 	//Get first command.
 	this->currentCommandIter = 
@@ -363,7 +364,7 @@ void CDemoScreen::OnBetweenEvents()
 			if (LoadDemoGame(this->pDemo->dwNextDemoID))
 			{
 				//Load succeeded -- start playing it next frame.
-				this->pRoomWidget->ShowRoomTransition(wExitOrientation);
+				this->pRoomWidget->ShowRoomTransition(wExitOrientation, CGameScreen::sCueEvents);
 				this->pMapWidget->DrawMapSurfaceFromRoom(CGameScreen::pCurrentGame->pRoom);
 				this->pMapWidget->RequestPaint();
 				this->currentCommandIter = CGameScreen::pCurrentGame->Commands.GetFirst();

--- a/drodrpg/DROD/DemosScreen.cpp
+++ b/drodrpg/DROD/DemosScreen.cpp
@@ -382,8 +382,11 @@ bool CDemosScreen::SetForActivate()
 	if (this->bRetainDemos)
 	{
 		this->bRetainDemos = false;
-		if (this->pDemoCurrentGame)
+		if (this->pDemoCurrentGame) {
 			this->pRoomWidget->LoadFromCurrentGame(this->pDemoCurrentGame);
+			CCueEvents Ignored;
+			this->pRoomWidget->DisplayPersistingImageOverlays(Ignored);
+		}
 		return true;
 	}
 
@@ -1380,6 +1383,7 @@ void CDemosScreen::SetWidgetsToDemo(
 			this->pDemoCurrentGame->Commands.GetFirst(); //quick replay from beginning
 		this->pDemoCurrentGame->SetTurn(pDemo->wBeginTurnNo, Ignored);
 		this->pRoomWidget->LoadFromCurrentGame(this->pDemoCurrentGame);
+		this->pRoomWidget->DisplayPersistingImageOverlays(Ignored);
 
 /*
 		//Since there is no way to flag hold mastery in a demo,

--- a/drodrpg/DROD/DrodEffect.h
+++ b/drodrpg/DROD/DrodEffect.h
@@ -66,6 +66,7 @@ enum EffectType
 	ECHATTEXT,        //CaravelNet chat text display
 	ERAINDROP,        //a falling rain drop
 	EDAMAGEPREVIEW,   //hovering enemy damage display
+	EIMAGEOVERLAY,    //image overlay
 };
 
 //*****************************************************************************

--- a/drodrpg/DROD/DrodScreen.h
+++ b/drodrpg/DROD/DrodScreen.h
@@ -107,6 +107,7 @@ protected:
 	virtual bool   PlayVideo(const WCHAR *pFilename, const UINT dwHoldID, const int x=0, const int y=0);
 	bool           PlayVideo(const UINT dwDataID, const int x=0, const int y=0);
 	void           PopulateChatUserList(const UINT tagUserList);
+	void           ProcessImageEvents(CCueEvents& CueEvents, CRoomWidget* pRoomWidget, const CCurrentGame* pGame);
 	void           ProcessReceivedChatData(const UINT tagUserList);
 	bool           PollForCNetInterrupt();
 	void           ReformatChatText(const UINT chatInputTextTag, const bool bNextOption=false);

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -91,6 +91,7 @@ protected:
 	void           ClearSpeech(const bool bForceClearAll=false);
 	void           ClickOnEquipment(const UINT eCommand, const bool bRightMouseButton);
 	virtual void   DisplayChatText(const WSTRING& text, const SDL_Color& color);
+	void           DisplayPersistentEffects();
 	void           DrawCurrentTurn();
 	WSTRING        GetEquipmentPropertiesText(const UINT eCommand);
 	void           GotoHelpPage();
@@ -142,7 +143,7 @@ private:
 	void           DisplayAdjacentTempRoom(const UINT direction);
 	void           DisplayChatDialog();
 //	void           DisplayRoomStats();
-	void           FadeRoom(const bool bFadeIn, const Uint32 dwDuration);
+	void           FadeRoom(const bool bFadeIn, const Uint32 dwDuration, CCueEvents& CueEvents);
 	UINT           GetEffectDuration(const UINT baseDuration) const;
 //	WSTRING        GetGameStats(const bool bHoldTotals=false, const bool bOnlyCurrentGameRooms=false) const;
 	UINT           GetMessageAnswer(const CMonsterMessage *pMsg);
@@ -185,7 +186,7 @@ private:
 //	void           ShowLockIcon(const bool bShow=true);
 	void           UpdatePlayerFace();
 	void           ResolvePlayerFace(SPEAKER& pSpeaker, HoldCharacter** playerHoldCharacter);
-	UINT           ShowRoom(CDbRoom *pRoom);
+	UINT           ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents);
 	void           ShowRoomCoords(CDbRoom *pRoom);
 	void           ShowRoomTemporarily(UINT roomID);
 	void           ShowScoreDialog(const WSTRING pTitle, const PlayerStats& st);

--- a/drodrpg/DROD/HoldSelectScreen.cpp
+++ b/drodrpg/DROD/HoldSelectScreen.cpp
@@ -1805,6 +1805,9 @@ void CHoldSelectScreen::ShowActiveRoom(const UINT dwHoldID)
 	if (bGame)
 	{
 		VERIFY(this->pRoomWidget->LoadFromCurrentGame(this->pCurrentRestoreGame));
+		CCueEvents Ignored;
+		this->pRoomWidget->DisplayPersistingImageOverlays(Ignored);
+
 		this->pRoomWidget->RequestPaint();
 		wstrDesc += (const WCHAR*)this->pCurrentRestoreGame->pLevel->NameText;
 		wstrDesc += wszColon;

--- a/drodrpg/DROD/ImageOverlayEffect.cpp
+++ b/drodrpg/DROD/ImageOverlayEffect.cpp
@@ -1,0 +1,936 @@
+// $Id$
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2002, 2005, 2007
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s): Mike Rimer (mrimer)
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+ /*
+ A poor man's guide to how Image Overlay effects work.
+
+ In its simplest, an Image Overlay is a queue of commands that each time 0 or more milliseconds
+ and are executed one after the other. This is the core functionality, but besides it you have:
+	- Looping  - essentially rerun the whole queue X number of times
+	- Parallel commands - they run parallel to other commands, all at once
+	- Cancelling layers - handled externally
+ */
+
+#include "ImageOverlayEffect.h"
+#include "DrodBitmapManager.h"
+#include "DrodEffect.h"
+#include "RoomWidget.h"
+#include "../DRODLib/CharacterCommand.h"
+#include "../DRODLib/CurrentGame.h"
+
+#include <FrontEndLib/Screen.h>
+
+#include <map>
+#include <string>
+using std::map;
+using std::string;
+
+const int ORIGINAL_SCALE = 100; //percent
+
+long nextDrawSequence = 0; //each new effect is drawn after/on top of the previous ones
+
+int clipAlpha(int val)
+{
+	if (val < 0)
+		return 0;
+	if (val > 255)
+		return 255;
+	return val;
+}
+
+int clipAngle(int val)
+{
+	if (val < 0) {
+		const int cycles = -val / 360;
+		return val + (cycles + 1) * 360;
+	}
+	return val % 360;
+}
+
+int clipScale(int val)
+{
+	if (val <= 0)
+		return 1;
+
+	return val;
+}
+
+//*****************************************************************************
+CImageOverlayEffect::CImageOverlayEffect(
+	CWidget* pSetWidget,
+	const CImageOverlay* pImageOverlay,
+	const UINT turnNo,
+	const Uint32 dwStartTime)
+	: CEffect(pSetWidget, (UINT)-1, EIMAGEOVERLAY)
+	, drawSequence(++nextDrawSequence)
+	, pImageSurface(NULL), pAlteredSurface(NULL), pTiledSurface(NULL)
+	, bPrepareAlteredImage(false)
+	, x(0), y(0)
+	, drawX(0), drawY(0)
+	, alpha(255), drawAlpha(255)
+	, angle(0), scale(ORIGINAL_SCALE)
+	, jitter(0)
+	, xTile(0), yTile(0)
+	, repetitions(0), xRepeatOffset(0), yRepeatOffset(0)
+	, index(UINT(-1))
+	, loopIteration(0), maxLoops(0)
+	, startOfNextEffect(dwStartTime)
+	, pRoomWidget(NULL)
+	, turnNo(turnNo)
+	, instanceID(0)
+	, drawSourceRect(MAKE_SDL_RECT(0, 0, 0, 0))
+	, drawDestinationRect(MAKE_SDL_RECT(0, 0, 0, 0))
+{
+	ASSERT(pSetWidget);
+	ASSERT(pSetWidget->GetType() == WT_Room);
+	this->pRoomWidget = DYN_CAST(CRoomWidget*, CWidget*, pSetWidget);
+
+	ASSERT(pImageOverlay);
+
+	this->pImageSurface = g_pTheDBM->LoadImageSurface(pImageOverlay->imageID);
+	static const SDL_Rect rect = { 0,0,0,0 };
+	this->dirtyRects.push_back(rect);
+
+	InitParams();
+
+	this->commands = pImageOverlay->commands;
+	this->instanceID = pImageOverlay->instanceID;
+}
+
+CImageOverlayEffect::~CImageOverlayEffect()
+{
+	if (this->pImageSurface)
+		SDL_FreeSurface(this->pImageSurface);
+	if (this->pAlteredSurface)
+		SDL_FreeSurface(this->pAlteredSurface);
+	if (this->pTiledSurface)
+		SDL_FreeSurface(this->pTiledSurface);
+}
+
+void CImageOverlayEffect::InitParams()
+{
+	this->x = 0;
+	this->y = 0;
+	this->alpha = 255;
+	this->drawX = 0;
+	this->drawY = 0;
+	this->drawAlpha = 255;
+	this->angle = 0;
+	this->jitter = 0;
+	this->scale = ORIGINAL_SCALE;
+
+	static const SDL_Rect rect = { 0,0,0,0 };
+	this->sourceClipRect = rect;
+	this->parallelCommands.clear();
+}
+
+int CImageOverlayEffect::getGroup() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::Group)
+			return c.val[0];
+	}
+
+	return ImageOverlayCommand::DEFAULT_GROUP;
+}
+
+bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
+{
+	if (!this->pImageSurface)
+		return false;
+
+	if (!AdvanceState(wDeltaTime))
+		return false;
+
+	if (this->bPrepareAlteredImage) {
+		PrepareAlteredImage();
+		this->bPrepareAlteredImage = false;
+	}
+
+	PrepareDrawProperties();
+
+	return true;
+}
+
+void CImageOverlayEffect::PrepareDrawProperties()
+{
+	this->drawX = this->x;
+	this->drawY = this->y;
+
+	if (this->jitter) {
+		this->drawX += ROUND(fRAND_MID(this->jitter));
+		this->drawY += ROUND(fRAND_MID(this->jitter));
+	}
+
+	this->pOwnerWidget->GetRect(this->drawDestinationRect);
+	this->drawSourceRect = this->sourceClipRect;
+
+	if (this->pTiledSurface) {
+		this->drawSourceRect.w = this->pTiledSurface->w;
+		this->drawSourceRect.h = this->pTiledSurface->h;
+	}
+	else if (this->pAlteredSurface) {
+		SDL_Surface* pSrcSurface = this->pAlteredSurface;
+		if (!this->drawSourceRect.w)
+			this->drawSourceRect.w = pSrcSurface->w;
+		else if (this->drawSourceRect.w > pSrcSurface->w)
+			this->drawSourceRect.w = pSrcSurface->w;
+		if (!this->drawSourceRect.h)
+			this->drawSourceRect.h = pSrcSurface->h;
+		else if (this->drawSourceRect.h > pSrcSurface->h)
+			this->drawSourceRect.h = pSrcSurface->h;
+		this->drawX += (int(this->pImageSurface->w) - pSrcSurface->w) / 2; //keep centered
+		this->drawY += (int(this->pImageSurface->h) - pSrcSurface->h) / 2; //keep centered
+	}
+	else {
+		SDL_Surface* pSrcSurface = this->pImageSurface;
+		if (!this->drawSourceRect.w)
+			this->drawSourceRect.w = this->pImageSurface->w;
+		if (!this->drawSourceRect.h)
+			this->drawSourceRect.h = this->pImageSurface->h;
+	}
+
+	this->drawAlpha = Uint8(this->alpha * this->fOpacity);
+
+	if (IsImageDrawn())
+		this->dirtyRects[0] = this->drawDestinationRect;
+	else {
+		this->dirtyRects[0].w = this->dirtyRects[0].h = 0;
+		this->drawDestinationRect.w = 0;
+		this->drawDestinationRect.h = 0;
+	}
+}
+
+void CImageOverlayEffect::Draw(SDL_Surface& destSurface)
+{
+	SDL_Surface* pSrcSurface;
+
+	if (this->pTiledSurface)
+		pSrcSurface = this->pTiledSurface;
+	else if (this->pAlteredSurface)
+		pSrcSurface = this->pAlteredSurface;
+	else
+		pSrcSurface = this->pImageSurface;
+
+	if (this->drawDestinationRect.w > 0 && this->drawDestinationRect.h > 0) {
+		g_pTheBM->BlitAlphaSurfaceWithTransparency(this->drawSourceRect, pSrcSurface, this->drawDestinationRect, &destSurface, this->drawAlpha);
+
+		if (IsRepeated()) {
+			DrawRepeated(pSrcSurface, &destSurface);
+		}
+	}
+}
+
+void CImageOverlayEffect::DrawRepeated(SDL_Surface* srcSurface, SDL_Surface* destSurface)
+{
+	SDL_Rect srcRect;
+	SDL_Rect destRect;
+	SDL_Rect widgetRect = {
+		this->pOwnerWidget->GetX(),
+		this->pOwnerWidget->GetY(),
+		this->pOwnerWidget->GetW(),
+		this->pOwnerWidget->GetH()
+	};
+
+	int repeats = 0;
+	for (int r = 1; r <= repetitions; ++r) {
+		srcRect = this->drawSourceRect;
+		// Destination rect is created in "widget space" for clipping
+		destRect = {
+			this->drawDestinationRect.x + (r * xRepeatOffset) - widgetRect.x,
+			this->drawDestinationRect.y + (r * yRepeatOffset) - widgetRect.y,
+			this->drawDestinationRect.w,
+			this->drawDestinationRect.h,
+		};
+
+		g_pTheBM->ClipSrcAndDestToRect(srcRect, destRect, widgetRect.w, widgetRect.h);
+		if (destRect.w == 0) {
+			break;
+		}
+		// Translate back to surface space
+		destRect.x += widgetRect.x;
+		destRect.y += widgetRect.y;
+
+		g_pTheBM->BlitAlphaSurfaceWithTransparency(srcRect, srcSurface, destRect, destSurface, this->drawAlpha);
+		++repeats;
+	}
+
+	// Work out how large the dirty rect is
+	int totalXOffset = repeats * abs(xRepeatOffset);
+	int totalYOffset = repeats * abs(yRepeatOffset);
+	SDL_Rect dirtyRect = this->drawDestinationRect;
+	dirtyRect.w += totalXOffset;
+	dirtyRect.h += totalYOffset;
+
+	// Negative offsets require the dirty rect to be shifted
+	if (this->xRepeatOffset < 0) {
+		dirtyRect.x = max(0, dirtyRect.x - totalXOffset);
+	}
+	if (this->yRepeatOffset < 0) {
+		dirtyRect.y = max(0, dirtyRect.y - totalYOffset);
+	}
+
+	this->dirtyRects[0] = dirtyRect;
+}
+
+bool CImageOverlayEffect::IsImageDrawn()
+{
+	return this->drawAlpha > 0 && PositionDisplayInsideRect(this->drawSourceRect, this->drawDestinationRect, this->drawX, this->drawY);
+}
+
+bool CImageOverlayEffect::IsRepeated() const
+{
+	return (this->repetitions > 0 && (this->xRepeatOffset != 0 || this->yRepeatOffset != 0));
+}
+
+bool CImageOverlayEffect::IsTiled() const
+{
+	return (xTile != 0 && yTile != 0 && (xTile > 1 || yTile > 1));
+}
+
+bool CImageOverlayEffect::AdvanceState(const UINT wDeltaTime)
+{
+	// We execute commands one by one and use up the time we have allocated for this rendering pass
+	Uint32 dwRemainingTime = wDeltaTime;
+	// For infinite loop protection
+	const UINT wInitialIndex = this->index;
+
+	if (this->commands.size() == 0)
+		return false; // If there are no commands to run then just finish the effect
+
+	if (this->index == (UINT)-1) {
+		++this->index;
+		StartNextCommand();
+	}
+
+	// do{} is used because on the first draw wDeltaTime will be 0, and we still want non time-based commands to happen
+	do {
+		Uint32 dwConsumedTime = UpdateCommand(this->commands[this->index], this->executionState, dwRemainingTime);
+		UpdateParallelCommands(dwConsumedTime);
+
+		ASSERT(dwConsumedTime <= dwRemainingTime);
+		dwRemainingTime -= dwConsumedTime;
+
+		if (IsCurrentCommandFinished()) {
+			FinishCommand(this->commands[this->index], this->executionState);
+			++this->index;
+			StartNextCommand();
+		}
+		else
+			break;
+	} while (CanContinuePlayingEffect(dwRemainingTime));
+
+	if (dwRemainingTime > 0)
+		dwRemainingTime -= UpdateParallelCommands(dwRemainingTime);
+
+	if (dwRemainingTime > 0 && IsCommandQueueFinished()) {
+		if (wInitialIndex == (UINT)-1 && dwRemainingTime == wDeltaTime)
+			return false; // Infinite loop protection
+
+		++this->loopIteration;
+		if (!CanLoop())
+			return false;
+
+		//Loop
+		InitParams();
+		this->index = (UINT)-1;
+		AdvanceState(dwRemainingTime);
+	}
+
+	return CanLoop() || !IsCommandQueueFinished();
+}
+
+bool CImageOverlayEffect::CanLoop() const
+{
+	return this->maxLoops == ImageOverlayCommand::NO_LOOP_MAX || this->loopIteration < this->maxLoops;
+}
+
+bool CImageOverlayEffect::CanContinuePlayingEffect(const Uint32 dwRemainingTIme) const
+{
+	// There are no more effects to play, so AdvanceState() has to handle looping nopw
+	if (IsCommandQueueFinished())
+		return false;
+
+	// If there is any remaining time then continue playing commands
+	if (dwRemainingTIme > 0)
+		return true;
+
+	// If it's a time based command we need to stop
+	return !IsTimeBasedCommand(this->commands[this->index].type);
+}
+
+bool CImageOverlayEffect::IsCommandQueueFinished() const
+{
+	return this->index >= this->commands.size();
+}
+
+bool CImageOverlayEffect::IsCurrentCommandFinished() const
+{
+	if (IsCommandQueueFinished())
+		return true;
+
+	const ImageOverlayCommand command = this->commands[this->index];
+	if (IsTimeBasedCommand(command.type))
+		return this->executionState.remainingTime == 0;
+
+	else if (IsTurnBasedCommand(command.type)) {
+		const CDbRoom* pRoom = this->pRoomWidget->GetRoom();
+		const UINT gameTurn = pRoom ? pRoom->GetCurrentGame()->wPlayerTurn : 0;
+
+		return this->executionState.endTurn == gameTurn;
+	}
+	else
+		return true;
+}
+
+Uint32 CImageOverlayEffect::UpdateCommand(
+	const ImageOverlayCommand& command,     //(in) Command to be updated
+	CommandExecution& executionState,       //(in) Command's execution state
+	const Uint32 wRemainingTime)            //(in) Amount of time that the command can consume
+	// Updates the consumed time in the execution state and updates the display state of the image to match the command
+	// Returns: amount of milliseconds consumed by the effect
+{
+	// Non-time-based commands do nothing here
+	if (!IsTimeBasedCommand(command.type))
+		return 0;
+
+	// Parallel commands executed
+	const Uint32 dwConsumedTime = min(executionState.remainingTime, wRemainingTime);
+	executionState.remainingTime -= dwConsumedTime;
+
+	const float t = 1.0f - (float(executionState.remainingTime) / float(executionState.duration));
+	switch (command.type) {
+	case ImageOverlayCommand::FadeToAlpha:
+	{
+		const int deltaAlpha = command.val[0] - executionState.startAlpha;
+		this->alpha = clipAlpha(executionState.startAlpha + int(deltaAlpha * t));
+	}
+	break;
+	case ImageOverlayCommand::Grow:
+	{
+		const int deltaScale = command.val[0];
+		this->scale = clipScale(executionState.startScale + int(deltaScale * t));
+		this->bPrepareAlteredImage = true;
+	}
+	break;
+	case ImageOverlayCommand::Jitter:
+		//nothing to do here
+		break;
+	case ImageOverlayCommand::Move:
+	{
+		const int deltaX = command.val[0];
+		const int deltaY = command.val[1];
+		this->x = executionState.startX + int(deltaX * t);
+		this->y = executionState.startY + int(deltaY * t);
+	}
+	break;
+	case ImageOverlayCommand::MoveTo:
+	{
+		const int deltaX = command.val[0] - executionState.startX;
+		const int deltaY = command.val[1] - executionState.startY;
+		this->x = executionState.startX + int(deltaX * t);
+		this->y = executionState.startY + int(deltaY * t);
+	}
+	break;
+	case ImageOverlayCommand::Rotate:
+	{
+		const int deltaAngle = command.val[0];
+		this->angle = clipAngle(executionState.startAngle + int(deltaAngle * t));
+		this->bPrepareAlteredImage = true;
+	}
+	break;
+	default: break;
+	}
+
+	return dwConsumedTime;
+}
+
+
+Uint32 CImageOverlayEffect::UpdateParallelCommands(const Uint32 dwDeltaTime)
+// Updates the parallel commands, removing them when finished
+// Returns: the max number of milliseconds consumed by any parallel commands
+{
+	if (this->parallelCommands.empty())
+		return 0;
+
+	vector<ParallelCommand> continuingCommands;
+	Uint32 maxConsumedTime = 0;
+
+	for (vector<ParallelCommand>::iterator it = this->parallelCommands.begin();
+		it != this->parallelCommands.end(); ++it)
+	{
+		ParallelCommand& c = *it;
+		const Uint32 dwConsumedTime = UpdateCommand(c.command, c.executionState, dwDeltaTime);
+
+		if (dwConsumedTime > maxConsumedTime)
+			maxConsumedTime = max(maxConsumedTime, dwConsumedTime);
+
+		if (c.executionState.remainingTime == 0) {
+			FinishCommand(c.command, c.executionState);
+		}
+		else
+			continuingCommands.push_back(c);
+	}
+
+	this->parallelCommands = continuingCommands;
+
+	return maxConsumedTime;
+}
+
+
+void CImageOverlayEffect::StartNextCommand()
+{
+	this->executionState.duration = this->startOfNextEffect;
+	this->executionState.remainingTime = UINT(-1);
+	this->executionState.endTurn = UINT(-1);
+
+	if (IsCommandQueueFinished())
+		return;
+
+	const ImageOverlayCommand command = this->commands[this->index];
+
+	const ImageOverlayCommand::IOC curCommand = command.type;
+	int val = command.val[0];
+	switch (curCommand) {
+	case ImageOverlayCommand::CancelAll:
+	case ImageOverlayCommand::CancelGroup:
+	case ImageOverlayCommand::CancelLayer:
+	case ImageOverlayCommand::Group:
+	case ImageOverlayCommand::Layer:
+		// Do nothing, these are handled externally
+		return;
+
+	case ImageOverlayCommand::AddX:
+		this->x += val;
+		break;
+	case ImageOverlayCommand::AddY:
+		this->y += val;
+		break;
+
+	case ImageOverlayCommand::Center:
+		this->x = (int(this->pRoomWidget->GetW()) - int(this->pImageSurface->w)) / 2;
+		this->y = (int(this->pRoomWidget->GetH()) - int(this->pImageSurface->h)) / 2;
+		break;
+
+	case ImageOverlayCommand::DisplayDuration:
+		this->executionState.remainingTime = this->executionState.duration = max(0, val);
+		break;
+
+	case ImageOverlayCommand::DisplayRect:
+		this->sourceClipRect.x = max(0, val);
+		this->sourceClipRect.y = max(0, command.val[1]);
+		this->sourceClipRect.w = min(max(0, command.val[2]), this->pImageSurface->w);
+		this->sourceClipRect.h = min(max(0, command.val[3]), this->pImageSurface->h);
+		break;
+
+	case ImageOverlayCommand::DisplayRectModify:
+		this->sourceClipRect.x = max(0, this->sourceClipRect.x + val);
+		this->sourceClipRect.y = max(0, this->sourceClipRect.y + command.val[1]);
+		this->sourceClipRect.w = min(max(0, this->sourceClipRect.w + command.val[2]), this->pImageSurface->w);
+		this->sourceClipRect.h = min(max(0, this->sourceClipRect.h + command.val[3]), this->pImageSurface->h);
+
+	case ImageOverlayCommand::DisplaySize:
+		this->sourceClipRect.w = min(max(0, val), this->pImageSurface->w);
+		this->sourceClipRect.h = min(max(0, command.val[1]), this->pImageSurface->h);
+		break;
+
+	case ImageOverlayCommand::FadeToAlpha:
+		this->executionState.remainingTime = this->executionState.duration = max(0, command.val[1]);
+		this->executionState.startAlpha = this->alpha;
+		break;
+
+	case ImageOverlayCommand::ParallelFadeToAlpha:
+	{
+		ParallelCommand c(command, this->executionState);
+		c.command.type = ImageOverlayCommand::FadeToAlpha;
+		c.executionState.duration = max(0, command.val[1]);
+		c.executionState.remainingTime = max(0, command.val[1]);
+		c.executionState.startAlpha = this->alpha;
+		this->parallelCommands.push_back(c);
+	}
+	break;
+
+	case ImageOverlayCommand::Grow:
+		this->executionState.startScale = this->scale;
+		this->executionState.remainingTime = this->executionState.duration = max(0, command.val[1]);
+		break;
+
+	case ImageOverlayCommand::ParallelGrow:
+	{
+		ParallelCommand c(command, this->executionState);
+		c.command.type = ImageOverlayCommand::Grow;
+		c.executionState.startScale = this->scale;
+		c.executionState.duration = max(0, command.val[1]);
+		c.executionState.remainingTime = max(0, command.val[1]);
+		this->parallelCommands.push_back(c);
+	}
+	break;
+
+	case ImageOverlayCommand::Jitter:
+		this->jitter = max(0, val);
+		this->executionState.remainingTime = this->executionState.duration = max(0, command.val[1]);
+		break;
+
+	case ImageOverlayCommand::ParallelJitter:
+	{
+		this->jitter = max(0, val);
+
+		ParallelCommand c(command, this->executionState);
+		c.command.type = ImageOverlayCommand::Jitter;
+		c.executionState.duration = max(0, command.val[1]);
+		c.executionState.remainingTime = max(0, command.val[1]);
+		this->parallelCommands.push_back(c);
+	}
+	break;
+
+	break;
+
+	case ImageOverlayCommand::Loop:
+		this->maxLoops = val;
+		break;
+
+	case ImageOverlayCommand::Move:
+	case ImageOverlayCommand::MoveTo:
+		this->executionState.startX = this->x;
+		this->executionState.startY = this->y;
+		this->executionState.remainingTime = this->executionState.duration = max(0, command.val[2]);
+		break;
+	case ImageOverlayCommand::ParallelMove:
+	case ImageOverlayCommand::ParallelMoveTo:
+	{
+		ParallelCommand c(command, this->executionState);
+		c.command.type = c.command.type == ImageOverlayCommand::ParallelMove
+			? ImageOverlayCommand::Move
+			: ImageOverlayCommand::MoveTo;
+		c.executionState.startX = this->x;
+		c.executionState.startY = this->y;
+		c.executionState.duration = max(0, command.val[1]);
+		c.executionState.remainingTime = max(0, command.val[1]);
+		this->parallelCommands.push_back(c);
+	}
+	break;
+
+	case ImageOverlayCommand::Repeat: {
+		this->repetitions = max(0, val);
+		this->xRepeatOffset = command.val[1];
+		this->yRepeatOffset = command.val[2];
+	}
+																	break;
+
+	case ImageOverlayCommand::Rotate:
+		this->executionState.startAngle = this->angle;
+		this->executionState.remainingTime = this->executionState.duration = max(0, command.val[1]);
+		break;
+
+	case ImageOverlayCommand::ParallelRotate:
+	{
+		ParallelCommand c(command, this->executionState);
+		c.command.type = ImageOverlayCommand::Rotate;
+		c.executionState.startAngle = this->angle;
+		c.executionState.duration = max(0, command.val[1]);
+		c.executionState.remainingTime = max(0, command.val[1]);
+		this->parallelCommands.push_back(c);
+	}
+	break;
+
+	case ImageOverlayCommand::Scale:
+		this->scale = clipScale(val);
+		this->bPrepareAlteredImage = true;
+		break;
+	case ImageOverlayCommand::SetAlpha:
+		this->alpha = clipAlpha(val);
+		break;
+	case ImageOverlayCommand::SetAngle:
+		this->angle = clipAngle(val);
+		this->bPrepareAlteredImage = true;
+		break;
+	case ImageOverlayCommand::SetX:
+		this->x = val;
+		break;
+	case ImageOverlayCommand::SetY:
+		this->y = val;
+		break;
+	case ImageOverlayCommand::SrcXY:
+		this->sourceClipRect.x = max(0, val);
+		this->sourceClipRect.y = max(0, command.val[1]);
+		break;
+
+	case ImageOverlayCommand::TileGrid:
+	{
+		this->xTile = max(0, val);
+		this->yTile = max(0, command.val[1]);
+		this->bPrepareAlteredImage = true;
+	}
+	break;
+
+	case ImageOverlayCommand::TurnDuration:
+	{
+		const CDbRoom* pRoom = this->pRoomWidget->GetRoom();
+		const UINT gameTurn = pRoom ? pRoom->GetCurrentGame()->wPlayerTurn : 0;
+		this->executionState.endTurn = gameTurn + max(0, val);
+	}
+	break;
+	}
+}
+
+void CImageOverlayEffect::FinishCommand(
+	// Finalizes state update of a given command
+	const ImageOverlayCommand& command,
+	const CommandExecution& executionState)
+{
+	switch (command.type) {
+	case ImageOverlayCommand::FadeToAlpha:
+		this->alpha = clipAlpha(command.val[0]);
+		break;
+	case ImageOverlayCommand::Grow:
+		this->scale = clipScale(executionState.startScale + command.val[0]);
+		this->bPrepareAlteredImage = true;
+		break;
+	case ImageOverlayCommand::Jitter:
+		this->jitter = 0;
+		break;
+	case ImageOverlayCommand::Move:
+		this->x = executionState.startX + command.val[0];
+		this->y = executionState.startY + command.val[1];
+		break;
+	case ImageOverlayCommand::MoveTo:
+		this->x = command.val[0];
+		this->y = command.val[1];
+		break;
+	case ImageOverlayCommand::Rotate:
+		this->angle = clipAngle(executionState.startAngle + command.val[0]);
+		this->bPrepareAlteredImage = true;
+		break;
+	case ImageOverlayCommand::TurnDuration:
+		// This is required for any time-based command that runs afterwards to correctly
+		// calculate the start time
+		this->startOfNextEffect = CScreen::dwCurrentTicks;
+		break;
+	case ImageOverlayCommand::ParallelFadeToAlpha:
+	case ImageOverlayCommand::ParallelRotate:
+	case ImageOverlayCommand::ParallelMoveTo:
+	case ImageOverlayCommand::ParallelMove:
+	case ImageOverlayCommand::ParallelJitter:
+	case ImageOverlayCommand::ParallelGrow:
+	default: break;
+	}
+}
+
+bool CImageOverlayEffect::PositionDisplayInsideRect(
+	SDL_Rect& src, SDL_Rect& dest,
+	int display_x, int display_y)
+	const
+{
+	if (display_x >= 0) {
+		dest.x += display_x;
+
+		if (display_x >= dest.w)
+			return false;
+		dest.w -= display_x;
+	}
+	else {
+		const int delta = -display_x;
+		src.x = delta;
+
+		if (src.w <= delta)
+			return false;
+		src.w -= delta;
+	}
+	if (src.w > dest.w)
+		src.w = dest.w;
+	else if (dest.w > src.w)
+		dest.w = src.w;
+
+	if (display_y >= 0) {
+		dest.y += display_y;
+
+		if (display_y >= dest.h)
+			return false;
+		dest.h -= display_y;
+	}
+	else {
+		const int delta = -display_y;
+		src.y = delta;
+
+		if (src.h <= delta)
+			return false;
+		src.h -= delta;
+	}
+	if (src.h > dest.h)
+		src.h = dest.h;
+	else if (dest.h > src.h)
+		dest.h = src.h;
+
+	return true;
+}
+
+void CImageOverlayEffect::PrepareAlteredImage()
+{
+	if (this->pAlteredSurface) {
+		SDL_FreeSurface(this->pAlteredSurface);
+		this->pAlteredSurface = NULL;
+	}
+
+	if (this->angle || this->scale != ORIGINAL_SCALE) {
+		if (this->scale != ORIGINAL_SCALE) {
+			const SDL_Surface* pSurface = this->pImageSurface;
+			const Uint8* pSrcPixel = (Uint8*)pSurface->pixels;
+			const int new_width = pSurface->w * this->scale / 100;
+			const int new_height = pSurface->h * this->scale / 100;
+			this->pAlteredSurface = g_pTheDBM->ScaleSurface(pSurface, pSrcPixel,
+				pSurface->w, pSurface->h, new_width, new_height);
+		}
+
+		if (this->angle) {
+			SDL_Surface* pSurface = this->pAlteredSurface ? this->pAlteredSurface : this->pImageSurface;
+			Uint8* pSrcPixel = (Uint8*)pSurface->pixels;
+			SDL_Surface* pRotatedSurface = g_pTheDBM->RotateSurface(pSurface,
+				pSrcPixel, pSurface->w, pSurface->h, float(this->angle));
+			if (pRotatedSurface) {
+				if (this->pAlteredSurface)
+					SDL_FreeSurface(this->pAlteredSurface);
+				this->pAlteredSurface = pRotatedSurface;
+			}
+		}
+	}
+
+	if (this->IsTiled() && !this->angle) {
+		SDL_Surface* pSurface = this->pAlteredSurface ? this->pAlteredSurface : this->pImageSurface;
+		SDL_Surface* pTiledSurface = TileSurface(pSurface);
+		if (pTiledSurface) {
+			if (this->pTiledSurface)
+				SDL_FreeSurface(this->pTiledSurface);
+			this->pTiledSurface = pTiledSurface;
+		}
+	}
+}
+
+//*****************************************************************************
+// Creates a new surface by creating a repeating grid of the given surface.
+// Grid size is determined by the xTile and yTile values.
+SDL_Surface* CImageOverlayEffect::TileSurface(SDL_Surface* pSurface)
+{
+	ASSERT(this->xTile > 0);
+	ASSERT(this->yTile > 0);
+
+	SDL_Rect srcRect = {
+		this->sourceClipRect.x,
+		this->sourceClipRect.y,
+		this->sourceClipRect.w > 0 ? this->sourceClipRect.w : this->pImageSurface->w,
+		this->sourceClipRect.h > 0 ? this->sourceClipRect.h : this->pImageSurface->h,
+	};
+	if (this->scale != ORIGINAL_SCALE) {
+		srcRect.w *= (scale / 100);
+		srcRect.h *= (scale / 100);
+	}
+
+	SDL_Rect destRect = { 0, 0, srcRect.w, srcRect.h };
+
+	int newWidth = srcRect.w * this->xTile;
+	int newHeight = srcRect.h * this->yTile;
+	SDL_Surface* pDestSurface = g_pTheBM->CreateNewSurfaceLike(pSurface, newWidth, newHeight);
+
+	for (int i = 0; i < xTile; ++i) {
+		destRect.x = destRect.w * i;
+		for (int j = 0; j < yTile; ++j) {
+			destRect.y = destRect.h * j;
+			SDL_BlitSurface(pSurface, &srcRect, pDestSurface, &destRect);
+		}
+	}
+
+	return pDestSurface;
+}
+
+bool CImageOverlayEffect::IsTimeBasedCommand(const ImageOverlayCommand::IOC commandType) const {
+	switch (commandType) {
+		// Intentionally excluded parallel commands, see IsInstantCommand()
+	case ImageOverlayCommand::DisplayDuration:
+	case ImageOverlayCommand::FadeToAlpha:
+	case ImageOverlayCommand::Grow:
+	case ImageOverlayCommand::Jitter:
+	case ImageOverlayCommand::Move:
+	case ImageOverlayCommand::MoveTo:
+	case ImageOverlayCommand::Rotate:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool CImageOverlayEffect::IsTurnBasedCommand(const ImageOverlayCommand::IOC commandType) const {
+	return commandType == ImageOverlayCommand::TurnDuration;
+}
+
+bool CImageOverlayEffect::IsInstantCommand(const ImageOverlayCommand::IOC commandType) const {
+	switch (commandType) {
+	case ImageOverlayCommand::AddX:
+	case ImageOverlayCommand::AddY:
+	case ImageOverlayCommand::CancelAll:
+	case ImageOverlayCommand::CancelGroup:
+	case ImageOverlayCommand::CancelLayer:
+	case ImageOverlayCommand::Center:
+	case ImageOverlayCommand::DisplayRect:
+	case ImageOverlayCommand::DisplayRectModify:
+	case ImageOverlayCommand::DisplaySize:
+	case ImageOverlayCommand::Repeat:
+	case ImageOverlayCommand::Rotate:
+	case ImageOverlayCommand::Scale:
+	case ImageOverlayCommand::SetAlpha:
+	case ImageOverlayCommand::SetAngle:
+	case ImageOverlayCommand::SetX:
+	case ImageOverlayCommand::SetY:
+	case ImageOverlayCommand::SrcXY:
+	case ImageOverlayCommand::TileGrid:
+		// Parallel commands may take time but they run parallelly so for the purpose of occupying
+		// effect's time they are instant
+	case ImageOverlayCommand::ParallelFadeToAlpha:
+	case ImageOverlayCommand::ParallelJitter:
+	case ImageOverlayCommand::ParallelMove:
+	case ImageOverlayCommand::ParallelMoveTo:
+	case ImageOverlayCommand::ParallelRotate:
+	case ImageOverlayCommand::Invalid:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool CImageOverlayEffect::IsParallelCommand(const ImageOverlayCommand::IOC commandType) const {
+	switch (commandType) {
+	case ImageOverlayCommand::ParallelFadeToAlpha:
+	case ImageOverlayCommand::ParallelGrow:
+	case ImageOverlayCommand::ParallelJitter:
+	case ImageOverlayCommand::ParallelMove:
+	case ImageOverlayCommand::ParallelMoveTo:
+	case ImageOverlayCommand::ParallelRotate:
+		return true;
+	default:
+		return false;
+	}
+}

--- a/drodrpg/DROD/ImageOverlayEffect.h
+++ b/drodrpg/DROD/ImageOverlayEffect.h
@@ -1,0 +1,147 @@
+// $Id$
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2002, 2005, 2012, 2024
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s): Mike Rimer (mrimer)
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#ifndef IMAGEOVERLAYEFFECT_H
+#define IMAGEOVERLAYEFFECT_H
+
+#include "../DRODLib/CharacterCommand.h"
+#include <FrontEndLib/Effect.h>
+
+struct CommandExecution
+{
+	CommandExecution()
+		: duration(0), remainingTime(0)
+		, startAlpha(0)
+		, startX(0), startY(0)
+		, startAngle(0), startScale(0)
+	{ }
+
+	Uint32 duration, remainingTime;
+	Uint8 startAlpha;
+	int startX, startY;
+	int startAngle;
+	int startScale;
+	UINT endTurn;
+};
+
+struct ParallelCommand
+{
+	ParallelCommand(const ImageOverlayCommand& command, const CommandExecution& ce)
+		: command(command)
+		, executionState(ce)
+	{ }
+
+	ImageOverlayCommand command;
+	CommandExecution executionState;
+};
+
+class CImageOverlay;
+class CRoomWidget;
+class CImageOverlayEffect : public CEffect
+{
+public:
+	CImageOverlayEffect(CWidget* pSetWidget, const CImageOverlay* pImageOverlay, const UINT turnNo,
+		const Uint32 dwStartTime);
+	virtual ~CImageOverlayEffect();
+
+	virtual long GetDrawSequence() const { return drawSequence; }
+
+	UINT getInstanceID() const { return instanceID; }
+	UINT getStartTurn() const { return turnNo; }
+
+	int getGroup() const;
+
+protected:
+	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
+	virtual void Draw(SDL_Surface& destSurface);
+
+private:
+	bool AdvanceState(const UINT wDeltaTime);
+
+	void DrawRepeated(SDL_Surface* srcSurface, SDL_Surface* destSurface);
+
+	Uint32 UpdateCommand(const ImageOverlayCommand& command, CommandExecution& ce, const Uint32 dwRemainingTime);
+	Uint32 UpdateParallelCommands(const Uint32 dwDeltaTime);
+	bool IsCurrentCommandFinished() const;
+	bool CanContinuePlayingEffect(const Uint32 dwRemainingTime) const;
+	bool CanLoop() const;
+	inline bool IsCommandQueueFinished() const;
+	bool IsImageDrawn();
+	bool IsRepeated() const;
+	bool IsTiled() const;
+	void PrepareDrawProperties();
+	void StartNextCommand();
+	void FinishCommand(const ImageOverlayCommand& command, const CommandExecution& ce);
+
+	bool IsTimeBasedCommand(const ImageOverlayCommand::IOC commandType) const;
+	bool IsTurnBasedCommand(const ImageOverlayCommand::IOC commandType) const;
+	bool IsInstantCommand(const ImageOverlayCommand::IOC commandType) const;
+	bool IsParallelCommand(const ImageOverlayCommand::IOC commandType) const;
+
+	void InitParams();
+
+	bool PositionDisplayInsideRect(SDL_Rect& src, SDL_Rect& dest,
+		int display_x, int display_y) const;
+
+	void PrepareAlteredImage();
+
+	SDL_Surface* TileSurface(SDL_Surface* pSurface);
+
+	long drawSequence;
+
+	SDL_Surface* pImageSurface, * pAlteredSurface, * pTiledSurface;
+	bool bPrepareAlteredImage;
+
+	int x, y; // Real position of the image
+	Uint8 alpha;
+	int angle;
+	int scale;
+	int jitter;
+	int xTile, yTile;
+	int repetitions, xRepeatOffset, yRepeatOffset;
+	SDL_Rect sourceClipRect;
+
+	// Properties used for the drawing
+	int drawX, drawY; // Position to draw image after applying any active effects
+	Uint8 drawAlpha;
+	SDL_Rect drawSourceRect;
+	SDL_Rect drawDestinationRect;
+
+	ImageOverlayCommands commands;
+	UINT index;
+	int loopIteration, maxLoops;
+	Uint32 startOfNextEffect;
+
+	CommandExecution executionState;
+	vector<ParallelCommand> parallelCommands;
+
+	CRoomWidget* pRoomWidget;
+	UINT turnNo;
+
+	UINT instanceID; //for merging effect sets during play after move undo/checkpoint restore
+};
+
+#endif //...#ifndef IMAGEOVERLAYEFFECT_H

--- a/drodrpg/DROD/RestoreScreen.cpp
+++ b/drodrpg/DROD/RestoreScreen.cpp
@@ -753,6 +753,9 @@ void CRestoreScreen::UpdateWidgets()
 	if (IsCursorVisible())
 		SetCursor(CUR_Wait);
 	VERIFY(this->pRoomWidget->LoadFromCurrentGame(this->pCurrentRestoreGame));
+	CCueEvents Ignored;
+	this->pRoomWidget->DisplayPersistingImageOverlays(Ignored);
+
 	VERIFY(this->pMapWidget->LoadFromCurrentGame(this->pCurrentRestoreGame));
 	if (IsCursorVisible())
 		SetCursor();

--- a/drodrpg/DROD/RoomEffectList.cpp
+++ b/drodrpg/DROD/RoomEffectList.cpp
@@ -25,6 +25,7 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
+#include "ImageOverlayEffect.h"
 #include "RoomEffectList.h"
 #include "RoomWidget.h"
 #include <BackEndLib/Assert.h>
@@ -161,6 +162,43 @@ void CRoomEffectList::RemoveEffectsOfType(
 			++iSeek;
 			this->Effects.remove(pDelete);
 			delete pDelete;
+		}
+		else
+			++iSeek;
+	}
+}
+
+//*****************************************************************************
+void CRoomEffectList::RemoveOverlayEffectsInGroup(
+//Removes all image overlay effects in the given group from the list.
+//
+//Params:
+	const int clearGroup,//(in) Overlay group to remove
+	 bool bForceClearAll) //if set [default=true], delete all effects,
+//including those that request to be retained
+{
+	list<CEffect*>::const_iterator iSeek = this->Effects.begin();
+	while (iSeek != this->Effects.end())
+	{
+		if ((*iSeek)->GetEffectType() == EIMAGEOVERLAY)
+		{
+			//Remove from list.
+			CEffect* pDelete = *iSeek;
+			ASSERT(pDelete);
+			if (pDelete->RequestsRetainOnClear() && !bForceClearAll)
+			{
+				++iSeek;
+				continue;
+			}
+
+			CImageOverlayEffect* pDeleteOverlay = DYN_CAST(CImageOverlayEffect*, CEffect*, pDelete);
+
+			if (pDeleteOverlay->getGroup() == clearGroup) {
+				DirtyTilesForRects(pDelete->dirtyRects);  //touch up area before deleting
+				++iSeek;
+				this->Effects.remove(pDelete);
+				delete pDelete;
+			}
 		}
 		else
 			++iSeek;

--- a/drodrpg/DROD/RoomEffectList.h
+++ b/drodrpg/DROD/RoomEffectList.h
@@ -44,6 +44,7 @@ public:
 	void           DirtyTilesInRect(const UINT xStart, const UINT yStart,
 			const UINT xEnd, const UINT yEnd) const;
 	virtual void   RemoveEffectsOfType(const UINT eEffectType, const bool bForceClearAll=true);
+	virtual void   RemoveOverlayEffectsInGroup(const int clearGroup, const bool bForceClearAll = true);
 
 protected:
 	CRoomWidget *pOwnerWidget;

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -220,6 +220,7 @@ public:
 			const Uint32 dwDuration, const UINT displayLines=1, const SDL_Color& color=Black,
 			const UINT fadeDuration=500);
 	void           AddJitter(const CMoveCoord& coord, const float fDamagePercent);
+	void           AddLayerEffect(CEffect* pEffect, int layer);
 	void           AddLastLayerEffect(CEffect *pEffect);
 	void           AddMLayerEffect(CEffect *pEffect);
 	void           AddOLayerEffect(CEffect *pEffect);
@@ -237,6 +238,7 @@ public:
 	bool           AreCheckpointsVisible() const {return this->bShowCheckpoints;}
 	void           ClearEffects(const bool bKeepFrameRate = true);
 	void           DirtyRoom() {this->bAllDirty = true;}
+	void           DisplayPersistingImageOverlays(CCueEvents& CueEvents);
 	virtual void   DisplayChatText(const WSTRING& text, const SDL_Color& color);
 	void				DisplayRoomCoordSubtitle(const int nMouseX, const int nMouseY);
 	void           DisplaySubtitle(const WCHAR *pText, const UINT wX, const UINT wY,
@@ -247,8 +249,9 @@ public:
 	virtual void   DrawMonsters(CMonster *const pMonsterList,
 			SDL_Surface *pDestSurface, const bool bActionIsFrozen,
 			const bool bMoveInProgress=false);
-	void				FadeToLightLevel(const UINT wNewLight);
+	void				FadeToLightLevel(const UINT wNewLight, CCueEvents& CueEvents);
 	void           FinishMoveAnimation() {this->dwCurrentDuration = this->dwMoveDuration;}
+	CRoomEffectList* GetEffectListForLayer(const int layer) const;
 	WSTRING        GetInvisibleCharacterInfo(const UINT wX, const UINT wY) const;
 	void           GetSquareRect(UINT wCol, UINT wRow, SDL_Rect &SquareRect) const;
 	static UINT    GetKeyMID(const UINT param);
@@ -297,7 +300,9 @@ public:
 	void           PutTLayerEffectsOnMLayer();
 
 	void           RedrawMonsters(SDL_Surface* pDestSurface);
+	void           RemoveGroupEffects(int clearGroup);
 	void           RemoveLastLayerEffectsOfType(const EffectType eEffectType, const bool bForceClearAll=true);
+	void           RemoveLayerEffects(const EffectType eEffectType, int layer);
 	void           RemoveMLayerEffectsOfType(const EffectType eEffectType);
 	void           RemoveOLayerEffectsOfType(const EffectType eEffectType);
 	void           RemoveTLayerEffectsOfType(const EffectType eEffectType);
@@ -325,7 +330,7 @@ public:
 	virtual void   SetPlot(const UINT /*wCol*/, const UINT /*wRow*/) {}
 	void           ShowCheckpoints(const bool bVal=true) {this->bShowCheckpoints = bVal;}
 	void           ShowDamagePreview(const bool bVal = true) { this->bShowDamagePreview = bVal; }
-	void           ShowRoomTransition(const UINT wExitOrientation, const bool bShowPlayer = false);
+	void           ShowRoomTransition(const UINT wExitOrientation, CCueEvents& CueEvents, const bool bShowPlayer = false);
 	void           ShowPlayer(const bool bFlag=true) {this->bShowingPlayer = bFlag;}
 	void           StopSleeping();
 	bool           SubtitlesHas(CSubtitleEffect *pEffect) const;
@@ -434,6 +439,7 @@ protected:
 	float          getTileElev(const UINT i, const UINT j) const;
 	float          getTileElev(const UINT wOTile) const;
 	void           GetWeather();
+	bool           IsPersistentEffectPlaying(CEffectList* pEffectList, const UINT instanceID) const;
 	void           JitterBoundsCheck(const UINT wX, const UINT wY,
 			UINT& wXOffset, UINT& wYOffset);
 	void           LowPassLightFilter(LIGHTTYPE *pSrc, LIGHTTYPE *pDest,
@@ -577,6 +583,7 @@ private:
 
 	void           PlacePlayerLightAt(int pixel_x, int pixel_y);
 	void           PropagatePlayerLight();
+	void           RemoveEffectsQueuedForRemoval();
 	void           RenderPlayerLight();
 	void           ResetPlayerLightMap();
 	void           ResetUserLightsource();
@@ -593,6 +600,8 @@ private:
 	Uint32         time_of_last_sky_move;
 
 	bool           bShowDamagePreview;
+
+	multimap<EffectType, int> queued_layer_effect_type_removal;
 };
 
 #endif //#ifndef ROOMWIDGET_H

--- a/drodrpg/DROD/drod.2019.vcxproj.filters
+++ b/drodrpg/DROD/drod.2019.vcxproj.filters
@@ -235,6 +235,9 @@
     <ClCompile Include="IceMeltEffect.cpp">
       <Filter>Effects</Filter>
     </ClCompile>
+    <ClCompile Include="ImageOverlayEffect.cpp">
+      <Filter>Effects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Chat.h">
@@ -454,6 +457,9 @@
       <Filter>General</Filter>
     </ClInclude>
     <ClInclude Include="IceMeltEffect.h">
+      <Filter>Effects</Filter>
+    </ClInclude>
+    <ClInclude Include="ImageOverlayEffect.h">
       <Filter>Effects</Filter>
     </ClInclude>
   </ItemGroup>

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -180,6 +180,7 @@ inline bool bCommandHasData(const UINT eCommand)
 		case CCharacterCommand::CC_AmbientSoundAt:
 		case CCharacterCommand::CC_PlayVideo:
 		case CCharacterCommand::CC_SetMusic:
+		case CCharacterCommand::CC_ImageOverlay:
 			return true;
 		default:
 			return false;
@@ -381,6 +382,7 @@ void CCharacter::ChangeHoldForCommands(
 				case CCharacterCommand::CC_AmbientSound:
 				case CCharacterCommand::CC_AmbientSoundAt:
 				case CCharacterCommand::CC_PlayVideo:
+				case CCharacterCommand::CC_ImageOverlay:
 					//Make a copy of the media object in the new hold.
 					CDbData::CopyObject(info, c.w, pNewHold->dwHoldID);
 				break;
@@ -2915,6 +2917,15 @@ void CCharacter::Process(
 				*pText = text.c_str();
 				CColorText* pColorText = new CColorText(pText, px, py, pw, ph);
 				CueEvents.Add(CID_FlashingMessage, pColorText, true);
+
+				bProcessNextCommand = true;
+			}
+			break;
+			case CCharacterCommand::CC_ImageOverlay:
+			{
+				//Display image (w) with display strategy (label).
+				const WSTRING text = pGame->ExpandText(command.label.c_str(), this);
+				CueEvents.Add(CID_ImageOverlay, new CImageOverlay(text, command.w, pGame->GetNextImageOverlayID()), true);
 
 				bProcessNextCommand = true;
 			}

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -274,6 +274,7 @@ public:
 		CC_LogicalWaitOr,       //Begins a logical wait block. Waits until at least one condition is true.
 		CC_LogicalWaitXOR,      //Begins a logical wait block. Waits until exactly one condition is true.
 		CC_LogicalWaitEnd,      //Ends a logical wait block.
+		CC_ImageOverlay,        //Display image (w) with display strategy (text).
 		CC_Count
 	};
 
@@ -320,6 +321,89 @@ public:
 	CDbMessageText* pText;
 	int r, g, b;
 	int customColor;
+};
+
+struct ImageOverlayCommand
+{
+	static const int NO_LOOP_MAX;
+	static const int DEFAULT_LAYER;
+	static const int ALL_LAYERS;
+	static const int NO_LAYERS;
+	static const int DEFAULT_GROUP;
+	static const int NO_GROUP;
+
+	enum IOC {
+		AddX,
+		AddY,
+		CancelAll,
+		CancelGroup,
+		CancelLayer,
+		Center,
+		DisplayDuration,
+		DisplayRect,
+		DisplayRectModify,
+		DisplaySize,
+		FadeToAlpha,
+		Group,
+		Grow,
+		Jitter,
+		Layer,
+		Loop,
+		Move,
+		MoveTo,
+		ParallelFadeToAlpha,
+		ParallelGrow,
+		ParallelJitter,
+		ParallelMove,
+		ParallelMoveTo,
+		ParallelRotate,
+		Repeat,
+		Rotate,
+		Scale,
+		SetAlpha,
+		SetAngle,
+		SetX,
+		SetY,
+		SrcXY,
+		TileGrid,
+		TurnDuration,
+		Invalid
+	};
+
+	ImageOverlayCommand(IOC type, int val[4])
+		: type(type)
+	{
+		memcpy(this->val, val, 4 * sizeof(int));
+	}
+
+	IOC type;
+	int val[4];
+};
+typedef std::vector<ImageOverlayCommand> ImageOverlayCommands;
+
+class CImageOverlay : public CAttachableObject
+{
+public:
+	CImageOverlay(const WSTRING& text, UINT imageID, UINT instanceID)
+		: CAttachableObject()
+		, imageID(imageID)
+		, instanceID(instanceID)
+	{
+		parse(text, commands);
+	}
+	~CImageOverlay();
+
+	static bool parse(const WSTRING& wtext, ImageOverlayCommands& commands);
+
+	int getLayer() const;
+	int getGroup() const;
+	int clearsImageOverlays() const;
+	int clearsImageOverlayGroup() const;
+	bool loopsForever() const;
+
+	ImageOverlayCommands commands;
+	UINT imageID;
+	UINT instanceID; //for merging effect sets during play on move undo/checkpoint restore
 };
 
 typedef std::vector<CCharacterCommand> COMMAND_VECTOR;

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -670,6 +670,11 @@ enum CUEEVENT_ID
 	//Private data: CCoord *pSquare (one or more)
 	CID_ThinIceMelted,
 
+	//Image overlay script command
+	//
+	//Private data: CImageOverlay* (one or more)
+	CID_ImageOverlay,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -257,6 +257,7 @@ public:
 	float    GetGlobalStatModifier(ScriptVars::StatModifiers statType) const;
 	float    GetTotalStatModifier(ScriptVars::StatModifiers statType) const;
 	UINT     getNewScriptID();
+	UINT     GetNextImageOverlayID();
 	UINT     getSpawnID(UINT defaultMonsterID) const;
 	WSTRING  getStringVar(const UINT varIndex) const;
 	WSTRING  getTextForInputCommandKey(InputCommands::DCMD id) const;
@@ -330,6 +331,7 @@ public:
 	void     ProcessSwordHit(const UINT wX, const UINT wY, CCueEvents &CueEvents,
 			CMonster *pDouble = NULL);
 	void     QuickSave();
+	void     RemoveClearedImageOverlays(const int clearLayers);
 	void     RestartRoom(CCueEvents &CueEvents);
 	void     SaveGame(const SAVETYPE eSaveType, const WSTRING& name);
 	void     SaveToContinue();
@@ -354,6 +356,7 @@ public:
 	bool     SetPlayerSwordSheathed();
 	void     SetTurn(UINT wSetTurnNo, CCueEvents &CueEvents);
 	bool     ShowLevelStart() const;
+	void     StashPersistingEvents(CCueEvents& CueEvents);
 //	void     TallyKill();
 	void     ToggleSwordDisarm();
 	void     TradeAccessory(CCueEvents& CueEvents, const UINT newEquipment, const bool bShowStatChanges=true);
@@ -405,6 +408,9 @@ public:
 	//Front-end effects.
 	MusicData music;
 	WSTRING  customRoomLocationText;
+	vector<CImageOverlay> persistingImageOverlays;
+
+	UINT imageOverlayNextID;
 
 	//Internet.
 //	static queue<DEMO_UPLOAD*> demosForUpload;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -807,6 +807,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ForceArrowDisabledNE: strText = "Disabled force arrow (northeast)"; break;
 		case MID_ForceArrowDisabledSE: strText = "Disabled force arrow (southeast)"; break;
 		case MID_ForceArrowDisabledSW: strText = "Disabled force arrow (southeast)"; break;
+		case MID_ImageOverlay: strText = "Image overlay"; break;
+		case MID_ImageOverlayStrategy: strText = "Image overlay strategy"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -26,7 +26,8 @@ There are five general classes of script commands, as follows:</p>
 <a href="#multichoiceexample">Example of a multiple choice question</a><br />
 <a href="#newmonsters">How to make a new monster type</a><br />
 <a href="#character-on-tarstuff">Character on tarstuff</a><br />
-<a href="#customequipment">How to make custom equipment</a>
+<a href="#customequipment">How to make custom equipment</a><br />
+<a href="#image-overlay-commands">Image Overlay commands</a>
 </p>
 <hr />
 <p><a name="placement"><b>1.&nbsp;&nbsp;Placement</b></a> - Change the NPC's location.</p>
@@ -315,6 +316,7 @@ interacts with its environment.</p>
   <li><a name="gameeffect"><b>Game effect</b></a> - Display a visual effect
 	  at a specified room location.  Particle effects may have a direction
 	  given them.  Some effects may play an optional accompanying sound effect.</li>
+  <li><a name="image-overlay"><b>Image overlay</b></a> - Input a <a href="#image-overlay-commands">custom set of commands</a> for displaying a custom image effect in the game room.</li>
 </ol>
 
 <p><a name="queries"><b>4.&nbsp;&nbsp;Queries</b></a> - Use queries to examine
@@ -1059,6 +1061,45 @@ Essentially, it's being treated as a Tarstuff Mother, although there are certain
   <li>The "Graphics" list selection and "Avatar" image are
     irrelevant for custom equipment.</li>
 </ol>
+
+<p><a name="image-overlay-commands"><b>Image overlay commands</b></a></p>
+  In addition to selecting an image for display with the "Image overlay" command, you must provide a simple set of commands to define how the image will be displayed in-game.  The list of supported (case-insensitive) commands for use in an Image Overlay script is as follows:<br />
+<br />
+<b>AddX (pixels)</b> -- shifts the image's X coordinate. Positive values shift to the right, negative values shift to the left.<br />
+<b>AddY (pixels)</b> -- shifts the image's Y coordinate. Positive values shift downwards, negative values shift upwards.<br />
+<b>CancelAll</b> -- remove all currently displaying image overlay effects. This command is typically run singly.<br />
+<b>CancelGroup (group #)</b> -- remove image overlay effects in the specified display group (0 or greater)<br />
+<b>CancelLayer (layer #)</b> -- remove image overlay effects on the specified display layer (0 through 3)<br />
+<b>Center</b> -- center the image within the room area<br />
+<b>Display (ms)</b> -- display the image in its current form for the specified duration<br />
+<b>DisplayRect (x) (y) (w) (h)</b> -- show this region of the source image<br />
+<b>DisplayRectModify (delta x) (delta y) (delta w) (delta h)</b> -- modifies the display region for the source image<br />
+<b>DisplaySize (w) (h)</b> -- show this amount of the source image, in pixels<br />
+<b>DisplayTurns (# turns)</b> -- display the image in its current form for the indicated number of game turns<br />
+<b>(p)FadeToAlpha (alpha) (ms)</b> -- transition the image from its current alpha value to the indicated value over the specified time interval<br />
+<b>Group (group #)</b> -- assign the effect to the given display group (0 or greater). Overlays without a Group command are assigned to Group #0. Only the first instance of this command in a script is executed.<br />
+<b>(p)Grow (percent of original) (ms)</b> -- scale the image by the indicated amount over the specified time interval<br />
+<b>(p)Jitter (pixels) (ms)</b> -- randomly shake the image off-center up to the indicated range for the specified time interval<br />
+<b>Layer (layer)</b> -- place the effect on the indicated display layer (0 through 3, generally corresponding to the menu tabs used for placing game elements in the room editor). Only the first instance of this command in a script is executed.<br />
+<b>Loop (times)</b> -- loop through the image command list this many times (-1 = infinite)<br />
+<b>(p)Move (x pixels) (y pixels) (ms)</b> -- translate the image's position by the indicated number of pixels over the indicated time interval<br />
+<b>(p)MoveTo (x pixel) (y pixel) (ms)</b> -- move the image from its current position to the indicated screen location over the course of the indicated time interval<br />
+<b>Repeat (repetions, x, y)</b> -- repeat the final image a positive number of times, with each copy offset from the previous image by x and y pixels, including in negative directions.<br />
+<b>(p)Rotate (degrees) (ms)</b> -- rotate the image the indicated amount over the specified time interval<br />
+<b>Scale (percent of original)</b> -- scale the image to the indicated amount<br />
+<b>SetAlpha (0-255)</b> -- set the image's alpha transparency to the indicated value<br />
+<b>SetAngle (degrees)</b> -- set the image's angle of rotation<br />
+<b>SetX (pixel)</b> -- set the image's X coordinate<br />
+<b>SetY (pixel)</b> -- set the image's Y coordinate<br />
+<b>SrcXY (x) (y)</b> - show the source image starting from the indicated pixel position<br />
+<b>TileGrid (w) (h)</b> -- replicate the image in a w by h grid. Tiling is not supported for images that have had rotations applied.<br />
+<br />
+As an example, you can make an image start invisible, fade in, display for a couple seconds, then fade out by providing the following command sequence:<br />
+<br />
+setalpha 0 fadetoalpha 255 1000 display 2000 fadetoalpha 0 800<br />
+<br />
+The text supports variable interpolation, so you can have parameters like "$.ImageX$" in the text. Any part of the command text may be inserted in this fashion.<br />
+Certain commands with time duration, marked above, may be optionally prefixed with the letter "p".  This indicates that the command will not run to completion before any subsequent commands are executed, but rather will run in parallel with the next command. Multiple parallel commands may be executed concurrently.<br />
 
 <hr />
 <a href="character.html">Character Scripting</a><br />

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1542,6 +1542,8 @@ enum MID_CONSTANT {
   MID_NotInvisibleInspectable = 1870,
   MID_ThinIceMelted = 1872,
   MID_IceMeltEffect = 1873,
+  MID_ImageOverlay = 1883,
+  MID_ImageOverlayStrategy = 1884,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1375,3 +1375,11 @@ Thin ice melted
 [MID_IceMeltEffect]
 [eng]
 Ice melting
+
+[MID_ImageOverlay]
+[eng]
+Image overlay
+
+[MID_ImageOverlayStrategy]
+[eng]
+Image overlay strategy


### PR DESCRIPTION
Adds support for Image overlays to RPG. The effect code is taken from the 5.2 dev branch in order to include the new image overlay commands.

All the wiring should be included, although it does touch a lot of places so it's possible I missed something.