### PR TITLE
RPG: Add DEF nullifying tile (mist)

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4198,6 +4198,7 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(T_TAR, g_pTheDB->GetMessageText(MID_Tar));
 	pListBox->AddItem(T_MIRROR, g_pTheDB->GetMessageText(MID_Mirror));
 	pListBox->AddItem(T_CRATE, g_pTheDB->GetMessageText(MID_Crate));
+	pListBox->AddItem(T_MIST, g_pTheDB->GetMessageText(MID_Mist));
 	pListBox->AddItem(T_HEALTH_HUGE, g_pTheDB->GetMessageText(MID_HugeHealth));
 	pListBox->AddItem(T_HEALTH_BIG, g_pTheDB->GetMessageText(MID_LargeHealth));
 	pListBox->AddItem(T_HEALTH_MED, g_pTheDB->GetMessageText(MID_MediumHealth));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -3993,6 +3993,7 @@ void CCharacterDialogWidget::PopulateEventListBox()
 	this->pEventListBox->AddItem(CID_Jump, g_pTheDB->GetMessageText(MID_PlayerJumped));
 	this->pEventListBox->AddItem(CID_LightToggled, g_pTheDB->GetMessageText(MID_LightToggled));
 	this->pEventListBox->AddItem(CID_MirrorShattered, g_pTheDB->GetMessageText(MID_MirrorShattered));
+	this->pEventListBox->AddItem(CID_MistDestroyed, g_pTheDB->GetMessageText(MID_MistDestroyed));
 	this->pEventListBox->AddItem(CID_MoneyDoorLocked, g_pTheDB->GetMessageText(MID_MoneyDoorLocked));
 	this->pEventListBox->AddItem(CID_MoneyDoorOpened, g_pTheDB->GetMessageText(MID_MoneyDoorOperated));
 	this->pEventListBox->AddItem(CID_MonsterBurned, g_pTheDB->GetMessageText(MID_MonsterBurned));

--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -450,6 +450,23 @@ void CDrodScreen::AddVisualCues(CCueEvents& CueEvents, CRoomWidget* pRoomWidget,
 			break;
 		}
 	}
+	for (pObj = CueEvents.GetFirstPrivateData(CID_MistDestroyed);
+		pObj != NULL; pObj = CueEvents.GetNextPrivateData())
+	{
+		const CMoveCoordEx* pCoord = DYN_CAST(const CMoveCoordEx*, const CAttachableObject*, pObj);
+		switch (pCoord->wValue)
+		{
+		case T_MIST:
+			if (bIsSolidOTile(pGame->pRoom->GetOSquare(pCoord->wX, pCoord->wY)))
+				pRoomWidget->AddTLayerEffect(
+					new CFluffInWallEffect(pRoomWidget, *pCoord));
+			else
+				pRoomWidget->AddTLayerEffect(
+					new CFluffStabEffect(pRoomWidget, *pCoord,
+						GetEffectDuration(pGame, 6), GetParticleSpeed(pGame, 2)));
+			break;
+		}
+	}
 
 	//Remove old sparks before drawing the current ones.
 	pRoomWidget->RemoveTLayerEffectsOfType(ESPARK);

--- a/drodrpg/DROD/DrodSound.cpp
+++ b/drodrpg/DROD/DrodSound.cpp
@@ -154,6 +154,7 @@ const
 		case SEID_POTION:    strKeyName="Potion"; break;
 		case SEID_PRESSPLATE:       strKeyName="PressPlate"; break;
 		case SEID_PRESSPLATEUP:       strKeyName="PressPlateUp"; break;
+		case SEID_PUFF_EXPLOSION:       strKeyName="PuffExplosion"; break;
 		case SEID_PUNCH:        strKeyName="Punch"; break;
 		case SEID_READ:         strKeyName="Read"; break;
 		case SEID_SECRET:    strKeyName="Secret"; break;
@@ -362,6 +363,7 @@ bool CDrodSound::LoadSoundEffects()
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_POTION );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_PRESSPLATE );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_PRESSPLATEUP );
+	SHARED_CHANNEL_SOUNDEFFECT( SEID_PUFF_EXPLOSION );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_PUNCH );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_READ );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_SECRET );

--- a/drodrpg/DROD/DrodSound.h
+++ b/drodrpg/DROD/DrodSound.h
@@ -140,6 +140,7 @@ enum SEID
 	SEID_SHOVEL_PICKUP,
 	SEID_DIG,
 	SEID_ICEMELT,
+	SEID_PUFF_EXPLOSION,
 
 	//Grouped sound effects -- may only play one at a time -- designated private channels.
 	//Channel n+1--Tendry's voice.

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -244,6 +244,7 @@ const UINT MenuDisplayTiles[TOTAL_EDIT_TILE_COUNT][4] =
 	{ TI_ARROW_OFF_SW },                               //T_ARROW_OFF_SW
 	{ TI_ARROW_OFF_W },                                //T_ARROW_OFF_W
 	{ TI_ARROW_OFF_NW },                               //T_ARROW_OFF_NW
+	{ TI_MIST },                                       //T_MIST
 
 	//monsters
 	{TI_ROACH_S},
@@ -410,6 +411,7 @@ const bool SinglePlacement[TOTAL_EDIT_TILE_COUNT] =
 	0, //T_ARROW_OFF_SW  112
 	0, //T_ARROW_OFF_W   113
 	0, //T_ARROW_OFF_NW  114
+	0, //T_MIST          115
 
 	0, //T_ROACH         +0
 	0, //T_QROACH        +1
