### PR TITLE
Add commands to cap image overlay duration

### DIFF
--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -419,7 +419,12 @@ bool CImageOverlayEffect::IsCurrentCommandFinished() const
 UINT CImageOverlayEffect::GetGameTurn() const
 {
 	const CDbRoom* pRoom = this->pRoomWidget->GetRoom();
-	return pRoom ? pRoom->GetCurrentGame()->wPlayerTurn : 0;
+
+	if (!pRoom)
+		return 0;
+
+	const CCurrentGame* pGame = pRoom->GetCurrentGame();
+	return pGame ? pGame->wPlayerTurn : 0;
 }
 
 Uint32 CImageOverlayEffect::UpdateCommand(

--- a/DROD/ImageOverlayEffect.h
+++ b/DROD/ImageOverlayEffect.h
@@ -88,6 +88,7 @@ private:
 	bool IsCurrentCommandFinished() const;
 	bool CanContinuePlayingEffect(const Uint32 dwRemainingTime) const;
 	bool CanLoop() const;
+	UINT GetGameTurn() const;
 	inline bool IsCommandQueueFinished() const;
 	bool IsImageDrawn();
 	bool IsRepeated() const;
@@ -133,13 +134,13 @@ private:
 	ImageOverlayCommands commands;
 	UINT index;
 	int loopIteration, maxLoops;
-	Uint32 startOfNextEffect;
+	Uint32 startOfNextEffect, endTime;
 
 	CommandExecution executionState;
 	vector<ParallelCommand> parallelCommands;
 
 	CRoomWidget *pRoomWidget;
-	UINT turnNo;
+	UINT turnNo, endTurn;
 
 	UINT instanceID; //for merging effect sets during play after move undo/checkpoint restore
 };

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -281,7 +281,9 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("setx")] = ImageOverlayCommand::SetX;
 		commandMap[string("sety")] = ImageOverlayCommand::SetY;
 		commandMap[string("srcxy")] = ImageOverlayCommand::SrcXY;
+		commandMap[string("timelimit")] = ImageOverlayCommand::TimeLimit;
 		commandMap[string("tilegrid")] = ImageOverlayCommand::TileGrid;
+		commandMap[string("turnlimit")] = ImageOverlayCommand::TurnLimit;
 	}
 
 	for (CommandMap::const_iterator it=commandMap.begin(); it!=commandMap.end(); ++it) {
@@ -452,6 +454,32 @@ int CImageOverlay::getGroup() const
 	}
 
 	return ImageOverlayCommand::DEFAULT_GROUP;
+}
+
+UINT CImageOverlay::getTimeLimit() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::TimeLimit)
+			return c.val[0] > 0 ? c.val[0] : 0;
+	}
+
+	return 0;
+}
+
+UINT CImageOverlay::getTurnLimit() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::TurnLimit)
+			return c.val[0] > 0 ? c.val[0] : 0;
+	}
+
+	return 0;
 }
 
 bool CImageOverlay::loopsForever() const

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -480,7 +480,9 @@ struct ImageOverlayCommand
 		SetY,
 		SrcXY,
 		TileGrid,
+		TimeLimit,
 		TurnDuration,
+		TurnLimit,
 		Invalid
 	};
 
@@ -511,6 +513,8 @@ public:
 
 	int getLayer() const;
 	int getGroup() const;
+	UINT getTimeLimit() const;
+	UINT getTurnLimit() const;
 	int clearsImageOverlays() const;
 	int clearsImageOverlayGroup() const;
 	bool loopsForever() const;

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -788,6 +788,8 @@ Variables prefixed with "_My" are connected to the state of the NPC, the "_*Imag
 <b>SetY (pixel)</b> -- set the image's Y coordinate<br />
 <b>SrcXY (x) (y)</b> - show the source image starting from the indicated pixel position<br />
 <b>TileGrid (w) (h)</b> -- replicate the image in a w by h grid. Tiling is not supported for images that have had rotations applied.<br />
+<b>TimeLimit (ms)</b> -- set a maximum duration for the overlay to exist. After this time has elapsed, the overlay will end, even if not all commands have been processed. Only the first instance of this command in a script is executed.<br />
+<b>TurnLimit (# turns)</b> -- set a maximum number of game turns for the overlay to exist. After that many turns have passed, the overlay will end, even if not all commands have been processed. Only the first instance of this command in a script is executed.<br />
 <br />
 As an example, you can make an image start invisible, fade in, display for a couple seconds, then fade out by providing the following command sequence:<br />
 <br />


### PR DESCRIPTION
Adds two new image overlay commands, `TimeLimit` and `TurnLimit`, that place a restriction on how long an image overlay can live for.

`TimeLimit` causes the overlay to end after the specified amount of time. Primarily useful for capping the length of dynamic effects where it may be difficult to otherwise set the duration.
`TurnLimit` causes the overlay to end after the specified number of turns pass. Useful for placing a turn limit on an effect that loops forever, in a way that is self-contained.