### PR TITLE
RPG: Add commands to cap image overlay duration

### DIFF
--- a/drodrpg/DROD/ImageOverlayEffect.cpp
+++ b/drodrpg/DROD/ImageOverlayEffect.cpp
@@ -97,9 +97,9 @@ CImageOverlayEffect::CImageOverlayEffect(
 	, repetitions(0), xRepeatOffset(0), yRepeatOffset(0)
 	, index(UINT(-1))
 	, loopIteration(0), maxLoops(0)
-	, startOfNextEffect(dwStartTime)
+	, startOfNextEffect(dwStartTime), endTime(0)
 	, pRoomWidget(NULL)
-	, turnNo(turnNo)
+	, turnNo(turnNo), endTurn(0)
 	, instanceID(0)
 	, drawSourceRect(MAKE_SDL_RECT(0, 0, 0, 0))
 	, drawDestinationRect(MAKE_SDL_RECT(0, 0, 0, 0))
@@ -115,6 +115,12 @@ CImageOverlayEffect::CImageOverlayEffect(
 	this->dirtyRects.push_back(rect);
 
 	InitParams();
+
+	endTime = pImageOverlay->getTimeLimit();
+	UINT maxTurns = pImageOverlay->getTurnLimit();
+	if (maxTurns > 0) {
+		endTurn = turnNo + maxTurns;
+	}
 
 	this->commands = pImageOverlay->commands;
 	this->instanceID = pImageOverlay->instanceID;
@@ -163,6 +169,10 @@ int CImageOverlayEffect::getGroup() const
 bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 {
 	if (!this->pImageSurface)
+		return false;
+
+	if ((endTime > 0 && dwTimeElapsed >= endTime) ||
+		(endTurn > 0 && GetGameTurn() >= endTurn))
 		return false;
 
 	if (!AdvanceState(wDeltaTime))
@@ -400,13 +410,22 @@ bool CImageOverlayEffect::IsCurrentCommandFinished() const
 		return this->executionState.remainingTime == 0;
 
 	else if (IsTurnBasedCommand(command.type)) {
-		const CDbRoom* pRoom = this->pRoomWidget->GetRoom();
-		const UINT gameTurn = pRoom ? pRoom->GetCurrentGame()->wPlayerTurn : 0;
-
+		const UINT gameTurn = GetGameTurn();
 		return this->executionState.endTurn == gameTurn;
 	}
 	else
 		return true;
+}
+
+UINT CImageOverlayEffect::GetGameTurn() const
+{
+	const CDbRoom* pRoom = this->pRoomWidget->GetRoom();
+
+	if (!pRoom)
+		return 0;
+
+	const CCurrentGame* pGame = pRoom->GetCurrentGame();
+	return pGame ? pGame->wPlayerTurn : 0;
 }
 
 Uint32 CImageOverlayEffect::UpdateCommand(

--- a/drodrpg/DROD/ImageOverlayEffect.h
+++ b/drodrpg/DROD/ImageOverlayEffect.h
@@ -88,6 +88,7 @@ private:
 	bool IsCurrentCommandFinished() const;
 	bool CanContinuePlayingEffect(const Uint32 dwRemainingTime) const;
 	bool CanLoop() const;
+	UINT GetGameTurn() const;
 	inline bool IsCommandQueueFinished() const;
 	bool IsImageDrawn();
 	bool IsRepeated() const;
@@ -133,13 +134,13 @@ private:
 	ImageOverlayCommands commands;
 	UINT index;
 	int loopIteration, maxLoops;
-	Uint32 startOfNextEffect;
+	Uint32 startOfNextEffect, endTime;
 
 	CommandExecution executionState;
 	vector<ParallelCommand> parallelCommands;
 
 	CRoomWidget* pRoomWidget;
-	UINT turnNo;
+	UINT turnNo, endTurn;
 
 	UINT instanceID; //for merging effect sets during play after move undo/checkpoint restore
 };

--- a/drodrpg/DRODLib/CharacterCommand.cpp
+++ b/drodrpg/DRODLib/CharacterCommand.cpp
@@ -306,7 +306,9 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("setx")] = ImageOverlayCommand::SetX;
 		commandMap[string("sety")] = ImageOverlayCommand::SetY;
 		commandMap[string("srcxy")] = ImageOverlayCommand::SrcXY;
+		commandMap[string("timelimit")] = ImageOverlayCommand::TimeLimit;
 		commandMap[string("tilegrid")] = ImageOverlayCommand::TileGrid;
+		commandMap[string("turnlimit")] = ImageOverlayCommand::TurnLimit;
 	}
 
 	for (CommandMap::const_iterator it = commandMap.begin(); it != commandMap.end(); ++it) {
@@ -477,6 +479,32 @@ int CImageOverlay::getGroup() const
 	}
 
 	return ImageOverlayCommand::DEFAULT_GROUP;
+}
+
+UINT CImageOverlay::getTimeLimit() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::TimeLimit)
+			return c.val[0] > 0 ? c.val[0] : 0;
+	}
+
+	return 0;
+}
+
+UINT CImageOverlay::getTurnLimit() const
+{
+	for (ImageOverlayCommands::const_iterator it = commands.begin();
+		it != commands.end(); ++it)
+	{
+		const ImageOverlayCommand& c = *it;
+		if (c.type == ImageOverlayCommand::TurnLimit)
+			return c.val[0] > 0 ? c.val[0] : 0;
+	}
+
+	return 0;
 }
 
 bool CImageOverlay::loopsForever() const

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -366,7 +366,9 @@ struct ImageOverlayCommand
 		SetY,
 		SrcXY,
 		TileGrid,
+		TimeLimit,
 		TurnDuration,
+		TurnLimit,
 		Invalid
 	};
 
@@ -397,6 +399,8 @@ public:
 
 	int getLayer() const;
 	int getGroup() const;
+	UINT getTimeLimit() const;
+	UINT getTurnLimit() const;
 	int clearsImageOverlays() const;
 	int clearsImageOverlayGroup() const;
 	bool loopsForever() const;

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -1093,6 +1093,8 @@ Essentially, it's being treated as a Tarstuff Mother, although there are certain
 <b>SetY (pixel)</b> -- set the image's Y coordinate<br />
 <b>SrcXY (x) (y)</b> - show the source image starting from the indicated pixel position<br />
 <b>TileGrid (w) (h)</b> -- replicate the image in a w by h grid. Tiling is not supported for images that have had rotations applied.<br />
+<b>TimeLimit (ms)</b> -- set a maximum duration for the overlay to exist. After this time has elapsed, the overlay will end, even if not all commands have been processed. Only the first instance of this command in a script is executed.<br />
+<b>TurnLimit (# turns)</b> -- set a maximum number of game turns for the overlay to exist. After that many turns have passed, the overlay will end, even if not all commands have been processed. Only the first instance of this command in a script is executed.<br />
 <br />
 As an example, you can make an image start invisible, fade in, display for a couple seconds, then fade out by providing the following command sequence:<br />
 <br />


### PR DESCRIPTION
Adds the `TimeLimit` and `TurnLimit` image overlay commands to DROD RPG. See #573 for details.