@@ -475,6 +477,7 @@ const UINT wItemX[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, 1, 1, 1, 1, //shovels, dirt
 	1, //ice
 	1, 1, 1, 1, 1, 1, 1, 1,  //8 disabled arrows
+	1, //mist
 	1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
 	1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1, 1, //M+13
 	2, 1, 1 //psuedo tiles
@@ -500,6 +503,7 @@ const UINT wItemY[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, 1, 1, 1, 1, //shovels, dirt
 	1, //ice
 	1, 1, 1, 1, 1, 1, 1, 1,  //8 disabled arrows
+	1, //mist
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+13
 	1, 1, 1 //pseudo tiles
@@ -594,13 +598,13 @@ const UINT fLayerEntries[numFLayerEntries] = {
 	T_SWORDSMAN
 };
 
-const UINT numTLayerEntries = 22;
+const UINT numTLayerEntries = 23;
 const UINT tLayerEntries[numTLayerEntries] = {
 	T_SWORD, T_SHIELD, T_ACCESSORY, T_SCROLL, T_MAP,
 	T_ATK_UP, T_DEF_UP, T_HEALTH_SM, T_KEY, T_SHOVEL1,
 	T_FUSE, T_BOMB, T_MIRROR, T_CRATE, T_TOKEN,
 	T_BRIAR_SOURCE, T_BRIAR_LIVE, T_BRIAR_DEAD, T_ORB, T_LIGHT,
-	T_TAR, T_OBSTACLE
+	T_TAR, T_OBSTACLE, T_MIST
 };
 
 const UINT numMLayerEntries = 31;  //35
@@ -1878,7 +1882,8 @@ const
 		{TI_WALL_H},
 		{TI_GEL_NSEW},
 		{TI_PPB},
-		{TI_PPT}
+		{TI_PPT},
+		{TI_MIST_C}
 	};
 
 	if (wObjectNo < M_OFFSET)
@@ -1909,6 +1914,7 @@ const
 			case T_TAR: return Tiles[5];
 			case T_MUD: return Tiles[8];
 			case T_GEL: return Tiles[10];
+			case T_MIST: return Tiles[13];
 			case T_OBSTACLE:
 			{
 				//Show from the smallest obstacle of the selected type.

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -5388,6 +5388,8 @@ void CEditRoomScreen::PlotObjects()
 				case T_GELMOTHER:	case T_GELBABY:
 				case T_GOO:
 					g_pTheSound->PlaySoundEffect(SEID_STABTAR);  break;
+				case T_MIST:
+					g_pTheSound->PlaySoundEffect(SEID_PUFF_EXPLOSION); break;
 				case T_ROCKGOLEM:
 				case T_ROCKGIANT:
 					g_pTheSound->PlaySoundEffect(SEID_BREAKWALL);   break;

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -777,14 +777,15 @@ const
 			if (bIsPit(wTileNo[0]))
 				return true;
 			return (wTileNo[1] == T_EMPTY || wTileNo[1] == T_FUSE || wTileNo[1] == T_OBSTACLE ||
-					  wTileNo[1] == T_TOKEN || bIsLight(wTileNo[1])) &&
+					  wTileNo[1] == T_TOKEN || wTileNo[1] == T_MIST || bIsLight(wTileNo[1])) &&
 					(!pMonster || wTileNo[2] == M_WWING || wTileNo[2] == M_FEGUNDO || wTileNo[2] == M_CHARACTER);
 		case T_WATER:
 			//Water -- flying+water monsters can be on it.
 			if (bIsWater(wTileNo[0]))
 				return true;
 			return (wTileNo[1] == T_EMPTY || wTileNo[1] == T_FUSE ||
-						wTileNo[1] == T_OBSTACLE || wTileNo[1] == T_TOKEN || bIsLight(wTileNo[1])) &&
+						wTileNo[1] == T_OBSTACLE || wTileNo[1] == T_TOKEN ||
+						wTileNo[1] == T_MIST || bIsLight(wTileNo[1])) &&
 					(!pMonster || wTileNo[2] == M_WWING || wTileNo[2] == M_FEGUNDO ||
 					 wTileNo[2] == M_CHARACTER || wTileNo[2] == M_WATERSKIPPER);// || wTileNo[2] == M_SKIPPERNEST);
 		case T_STAIRS:
@@ -823,7 +824,7 @@ const
 			// FALL-THROUGH
 		case T_WALL_B:
 		case T_WALL_H:
-			if (bIsBriar(wTileNo[1]))
+			if (bIsBriar(wTileNo[1]) || wTileNo[1] == T_MIST)
 				return false;
 			if (wTileNo[2] != T_NOMONSTER && wTileNo[2] != M_SEEP &&
 					!bIsMother(wTileNo[2]) && //tarstuff mothers allowed on walls
@@ -837,7 +838,7 @@ const
 		case T_DOOR_Y:	case T_DOOR_G:	case T_DOOR_C:	case T_DOOR_R:	case T_DOOR_B:
 			//Doors can't have orbs on them.
 			//But can have tar.
-			if (wTileNo[1] == T_ORB)// || wTileNo[1] == T_STATION)
+			if (wTileNo[1] == T_ORB || wTileNo[1] == T_MIST)// || wTileNo[1] == T_STATION)
 				return false;
 			if (bIsTar(wTileNo[1])) return true;
 			if (IsObjectReplaceable(wSelectedObject, wTileLayer, wTileNo[wTileLayer]))
@@ -912,6 +913,9 @@ const
 		case T_FUSE:
 			//Not on monsters that use/affect the t-layer.
 			return !bIsMother(wTileNo[2]);
+		case T_MIST:
+			return !(bIsMother(wTileNo[2]) || bIsWall(wTileNo[0]) || bIsCrumblyWall(wTileNo[0]) ||
+				bIsDoor(wTileNo[0]));
 		case T_HEALTH_SM: case T_HEALTH_MED: case T_HEALTH_BIG: case T_HEALTH_HUGE:
 		case T_ATK_UP: case T_ATK_UP3: case T_ATK_UP10:
 		case T_DEF_UP: case T_DEF_UP3: case T_DEF_UP10:
@@ -969,7 +973,7 @@ const
 		case T_SERPENTG:
 		case T_SERPENTB:
 			if (!(wTileNo[1] == T_EMPTY ||
-					wTileNo[1] == T_FUSE || wTileNo[1] == T_TOKEN || wTileNo[1] == T_SCROLL))
+					wTileNo[1] == T_FUSE || wTileNo[1] == T_TOKEN || wTileNo[1] == T_SCROLL || wTileNo[1] == T_MIST))
 				return false;
 			//Serpents can never overwrite serpents.
 			if (pMonster && !bAllowSelf)

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -6149,6 +6149,30 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 			default: ASSERT(!"Invalid tar type"); break;
 		}
 	}
+	if (CueEvents.HasOccurred(CID_MistDestroyed))
+	{
+		for (pObj = CueEvents.GetFirstPrivateData(CID_MistDestroyed);
+			pObj != NULL; pObj = CueEvents.GetNextPrivateData())
+		{
+			const CMoveCoordEx* pCoord = DYN_CAST(const CMoveCoordEx*, const CAttachableObject*, pObj);
+			this->fPos[0] = static_cast<float>(pCoord->wX);
+			this->fPos[1] = static_cast<float>(pCoord->wY);
+			switch (pCoord->wValue)
+			{
+			case T_MIST:
+				PlaySoundEffect(SEID_PUFF_EXPLOSION, this->fPos);
+				if (bIsSolidOTile(this->pCurrentGame->pRoom->GetOSquare(pCoord->wX, pCoord->wY)))
+					this->pRoomWidget->AddTLayerEffect(
+						new CFluffInWallEffect(this->pRoomWidget, *pCoord));
+				else
+					this->pRoomWidget->AddTLayerEffect(
+						new CFluffStabEffect(this->pRoomWidget, *pCoord,
+							GetEffectDuration(6), GetParticleSpeed(2)));
+				break;
+			default: ASSERT(!"Invalid tar type"); break;
+			}
+		}
+	}
 	if (CueEvents.HasOccurred(CID_StepOnScroll))
 	{
 		this->pFaceWidget->SetReading(true);

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8036,7 +8036,8 @@ void CGameScreen::ShowStatsForMonster(CMonster *pMonster)
 
 		if (g_pPredictedCombat)
 			delete g_pPredictedCombat;
-		g_pPredictedCombat = new CCombat(this->pCurrentGame, pMonster, true, pOrigMonster->wX, pOrigMonster->wY);
+		g_pPredictedCombat = new CCombat(
+			this->pCurrentGame, pMonster, true, pOrigMonster->wX, pOrigMonster->wY, pOrigMonster->wX, pOrigMonster->wY);
 		RedrawStats(NULL, true); //predicted combat will be shown if no combat is actually in progress
 	}
 }

