### PR TITLE
RPG: Improve editor functionality

### DIFF
--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -4635,6 +4635,14 @@ void CEditRoomScreen::PasteRegion(
 						}
 						break;
 
+						case T_MIRROR: case T_CRATE:
+						{
+							const UINT coveredTLayerObject = pSrcRoom->GetCoveredTSquare(xSrc, ySrc);
+							if (coveredTLayerObject == T_FUSE || coveredTLayerObject == T_MIST)
+								room.coveredTSquares.Add(xDest, yDest, coveredTLayerObject);
+						}
+						break;
+
 						default: break;
 					}
 				}
@@ -5449,7 +5457,8 @@ bool CEditRoomScreen::PlotObjectAt(
 	if (!IsMonsterTileNo(wObject))
 	{
 		//Was an object of this type already on this square?
-		const bool bObjectWasHere = this->pRoom->GetTSquare(wX,wY) == wObject;
+		const UINT tTile = this->pRoom->GetTSquare(wX, wY);
+		const bool bObjectWasHere = tTile == wObject;
 		COrbData *pOldOrb = NULL;
 		if (wObject == T_ORB)
 		{
@@ -5503,6 +5512,11 @@ bool CEditRoomScreen::PlotObjectAt(
 				break;
 				case T_ACCESSORY:
 					this->pRoom->SetTParam(wX,wY, this->wSelAccessoryType);
+				break;
+				case T_MIRROR: case T_CRATE:
+					//Allow items to be covered
+					if (tTile != T_EMPTY)
+						this->pRoom->coveredTSquares.Add(wX, wY, tTile);
 				break;
 				default:
 					//Keep track of what kind of floor is in room.

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -1290,11 +1290,6 @@ void CEditRoomScreen::AddPlotEffect(
 	UINT wCX, wCY;
 	switch (wObjectNo)
 	{
-		case T_STAIRS:
-		case T_STAIRS_UP:
-			wCX = wCY = 3; //at least 3x3
-			break;
-
 		case T_TARMOTHER:
 		case T_MUDMOTHER:
 		case T_GELMOTHER:
@@ -5742,31 +5737,15 @@ void CEditRoomScreen::PlotStaircase(const UINT wStairType)
 	const UINT wStartY = this->pRoomWidget->wStartY;
 	UINT wEndX = this->pRoomWidget->wEndX;
 	UINT wEndY = this->pRoomWidget->wEndY;
-	UINT wX, wY, wObjectNo;
-
-	//3x3 minimum
-	if (wEndX - wStartX < 2)
-		wEndX = wStartX + 2;
-	if (wEndY - wStartY < 2)
-		wEndY = wStartY + 2;
-
-	//Determine where staircase entrance should be.
-	const UINT wBaseY = wStairType == T_STAIRS ? wEndY : wStartY;
-	const UINT wEntranceY = wStairType == T_STAIRS ? wStartY : wEndY;
+	UINT wX, wY;
 
 	//If all spots aren't safe, don't plot anything
 	this->pRoomWidget->ResetPlot();
-	for (wY=wStartY; wY<=wEndY; ++wY)
-		for (wX=wStartX; wX<=wEndX; ++wX)
+	for (wY = wStartY; wY <= wEndY; ++wY)
+		for (wX = wStartX; wX <= wEndX; ++wX)
 		{
 			//Determine what part of staircase is being plotted at this square.
-			if (wX == wStartX || wX == wEndX || wY == wBaseY)
-				wObjectNo = T_WALL;
-			else if (wY == wEntranceY)
-				continue;   //stair entrance -- nothing will be plotted here
-			else
-				wObjectNo = wStairType;
-			if (!this->pRoomWidget->IsSafePlacement(wObjectNo, wX, wY))
+			if (!this->pRoomWidget->IsSafePlacement(wStairType, wX, wY))
 			{
 				EditObjects();
 				PaintHighlights();
@@ -5780,19 +5759,9 @@ void CEditRoomScreen::PlotStaircase(const UINT wStairType)
 	Changing();
 
 	//Plot staircase.
-	for (wY=wStartY; wY<=wEndY; ++wY)
-		for (wX=wStartX; wX<=wEndX; ++wX)
-		{
-			//Determine what part of staircase is being plotted at this square.
-			if (wX == wStartX || wX == wEndX || wY == wBaseY)
-				wObjectNo = T_WALL;
-			else if (wY == wEntranceY)
-				continue;   //stair entrance -- nothing will be plotted here
-			else
-				wObjectNo = wStairType;
-
-			PlotObjectAt(wX,wY,wObjectNo,this->wO);
-		}
+	for (wY = wStartY; wY <= wEndY; ++wY)
+		for (wX = wStartX; wX <= wEndX; ++wX)
+			PlotObjectAt(wX, wY, wStairType, this->wO);
 
 	SetDestinationEntrance(wStartX + 1, wStartY + 1, wEndX - 1, wEndY - 1);
 

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -1310,8 +1310,8 @@ void CEditRoomWidget::DrawCharacter(
 	const bool bAlt = (SDL_GetModState() & KMOD_ALT) != 0;
 	const bool preview = (bAlt != characterPreview);
 	const UINT wIdentity = pCharacter->GetIdentity();
-	UINT wFrameIndex = this->pTileImages[this->pRoom->ARRAYINDEX(pCharacter->wX, pCharacter->wY)].animFrame % ANIMATION_FRAMES;
-	if (wIdentity != M_NONE && IsAnimated() && preview)
+	UINT wFrameIndex = IsAnimated() ? this->pTileImages[this->pRoom->ARRAYINDEX(pCharacter->wX, pCharacter->wY)].animFrame % ANIMATION_FRAMES : 0;
+	if (wIdentity != M_NONE && preview)
 	{
 		//Draw NPC's actual in-game image.
 		ASSERT(wIdentity < MONSTER_COUNT ||

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -619,6 +619,10 @@ const
 		//Can't replace customizable objects: scrolls, obstacles and lights.
 		if (wObject == T_SCROLL || wObject == T_OBSTACLE || bIsLight(wObject))
 			return false;
+		if (bIsTLayerCoveringItem(wObject) && (wTileNo == T_FUSE || wTileNo == T_MIST))
+			return true;
+		if (wObject == T_FUSE && bIsTLayerCoveringItem(wTileNo))
+			return true;
 		if (wObject == T_BOMB)
 			return false; //facilitate explosion range highlighting
 		if (bIsBriar(wTileNo) && bIsBriar(wObject))
@@ -627,6 +631,8 @@ const
 			return true;
 		if (bIsShovel(wTileNo) && bIsShovel(wObject))
 			return true;
+		if (wTileNo == T_MIRROR && wObject == T_MIRROR)
+			return false;
 		return wObject == wTileNo;
 	case 2:
 		//Same type of monster can replace itself, except long monsters and special character.

--- a/drodrpg/DROD/PendingPlotEffect.cpp
+++ b/drodrpg/DROD/PendingPlotEffect.cpp
@@ -142,10 +142,6 @@ void CPendingPlotEffect::Draw(SDL_Surface& destSurface)
 	case T_SWORDSMAN:
 		PlotSwordsman(this->wDrawStartX, this->wDrawStartY, destSurface);
 		break;
-	case T_STAIRS:
-	case T_STAIRS_UP:
-		PlotStaircase(this->wDrawStartX, this->wDrawStartY, this->wDrawEndX, this->wDrawEndY, this->wObjectNo, destSurface);
-		break;
 	default:
 	{
 		UINT wX, wY, wTileNo;
@@ -160,36 +156,6 @@ void CPendingPlotEffect::Draw(SDL_Surface& destSurface)
 	}
 	break;
 	}
-}
-
-//*****************************************************************************
-void CPendingPlotEffect::PlotStaircase(
-//Staircase is drawn with a wall around the left, bottom and right sides.
-//(And nothing on top.)
-//
-//Params:
-	const UINT wStartX, const UINT wStartY, const UINT wEndX, const UINT wEndY,
-	const UINT wStairType,     //(in)
-	SDL_Surface& destSurface) //(in)
-{
-	ASSERT(bIsStairs(wStairType));
-	const UINT wBaseY = wStairType == T_STAIRS ? wEndY : wStartY;
-	const UINT wEntranceY = wStairType == T_STAIRS ? wStartY : wEndY;
-	UINT wX, wY, wObjectNo, wTileNo;
-	for (wY=wStartY; wY<=wEndY; ++wY)
-		for (wX=wStartX; wX<=wEndX; ++wX)
-		{
-			//Determine what part of staircase is being plotted at this square.
-			if (wX == wStartX || wX == wEndX || wY == wBaseY)
-				wObjectNo = T_WALL;
-			else if (wY == wEntranceY)
-				continue;   //stair entrance -- nothing will be plotted here
-			else
-				wObjectNo = wStairType;
-
-			wTileNo = (bIsWall(wObjectNo) ? TI_WALL : TI_STAIRS);
-			PlotTile(wX, wY, wObjectNo, wTileNo, destSurface);
-		}
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/PendingPlotEffect.h
+++ b/drodrpg/DROD/PendingPlotEffect.h
@@ -44,9 +44,6 @@ protected:
 	virtual void Draw(SDL_Surface& destSurface);
 
 private:
-	void PlotStaircase(const UINT wStartX, const UINT wStartY,
-			const UINT wEndX, const UINT wEndY, const UINT wStairType,
-			SDL_Surface& pDestSurface);
 	void PlotSwordsman(const UINT wSwordsmanX, const UINT wSwordsmanY, SDL_Surface& pDestSurface);
 	void PlotTile(const UINT wX, const UINT wY, const UINT wObjectNo,
 			const UINT wTileNo, SDL_Surface& pDestSurface);

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -275,6 +275,8 @@ static inline bool bIsDEFUp(const UINT t) { return t == T_DEF_UP || t == T_DEF_U
 
 static inline bool bIsShovel(const UINT t) { return t == T_SHOVEL1 || t == T_SHOVEL3 || t == T_SHOVEL10; }
 
+static inline bool bIsTLayerCoveringItem(const UINT t) { return t == T_MIRROR || t == T_CRATE; }
+
 static inline bool bIsDiggableBlock(const UINT t) { return t == T_DIRT1 || t == T_DIRT3 || t == T_DIRT5; }
 
 static inline bool bIsSolidOTile(const UINT t) { return bIsWall(t) || bIsCrumblyWall(t) || bIsDoor(t); }


### PR DESCRIPTION
A few fixes/improvements for editing in RPG:

- Removes the automatic placement of walls around stairs, to match the change in TSS.
- Adds the ability to cover fuses and mist with mirrors and crates in the editor.
- Fixes automatic NPC previewing when an object menu is open. Previously, previewing required animation to be active, which was blocked when an object menu was opened. The code has been tweaked to allow preview even when animation is not happening. (thread: http://forum.caravelgames.com/viewtopic.php?TopicID=45910)