### PR TITLE
Fix CTransTileEffect::UpdateStaticState()

### DIFF
--- a/FrontEndLib/TransTileEffect.cpp
+++ b/FrontEndLib/TransTileEffect.cpp
@@ -64,6 +64,8 @@ Uint8 CTransTileEffect::UpdateStaticState()
 	if (CScreen::dwPresentsCount == lastUpdatePresentCount)
 		return nOpacity;
 
+	lastUpdatePresentCount = CScreen::dwPresentsCount;
+
 	//Value is modified by only one of the instances.
 	if (bRising)
 	{


### PR DESCRIPTION
When editing doors in the editor, the animated effect's speed increases in proportion to the number of door tiles highlighted. This is due to a problem in `CTransTileEffect::UpdateStaticState`. The function should only adjust the global effect opacity once per frame, however it never updates the tracking value, so instead the opacity is adjusted for each instance of the effect. By correctly storing this value, the effect animates at a constant rate.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46081