--- a/drodrpg/DROD/Main.cpp
+++ b/drodrpg/DROD/Main.cpp
@@ -1957,6 +1957,7 @@ void RepairMissingINIKeys(const bool bFullVersion)
 	AddIfMissing(INISection::Waves, "Potion", "potion.ogg");
 	AddIfMissing(INISection::Waves, "PressPlate", "pressurePlate.ogg");
 	AddIfMissing(INISection::Waves, "PressPlateUp", "pressurePlateUp.ogg");
+	AddIfMissing(INISection::Waves, "PuffExplosion", "puff-explosion.ogg");
 	AddIfMissing(INISection::Waves, "Punch", "punch.ogg");
 	AddIfMissing(INISection::Waves, "Read", "read.ogg");
 	AddIfMissing(INISection::Waves, "Secret", "SecretArea.ogg");

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -95,6 +95,7 @@ const int MONSTER_ANIMATION_DELAY = 3;
 #define SUNSHINE_SURFACE (3)
 
 #define THIN_ICE_OPACITY       (128) //Opacity of Thin Ice
+#define MIST_OPACITY       (150) //Opacity of Mist
 
 const Uint8 MAX_FOG_OPACITY = 128; //[0,255]
 const Uint8 MIN_FOG_OPACITY =  64; //[0,255]
@@ -4387,6 +4388,7 @@ void CRoomWidget::DrawTLayerTile(
 {
 	ASSERT(this->pRoom);
 	const UINT wTTileNo = this->pRoom->GetTSquare(wX, wY);
+	const UINT wCoveredTTile = this->pRoom->coveredTSquares.GetAt(wX, wY);
 
 	//Pits show only dark.  Light only shines on f+t-layer items.
 	//Deal with darkening the pit tile now.
@@ -4402,6 +4404,7 @@ void CRoomWidget::DrawTLayerTile(
 	}
 
 	bool bTar = bIsTar(wTTileNo);
+	bool bMist = (wTTileNo == T_MIST);
 	bool bTIsTransparent = bTar && bEditor;
 	bool bTIsTranslucent = bTar && this->pRoom->bBetterVision;
 
@@ -4414,8 +4417,13 @@ void CRoomWidget::DrawTLayerTile(
 	}
 
 	//4. Draw transparent (item) layer.
+	//4a. Draw covered mist tile beneath covering object
+	if (wCoveredTTile == T_MIST) {
+		DrawMistTile(wX, wY, nX, nY, pDestSurface, CalcTileImageForMist(this->pRoom, wX, wY));
+	}
+
 	bool bIsMoving = false;
-	if (ti.t != TI_TEMPTY && !bTar)
+	if (ti.t != TI_TEMPTY && !(bTar || bMist))
 	{
 		switch (wTTileNo)
 		{
@@ -4490,6 +4498,69 @@ void CRoomWidget::DrawTLayerTile(
 			DrawRoomTile(ti.t);
 		}
 		AddLight(pDestSurface, nX, nY, psL, fDark, ti.t);
+	}
+	//6b. Mist does its own thing
+	else if (bMist) {
+		DrawMistTile(wX, wY, nX, nY, pDestSurface, ti.t);
+		AddLight(pDestSurface, nX, nY, psL, fDark, ti.t);
+	}
+}
+
+//*****************************************************************************
+void CRoomWidget::DrawMistTile(
+	const UINT wX, const UINT wY,
+	const int nX, const int nY,
+	SDL_Surface* pDestSurface,
+	const UINT& ti
+)
+{
+	bool adj[3][3] = { {false} };
+
+	//mark where adjacent mist tiles are
+	const UINT endX = wX + 2, endY = wY + 2;
+	UINT x, y;
+	for (y = wY - 1; y != endY; ++y)
+	{
+		if (y >= this->pRoom->wRoomRows)
+			continue;
+		const int dy = y - wY + 1;
+		for (x = wX - 1; x != endX; ++x)
+		{
+			if (x >= this->pRoom->wRoomCols)
+				continue;
+			const int dx = x - wX + 1;
+			if (dx == 1 && dy == 1)
+				continue;
+			adj[dx][dy] = (this->pRoom->IsEitherTSquare(x, y, T_MIST));
+		}
+	}
+
+	int cx = CX_TILE / 2;
+	int cy = CY_TILE / 2;
+
+	if (adj[0][0] && adj[0][1] && adj[1][0]) //upper-left corner
+	{
+		g_pTheBM->BlitTileImagePart(TI_MIST_C, nX, nY, 0, 0, cx, cy, pDestSurface, false, MIST_OPACITY);
+	} else {
+		g_pTheBM->BlitTileImagePart(ti, nX, nY, 0, 0, cx, cy, pDestSurface, false, MIST_OPACITY);
+	}
+	if (adj[0][2] && adj[0][1] && adj[1][2]) //lower-left corner
+	{
+		g_pTheBM->BlitTileImagePart(TI_MIST_C, nX, nY + cy, 0, cy, cx, cy, pDestSurface, false, MIST_OPACITY);
+	} else {
+		g_pTheBM->BlitTileImagePart(ti, nX, nY + cy, 0, cy, cx, cy, pDestSurface, false, MIST_OPACITY);
+	}
+	if (adj[2][0] && adj[2][1] && adj[1][0]) //upper-right corner
+	{
+		g_pTheBM->BlitTileImagePart(TI_MIST_C, nX + cx, nY, cx, 0, cx, cy, pDestSurface, false, MIST_OPACITY);
+	} else {
+		g_pTheBM->BlitTileImagePart(ti, nX + cx, nY, cx, 0, cx, cy, pDestSurface, false, MIST_OPACITY);
+	}
+	if (adj[2][2] && adj[2][1] && adj[1][2]) //lower-right corner
+	{
+		g_pTheBM->BlitTileImagePart(TI_MIST_C, nX +cx, nY + cy, cx, cy, cx, cy, pDestSurface, false, MIST_OPACITY);
+	} else {
+		g_pTheBM->BlitTileImagePart(ti, nX +cx, nY + cy, cx, cy, cx, cy, pDestSurface, false, MIST_OPACITY);
 	}
 }
 #undef DrawRoomTile

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -4417,9 +4417,11 @@ void CRoomWidget::DrawTLayerTile(
 	}
 
 	//4. Draw transparent (item) layer.
-	//4a. Draw covered mist tile beneath covering object
+	//4a. Draw covered tile beneath covering object
 	if (wCoveredTTile == T_MIST) {
-		DrawMistTile(wX, wY, nX, nY, pDestSurface, CalcTileImageForMist(this->pRoom, wX, wY));
+		DrawMistTile(wX, wY, nX, nY, pDestSurface, ti.tCovered);
+	} else if (wCoveredTTile != T_EMPTY) {
+		DrawRoomTile(ti.tCovered);
 	}
 
 	bool bIsMoving = false;
@@ -9216,6 +9218,16 @@ bool CRoomWidget::UpdateDrawSquareInfo(
 				pTI->t = wTileImage;
 			}
 
+			wTileImage = GetTileImageForTileNo(this->pRoom->GetCoveredTSquare(wCol, wRow));
+			if (wTileImage == CALC_NEEDED) {
+				wTileImage = CalcTileImageForCoveredTSquare(this->pRoom, wCol, wRow);
+			}
+			if (wTileImage != pTI->tCovered)
+			{
+				pTI->dirty = 1;
+				pTI->tCovered = wTileImage;
+			}
+
 			}	//recalc
 
 			//Keep track of where wall shadows are being cast.
@@ -9348,7 +9360,7 @@ bool CRoomWidget::SetupDrawSquareInfo()
 	for (UINT wIndex = 0; wIndex<wSquareCount; ++wIndex) {
 		TileImages& ti = this->pTileImages[wIndex];
 		ti.o = TI_FLOOR;
-		ti.f = /*ti.tCovered = */ ti.t = T_EMPTY;
+		ti.f = ti.tCovered = ti.t = T_EMPTY;
 		ti.wallShadow = TI_UNSPECIFIED;
 
 		//Give each m-layer tile a random animation frame

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1432,6 +1432,17 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 		}
 	}
 
+	if (this->pRoom->GetCoveredTSquare(wX, wY) != T_EMPTY) {
+		const UINT tCoveredTile = this->pRoom->GetCoveredTSquare(wX, wY);
+		switch (tCoveredTile)
+		{
+		case T_TOKEN:
+			mid = GetTokenMID(this->pRoom->GetTParam(wX, wY)); break;
+			default: mid = TILE_MID[tCoveredTile]; break;
+		}
+		AppendLine(mid);
+	}
+
 	//Inspectable invisible characters
 	const WSTRING invisibleInfoStr = GetInvisibleCharacterInfo(wX, wY);
 	if (invisibleInfoStr.size())

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -70,7 +70,7 @@ struct EDGES {
 
 struct TileImages
 {
-	UINT o, f, t, /*tCovered,*/ wallShadow;
+	UINT o, f, t, tCovered, wallShadow;
 	EDGES edges; //black edges separating tile types
 	vector<UINT> shadowMasks;
 

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -319,6 +319,9 @@ public:
 			const UINT wOTileNo, const TileImages& ti, LIGHTTYPE *psL,
 			const float fDark, const bool bAddLight,
 			const bool bEditor, const vector<TweeningTileMask>* pPitPlatformMasks=NULL);
+	void           DrawMistTile(const UINT wX, const UINT wY,
+		const int nX, const int nY, SDL_Surface* pDestSurface,
+		const UINT& ti);
 	void           ResetForPaint();
 	void           ResetJitter();
 	void           ResetRoom() {this->pRoom = NULL;}

--- a/drodrpg/DROD/TarStabEffect.cpp
+++ b/drodrpg/DROD/TarStabEffect.cpp
@@ -30,6 +30,8 @@
 #include "../DRODLib/GameConstants.h"
 #include <BackEndLib/Assert.h>
 
+const UINT FLUFF_PARTICLES = 15;
+
 //********************************************************************************
 CTarStabEffect::CTarStabEffect(
 //Constructor.
@@ -97,4 +99,51 @@ CGelStabEffect::CGelStabEffect(
 	this->xDims[0] = this->yDims[0] = 12;
 	this->xDims[1] = this->yDims[1] = 16;
 	InitParticles();
+}
+
+//********************************************************************************
+CFluffStabEffect::CFluffStabEffect(
+	//Constructor.
+	//
+	//Params:
+	CWidget* pSetWidget,       //(in)   Should be a room widget.
+	const CMoveCoord& MoveCoord,  //(in)   Location of debris and direction of its movement.
+	const UINT wParticleMinDuration,
+	const UINT baseSpeed)
+	: CParticleExplosionEffect(pSetWidget, MoveCoord, 8, 8, 2, FLUFF_PARTICLES,
+		wParticleMinDuration, baseSpeed)
+{
+	this->bRotatingParticles = false;
+
+	this->tileNums[0] = TI_FLUFFBLOOD_1;
+	this->tileNums[1] = TI_FLUFFBLOOD_2;
+	this->xDims[0] = this->yDims[0] = 8;
+	this->xDims[1] = this->yDims[1] = 4;
+	InitParticles();
+}
+
+//********************************************************************************
+CFluffInWallEffect::CFluffInWallEffect(
+	//Particles move more slowly than for the normal effect.
+	//
+	//Params:
+	CWidget* pSetWidget,       //(in)   Should be a room widget.
+	const CMoveCoord& MoveCoord)  //(in)   Location of debris and direction of its movement.
+	: CParticleExplosionEffect(pSetWidget, MoveCoord, 6, 6, 2, FLUFF_PARTICLES, 12, 1)
+{
+	this->bRotatingParticles = false;
+
+	this->tileNums[0] = TI_FLUFFBLOOD_1;
+	this->tileNums[1] = TI_FLUFFBLOOD_2;
+	this->xDims[0] = this->yDims[0] = 6;
+	this->xDims[1] = this->yDims[1] = 4;
+	InitParticles();
+}
+
+//*****************************************************************************
+bool CFluffInWallEffect::HitsObstacle(const CDbRoom* pRoom, const PARTICLE&/*particle*/) const
+//Nothing is an obstacle to this effect.
+{
+	ASSERT(pRoom);
+	return false;
 }

--- a/drodrpg/DROD/TarStabEffect.h
+++ b/drodrpg/DROD/TarStabEffect.h
@@ -54,4 +54,19 @@ public:
 			const UINT particles=PARTICLES_PER_EXPLOSION);
 };
 
+class CFluffStabEffect : public CParticleExplosionEffect
+{
+public:
+	CFluffStabEffect(CWidget* pSetWidget, const CMoveCoord& MoveCoord,
+		const UINT wParticleMinDuration, const UINT baseSpeed);
+};
+
+class CFluffInWallEffect : public CParticleExplosionEffect
+{
+public:
+	CFluffInWallEffect(CWidget* pSetWidget, const CMoveCoord& MoveCoord);
+
+	virtual bool HitsObstacle(const CDbRoom* pRoom, const PARTICLE& particle) const;
+};
+
 #endif //...#ifndef TARSTABEFFECT_H

--- a/drodrpg/DROD/TileImageCalcs.cpp
+++ b/drodrpg/DROD/TileImageCalcs.cpp
@@ -43,6 +43,7 @@ UINT  CalcTileImageForTarstuff(const CDbRoom *pRoom, const UINT wCol, const UINT
 UINT  CalcTileImageForWall(const CDbRoom *pRoom, const UINT wCol, const UINT wRow);
 UINT  CalcTileImageForPlatform(const CDbRoom *pRoom, const UINT wCol, const UINT wRow, const UINT wTileNo);
 UINT  CalcTileImageForBriar(const CDbRoom *pRoom, const UINT wCol, const UINT wRow, const UINT wTileNo);
+UINT  CalcTileImageForMist(const CDbRoom* pRoom, const UINT wCol, const UINT wRow);
 UINT  CalcTileImageForStairsUp(const CDbRoom *pRoom, const UINT wCol, const UINT wRow);
 
 //Definitions
@@ -1683,6 +1684,16 @@ UINT CalcTileImageForTSquare(
 //TI_* constant.
 {
 	return CalcTileImageFor(pRoom, pRoom->GetTSquare(wCol, wRow), wCol, wRow);
+}
+
+//*****************************************************************************
+UINT CalcTileImageForCoveredTSquare(
+//Calculates a tile image for covered square on t-layer.
+//
+//Params:
+	const CDbRoom* pRoom, UINT wCol, UINT wRow)
+{
+	return CalcTileImageFor(pRoom, pRoom->coveredTSquares.GetAt(wCol, wRow), wCol, wRow);
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/TileImageCalcs.cpp
+++ b/drodrpg/DROD/TileImageCalcs.cpp
@@ -1551,6 +1551,7 @@ UINT GetTileImageForTileNo(
 		TI_ARROW_OFF_SW,  //T_ARROW_OFF_SW
 		TI_ARROW_OFF_W,   //T_ARROW_OFF_W
 		TI_ARROW_OFF_NW,  //T_ARROW_OFF_NW
+		CALC_NEEDED,      //T_MIST
 	};
 
 	ASSERT(IsValidTileNo(wTileNo));
@@ -1641,6 +1642,8 @@ UINT CalcTileImageFor(
 			const UINT tParam = pRoom->GetTParam(wCol,wRow);
 			return CalcTileImageForAccessory(tParam);
 		}
+		case T_MIST:
+			return CalcTileImageForMist(pRoom, wCol, wRow);
 
 		default: break;
 	}
@@ -1946,6 +1949,67 @@ UINT CalcTileImageForFuse(
 	const UINT wOSquare = pRoom->GetOSquare(wCol, wRow);
 	const UINT wFuseType = bShowsShadow(wOSquare) || bIsPit(wOSquare) ? 0 : 1;
 	return TileImages[wFuseType][wCalcCode];
+}
+
+//*****************************************************************************
+UINT CalcTileImageForMist(
+//Calcs a tile image to display for a mist square.
+//
+//Params:
+	const CDbRoom* pRoom, //(in) Room to use for calcs--not necessarily the current room
+	const UINT wCol, const UINT wRow //Mist square
+)
+{
+	UINT wCalcCode = 0;
+
+	//If north mist, set bit 1
+	if (wRow > 0) {
+		if (pRoom->IsEitherTSquare(wCol, wRow - 1, T_MIST))
+			wCalcCode = 1;
+	}
+
+	//If south mist, set bit 2.
+	if (wRow < pRoom->wRoomRows - 1) {
+		if (pRoom->IsEitherTSquare(wCol, wRow + 1, T_MIST))
+			wCalcCode += 2;
+	}
+
+	//If west mist, set bit 3.
+	if (wCol > 0) {
+		if (pRoom->IsEitherTSquare(wCol - 1, wRow, T_MIST))
+			wCalcCode += 4;
+	}
+
+	//If east mist, set bit 4.
+	if (wCol < pRoom->wRoomCols - 1) {
+		if (pRoom->IsEitherTSquare(wCol + 1, wRow, T_MIST))
+			wCalcCode += 8;
+	}
+
+	// ?.?   0     ?#?      1     ?.?      2     ?#?      3
+	// .X.         .X.            .X.            .X.
+	// ?.?         ?.?            ?#?            ?#?
+
+	// ?.?   4     ?#?      5     ?.?      6     ?#?      7
+	// #X.         #X.            #X.            #X.
+	// ?.?         ?.?            ?#?            ?#?
+
+	// ?.?   8     ?#?      9     ?.?      10    ?#?      11
+	// .X#         .X#            .X#            .X#
+	// ?.?         ?.?            ?#?            ?#?
+
+	// ?.?   12    ?#?      13    ? ?      14    ?#?      15
+	// #X#         #X#            #X#            #X#
+	// ?.?         ?.?            ?#?            ?#?
+	static const UINT TileImages[16] = {
+		TI_MIST,       TI_MIST_N,     TI_MIST_S,     TI_MIST_NS,
+		TI_MIST_W,     TI_MIST_NW,    TI_MIST_SW,    TI_MIST_NSW,
+		TI_MIST_E,     TI_MIST_NE,    TI_MIST_SE,    TI_MIST_NSE,
+		TI_MIST_WE,    TI_MIST_NWE,   TI_MIST_SWE,   TI_MIST_NSWE
+	};
+
+	ASSERT(wCalcCode < 16);
+	return TileImages[wCalcCode];
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/TileImageCalcs.h
+++ b/drodrpg/DROD/TileImageCalcs.h
@@ -63,6 +63,7 @@ UINT  GetTileImageForSerpentPiece(const UINT wType, const UINT wTileNo);
 UINT  GetTileImageForRockGiantPiece(const UINT wTileNo, const UINT wO, const UINT wFrame);
 UINT  GetTileImageForTileNo(const UINT wTileNo);
 UINT  CalcTileImageForKey(const BYTE tParam);
+UINT  CalcTileImageForMist(const CDbRoom* pRoom, const UINT wCol, const UINT wRow);
 UINT  CalcTileImageForSword(const BYTE tParam);
 UINT  CalcTileImageForShield(const BYTE tParam);
 UINT  CalcTileImageForAccessory(const BYTE tParam);

--- a/drodrpg/DROD/TileImageCalcs.h
+++ b/drodrpg/DROD/TileImageCalcs.h
@@ -54,6 +54,7 @@ void  CalcTileCoordForPit(const CDbRoom *pRoom, const UINT wCol, const UINT wRow
 UINT  CalcTileImageFor(const CDbRoom *pRoom, const UINT wTileNo, const UINT wCol, const UINT wRow);
 UINT  CalcTileImageForOSquare(const CDbRoom *pRoom, UINT wCol, UINT wRow);
 UINT  CalcTileImageForTSquare(const CDbRoom *pRoom, UINT wCol, UINT wRow);
+UINT  CalcTileImageForCoveredTSquare(const CDbRoom *pRoom, UINT wCol, UINT wRow);
 UINT  CalcTileImagesForWallShadow(const CDbRoom *pRoom, const UINT wCol, const UINT wRow);
 bool  CastsWallShadow(const UINT t);
 UINT  GetSwordlessEntityTile(const UINT wType, const UINT wO);
@@ -63,7 +64,6 @@ UINT  GetTileImageForSerpentPiece(const UINT wType, const UINT wTileNo);
 UINT  GetTileImageForRockGiantPiece(const UINT wTileNo, const UINT wO, const UINT wFrame);
 UINT  GetTileImageForTileNo(const UINT wTileNo);
 UINT  CalcTileImageForKey(const BYTE tParam);
-UINT  CalcTileImageForMist(const CDbRoom* pRoom, const UINT wCol, const UINT wRow);
 UINT  CalcTileImageForSword(const BYTE tParam);
 UINT  CalcTileImageForShield(const BYTE tParam);
 UINT  CalcTileImageForAccessory(const BYTE tParam);

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2417,7 +2417,25 @@
 #define TI_ARROW_OFF_W    2236
 #define TI_ARROW_OFF_NW   2237
 
-static const UINT TI_COUNT = 2238;
+#define TI_MIST           2238
+#define TI_MIST_E         2239
+#define TI_MIST_WE        2240
+#define TI_MIST_W         2241
+#define TI_MIST_S         2242
+#define TI_MIST_SE        2243
+#define TI_MIST_SWE       2244
+#define TI_MIST_SW        2245
+#define TI_MIST_NS        2246
+#define TI_MIST_NSE       2247
+#define TI_MIST_NSWE      2248
+#define TI_MIST_NSW       2249
+#define TI_MIST_N         2250
+#define TI_MIST_NE        2251
+#define TI_MIST_NWE       2252
+#define TI_MIST_NW        2253
+#define TI_MIST_C         2254
+
+static const UINT TI_COUNT = 2255;
 
 static inline bool bIsBriarTI(const UINT ti)
 {

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2435,7 +2435,10 @@
 #define TI_MIST_NW        2253
 #define TI_MIST_C         2254
 
-static const UINT TI_COUNT = 2255;
+#define TI_FLUFFBLOOD_1   2255
+#define TI_FLUFFBLOOD_2   2256
+
+static const UINT TI_COUNT = 2257;
 
 static inline bool bIsBriarTI(const UINT ti)
 {

--- a/drodrpg/DRODLib/Briar.cpp
+++ b/drodrpg/DRODLib/Briar.cpp
@@ -224,6 +224,12 @@ void CBriars::process(
 				//Briars break everything else.  Including orbs.
 				default: break;
 			}
+
+			//Misty tiles block briar
+			if (room.IsEitherTSquare(wX, wY, T_MIST)) {
+				bBlocked = true;
+			}
+
 			if (bBlocked) continue;
 
 			//Force arrows in wrong direction stop the briar

--- a/drodrpg/DRODLib/BuildUtil.cpp
+++ b/drodrpg/DRODLib/BuildUtil.cpp
@@ -446,6 +446,11 @@ bool BuildUtil::BuildRealTile(CDbRoom& room, const UINT tile, const UINT x, cons
 
 	room.Plot(x, y, tile);
 
+	if (bIsSolidOTile(tile) || tile == T_HOT)
+	{
+		room.DestroyMist(x, y, CueEvents);
+	}
+
 	//When placing a hole, things might fall.
 	if ((bIsPit(tile) || bIsWater(tile) || wLayer == LAYER_TRANSPARENT) &&
 		pCurrentGame->wTurnNo > 0) //don't allow player falling on room entrance

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2189,7 +2189,7 @@ void CCharacter::Process(
 							case T_DOOR_Y: case T_DOOR_B: case T_DOOR_G: case T_DOOR_R: case T_DOOR_C: case T_DOOR_MONEY:
 							case T_DOOR_YO: case T_DOOR_BO: case T_DOOR_GO: case T_DOOR_RO: case T_DOOR_CO: case T_DOOR_MONEYO:
 								//Toggle this door.
-								room.ToggleDoor(px, py);
+								room.ToggleDoor(px, py, CueEvents);
 								bProcessNextCommand = true;
 							break;
 							default:

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -675,6 +675,11 @@ enum CUEEVENT_ID
 	//Private data: CImageOverlay* (one or more)
 	CID_ImageOverlay,
 
+	//A mist tile is destroyed
+	//
+	//Private data: CMoveCoord *pSquareDestroyedAt (one or more)
+	CID_MistDestroyed,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3220,6 +3220,9 @@ int CCurrentGame::getPlayerDEF() const
 	const PlayerStats& st = this->pPlayer->st;
 	int def = st.DEF;
 
+	if (this->pRoom->GetTSquare(this->pPlayer->wX, this->pPlayer->wY) == T_MIST)
+		return 0;
+
 	if (!IsPlayerShieldDisabled())
 		addWithClamp(def, getShieldPower(st.shield));
 
@@ -4778,7 +4781,7 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 
 			CueEvents.Add(CID_MoneyDoorLocked);
 
-			this->pRoom->CloseDoor(wX, wY);
+			this->pRoom->CloseDoor(wX, wY, CueEvents);
 		}
 		return true; //done
 
@@ -4786,7 +4789,7 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 	}
 
 	CueEvents.Add(CID_DoorLocked, NULL, false);
-	this->pRoom->CloseDoor(this->pPlayer->wX, this->pPlayer->wY);
+	this->pRoom->CloseDoor(this->pPlayer->wX, this->pPlayer->wY, CueEvents);
 	return true;
 }
 
@@ -5346,6 +5349,7 @@ CheckTLayer:
 			}
 		break;
 		case T_CRATE:
+		case T_MIST:
 			bNotAnObstacle = true;
 		default:
 			goto CheckMonsterLayer;
@@ -5794,6 +5798,8 @@ CheckFLayer:
 			case T_BRIAR_SOURCE: case T_BRIAR_DEAD: case T_BRIAR_LIVE:
 				CueEvents.Add(CID_Scared);
 			break;
+			case T_MIST:
+				bNotAnObstacle = true;
 			default:
 				goto CheckMonsterLayer;	//no special obstacle handling on t-layer
 			break;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -810,6 +810,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ImageOverlay: strText = "Image overlay"; break;
 		case MID_ImageOverlayStrategy: strText = "Image overlay strategy"; break;
 		case MID_Mist: strText = "Mist"; break;
+		case MID_MistDestroyed: strText = "Mist destroyed"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -809,6 +809,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ForceArrowDisabledSW: strText = "Disabled force arrow (southeast)"; break;
 		case MID_ImageOverlay: strText = "Image overlay"; break;
 		case MID_ImageOverlayStrategy: strText = "Image overlay strategy"; break;
+		case MID_Mist: strText = "Mist"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -4590,6 +4590,10 @@ void CDbRoom::ExpandExplosion(
 			if (!explosion.has(wX,wY))
 				CueEvents.Add(CID_TarstuffDestroyed, new CMoveCoordEx(wX, wY, direction, wTileNo), true);
 			break;
+		case T_MIST:
+			if (!explosion.has(wX,wY))
+				CueEvents.Add(CID_MistDestroyed, new CMoveCoordEx(wX, wY, direction, T_MIST), true);
+			break;
 		default:
 			break;
 	}
@@ -7932,8 +7936,10 @@ void CDbRoom::DestroyMist(
 	if (GetTSquare(wX, wY) == T_MIST)
 	{
 		Plot(wX, wY, T_EMPTY);
+		CueEvents.Add(CID_MistDestroyed, new CMoveCoordEx(wX, wY, NO_ORIENTATION, T_MIST), true);
 	} else if (GetCoveredTSquare(wX, wY) == T_MIST) {
 		this->coveredTSquares.Remove(wX, wY);
+		CueEvents.Add(CID_MistDestroyed, new CMoveCoordEx(wX, wY, NO_ORIENTATION, T_MIST), true);
 	}
 }
 

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -202,6 +202,7 @@ public:
 	void           DeleteScrollTextAtSquare(const UINT wX, const UINT wY);
 	void           DestroyCrumblyWall(const UINT wX, const UINT wY,
 			CCueEvents &CueEvents, const UINT wStabO=NO_ORIENTATION);
+	void           DestroyMist(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	void           DestroyTar(const UINT wX, const UINT wY, CCueEvents &CueEvents);
 	void           DestroyTrapdoor(const UINT wX, const UINT wY, CCueEvents &CueEvents);
 	void           Dig(const UINT wX, const UINT wY, const UINT wO, CCueEvents& CueEvents);
@@ -268,6 +269,7 @@ public:
 			CCoordSet& tiles, const bool bAddAdjOnly=false) const;
 	UINT           GetTSquare(const UINT wX, const UINT wY) const;
 	UINT           GetTParam(const UINT wX, const UINT wY) const;
+	UINT           GetCoveredTSquare(const UINT wX, const UINT wY) const;
 	UINT           GetTSquareWithGuessing(int nX, int nY) const;
 	bool           HasClosedDoors() const;
 	bool           HasCombatableMonsters() const;
@@ -279,6 +281,7 @@ public:
 	UINT           GetBrainsPresent() const;
 	bool           IsDisarmTokenActive() const;
 	bool           IsDoorOpen(const int nCol, const int nRow);
+	bool           IsEitherTSquare(const UINT wX, const UINT wY, const UINT wTile) const;
 	bool           IsOrbBeingStruck(const UINT wX, const UINT wY) const;
 	bool           IsMonsterInRect(const UINT wLeft, const UINT wTop,
 			const UINT wRight, const UINT wBottom, const bool bConsiderPieces=true) const;
@@ -395,7 +398,7 @@ public:
 	bool           SwordfightCheck() const;
 	void           ToggleBlackGates(CCueEvents& CueEvents);
 	void           ToggleForceArrow(const UINT wX, const UINT wY);
-	void           ToggleDoor(const UINT wX, const UINT wY);
+	void           ToggleDoor(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	bool           ToggleTiles(const UINT wOldTile, const UINT wNewTile);
 	void           ToggleLight(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	bool     TunnelGetExit(const UINT wStartX, const UINT wStartY,
@@ -418,7 +421,7 @@ private:
 	void           AddPlatformPiece(const UINT wX, const UINT wY, CCoordIndex &plots);
 	void           Clear();
 	void           ClearPushInfo();
-	void           CloseDoor(const UINT wX, const UINT wY);
+	void           CloseDoor(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 //	void           DeletePathMaps();
 	CMonster*      FindLongMonster(const UINT wX, const UINT wY,
 			const UINT wFromDirection=10) const;

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -902,6 +902,7 @@ const
 				wLookTileNo==T_FUSE ||
 				wLookTileNo==T_TOKEN ||
 				wLookTileNo==T_KEY ||
+				wLookTileNo==T_MIST ||
 				bIsPowerUp(wLookTileNo) ||
 				bIsMap(wLookTileNo) ||
 				bIsShovel(wLookTileNo) ||
@@ -917,6 +918,7 @@ const
 				wLookTileNo==T_FUSE ||
 				wLookTileNo==T_SCROLL ||
 				wLookTileNo==T_KEY ||
+				wLookTileNo==T_MIST ||
 				bIsPowerUp(wLookTileNo) ||
 				bIsMap(wLookTileNo) ||
 				bIsShovel(wLookTileNo) ||
@@ -936,6 +938,7 @@ const
 				wLookTileNo==T_FUSE ||
 				wLookTileNo==T_TOKEN ||
 				wLookTileNo==T_KEY ||
+				wLookTileNo==T_MIST ||
 				bIsMap(wLookTileNo) ||
 				bIsShovel(wLookTileNo) ||
 				bIsPowerUp(wLookTileNo) ||
@@ -1529,6 +1532,9 @@ UINT CMonster::getColor() const
 UINT CMonster::getDEF() const
 //Return: monster's DEF
 {
+	if (IsOnMistTile())
+		return 0; //Mist tile nullifies DEF
+
 	UINT val = this->DEF;
 	if (!this->pCurrentGame || !val)
 		return val;
@@ -1733,6 +1739,13 @@ const
 		}
 	}
 	return false;
+}
+
+//*****************************************************************************
+bool CMonster::IsOnMistTile() const
+//Returns: whether the monster's tile has mist
+{
+	return this->pCurrentGame->pRoom->GetTSquare(this->wX, this->wY) == T_MIST;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -230,6 +230,7 @@ public:
 	virtual bool  IsLongMonster() const {return false;}
 	bool          IsNextToSwordsman() const;
 	bool          IsObjectAdjacent(const UINT wObject, UINT& wX, UINT& wY) const;
+	virtual bool  IsOnMistTile() const;
 	bool          IsOnSwordsman() const;
 	virtual bool  IsOpenMove(const int dx, const int dy) const;
 	virtual bool  IsOpenMove(const UINT wX, const UINT wY, const int dx, const int dy) const;

--- a/drodrpg/DRODLib/Splitter.cpp
+++ b/drodrpg/DRODLib/Splitter.cpp
@@ -80,6 +80,25 @@ bool CSplitter::CheckForDamage(CCueEvents& CueEvents)
 }
 
 //*****************************************************************************
+bool CSplitter::IsOnMistTile() const
+//Returns: If any piece of the monster is on a mist tile
+{
+	if (CMonster::IsOnMistTile()) {
+		return true;
+	}
+
+	const CDbRoom* room = this->pCurrentGame->pRoom;
+	for (MonsterPieces::const_iterator piece = this->Pieces.begin(); piece != this->Pieces.end(); ++piece) {
+		const CMonsterPiece& mpiece = *(*piece);
+		if (room->GetTSquare(mpiece.wX, mpiece.wY) == T_MIST) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//*****************************************************************************
 bool CSplitter::IsOpenMove(const int dx, const int dy) const
 //Returns: whether moving from the current position along (dx,dy) is valid
 {

--- a/drodrpg/DRODLib/Splitter.h
+++ b/drodrpg/DRODLib/Splitter.h
@@ -43,6 +43,7 @@ public:
 	virtual bool CheckForDamage(CCueEvents& CueEvents);
 
 	virtual bool IsLongMonster() const {return true;}
+	virtual bool IsOnMistTile() const override;
 	virtual bool IsOpenMove(const int dx, const int dy) const;
 	virtual void Process(const int nLastCommand, CCueEvents &CueEvents);
 

--- a/drodrpg/DRODLib/Swordsman.cpp
+++ b/drodrpg/DRODLib/Swordsman.cpp
@@ -362,6 +362,7 @@ const
 		wLookTileNo==T_NODIAGONAL ||
 		wLookTileNo==T_SCROLL ||
 		wLookTileNo==T_TOKEN ||
+		wLookTileNo==T_MIST ||
 		wLookTileNo==T_PRESSPLATE ||
 		(bIsFallingTile(wLookTileNo) && !CanDropTrapdoor(wLookTileNo)) //won't drop trapdoors
 	)

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -162,8 +162,9 @@
 #define T_ARROW_OFF_SW  112
 #define T_ARROW_OFF_W   113
 #define T_ARROW_OFF_NW  114
+#define T_MIST          115 //mist that nullifies DEF
 
-#define TILE_COUNT     (115) //Number of tile constants from above list.
+#define TILE_COUNT     (116) //Number of tile constants from above list.
 static inline bool IsValidTileNo(const UINT t) {return t < TILE_COUNT;}
 
 //
@@ -275,6 +276,8 @@ static inline bool bIsDEFUp(const UINT t) { return t == T_DEF_UP || t == T_DEF_U
 static inline bool bIsShovel(const UINT t) { return t == T_SHOVEL1 || t == T_SHOVEL3 || t == T_SHOVEL10; }
 
 static inline bool bIsDiggableBlock(const UINT t) { return t == T_DIRT1 || t == T_DIRT3 || t == T_DIRT5; }
+
+static inline bool bIsSolidOTile(const UINT t) { return bIsWall(t) || bIsCrumblyWall(t) || bIsDoor(t); }
 
 //Obstacle parameter bit format: <Top edge>:1 <Left edge>:1 <64 possible obstacle types>:6
 #define OBSTACLE_TOP (0x80)
@@ -517,6 +520,7 @@ static const UINT TILE_LAYER[TOTAL_EDIT_TILE_COUNT] =
 	LAYER_FLOOR, //T_ARROW_OFF_SW
 	LAYER_FLOOR, //T_ARROW_OFF_W
 	LAYER_FLOOR, //T_ARROW_OFF_NW
+	LAYER_TRANSPARENT, //T_MIST
 
 	LAYER_MONSTER, //M_ROACH         +0
 	LAYER_MONSTER, //M_QROACH        +1
@@ -679,6 +683,7 @@ static const UINT TILE_MID[TOTAL_EDIT_TILE_COUNT] =
 	MID_ForceArrowDisabled, //T_ARROW_OFF_SW
 	MID_ForceArrowDisabled, //T_ARROW_OFF_W
 	MID_ForceArrowDisabled, //T_ARROW_OFF_NW
+	MID_Mist, //T_MIST
 
 	MID_Roach,        //M_ROACH         +0
 	MID_RoachQueen,   //M_QROACH        +1

--- a/drodrpg/Texts/EditScreens.uni
+++ b/drodrpg/Texts/EditScreens.uni
@@ -918,6 +918,10 @@ Medium Power gem
 [eng]
 Large Power gem
 
+[MID_Mist]
+[eng]
+Mist
+
 [MID_PlatformWater]
 [eng]
 Platform (on water)

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -310,6 +310,7 @@ enum MID_CONSTANT {
   MID_ForceArrowDisabledNE = 1880,
   MID_ForceArrowDisabledSE = 1881,
   MID_ForceArrowDisabledSW = 1882,
+  MID_Mist = 1885,
   MID_FloorMosaic = 332,
   MID_FloorRoad = 333,
   MID_FloorGrass = 334,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1545,6 +1545,7 @@ enum MID_CONSTANT {
   MID_IceMeltEffect = 1873,
   MID_ImageOverlay = 1883,
   MID_ImageOverlayStrategy = 1884,
+  MID_MistDestroyed = 1886,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1383,3 +1383,7 @@ Image overlay
 [MID_ImageOverlayStrategy]
 [eng]
 Image overlay strategy
+
+[MID_MistDestroyed]
+[eng]
+Mist destroyed


### PR DESCRIPTION
Adds a new transparent layer tile (mist) that nullifies the DEF stat of a player or monster standing on it. The tile takes some mechanic cues from Fluff, being destroyed when doors are closed under it, and preventing briar growth.

Crates and mirrors can be pushed onto mist, and mist does not affect a player standing on a crate. To support this graphically, covered T-layer objects are now drawn into a room (as in DROD TSS), and are included in right-click tooltips.

As mist is transparent and uses corner filler when drawn, it requires its own function `CRoomWidget::DrawMistTile` for drawing. Its tile image calculations are also placed in a new function due to the requirement to check both the T-layer and covered T-layer object during calculation.