### PR TITLE
RPG: Add mist vent

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4200,6 +4200,7 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(T_MIRROR, g_pTheDB->GetMessageText(MID_Mirror));
 	pListBox->AddItem(T_CRATE, g_pTheDB->GetMessageText(MID_Crate));
 	pListBox->AddItem(T_MIST, g_pTheDB->GetMessageText(MID_Mist));
+	pListBox->AddItem(T_MISTVENT, g_pTheDB->GetMessageText(MID_MistVent));
 	pListBox->AddItem(T_HEALTH_HUGE, g_pTheDB->GetMessageText(MID_HugeHealth));
 	pListBox->AddItem(T_HEALTH_BIG, g_pTheDB->GetMessageText(MID_LargeHealth));
 	pListBox->AddItem(T_HEALTH_MED, g_pTheDB->GetMessageText(MID_MediumHealth));

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -245,6 +245,7 @@ const UINT MenuDisplayTiles[TOTAL_EDIT_TILE_COUNT][4] =
 	{ TI_ARROW_OFF_W },                                //T_ARROW_OFF_W
 	{ TI_ARROW_OFF_NW },                               //T_ARROW_OFF_NW
 	{ TI_MIST },                                       //T_MIST
+	{ TI_MISTVENT },                                   //T_MISTVENT
 
 	//monsters
 	{TI_ROACH_S},
@@ -412,6 +413,7 @@ const bool SinglePlacement[TOTAL_EDIT_TILE_COUNT] =
 	0, //T_ARROW_OFF_W   113
 	0, //T_ARROW_OFF_NW  114
 	0, //T_MIST          115
+	0, //T_MISTVENT      116
 
 	0, //T_ROACH         +0
 	0, //T_QROACH        +1
@@ -477,7 +479,7 @@ const UINT wItemX[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, 1, 1, 1, 1, //shovels, dirt
 	1, //ice
 	1, 1, 1, 1, 1, 1, 1, 1,  //8 disabled arrows
-	1, //mist
+	1, 1, //mist, vent
 	1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
 	1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1, 1, //M+13
 	2, 1, 1 //psuedo tiles
@@ -503,7 +505,7 @@ const UINT wItemY[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, 1, 1, 1, 1, //shovels, dirt
 	1, //ice
 	1, 1, 1, 1, 1, 1, 1, 1,  //8 disabled arrows
-	1, //mist
+	1, 1, //mist, vent
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+13
 	1, 1, 1 //pseudo tiles
@@ -581,14 +583,14 @@ const UINT oLayerFullEntries[numOLayerFullEntries] = {
 };
 */
 
-const UINT numOLayerEntries = 27;
+const UINT numOLayerEntries = 28;
 const UINT oLayerEntries[numOLayerEntries] = {
 	T_WALL, T_WALL2, T_WALL_B, T_WALL_H, T_STAIRS_UP,
 	T_DOOR_Y, T_DOOR_G, T_DOOR_C, T_PRESSPLATE, T_STAIRS,
 	T_DOOR_R, T_DOOR_B, T_DOOR_MONEY, T_GOO, T_HOT,
 	T_TRAPDOOR, T_PIT, T_PLATFORM_P, T_BRIDGE, T_TUNNEL_E,
 	T_TRAPDOOR2, T_WATER, T_PLATFORM_W, T_THINICE, T_FLOOR, T_FLOOR_IMAGE,
-	T_DIRT1
+	T_DIRT1, T_MISTVENT
 };
 
 const UINT numFLayerEntries = 7;
@@ -5392,6 +5394,7 @@ void CEditRoomScreen::PlotObjects()
 				case T_GOO:
 					g_pTheSound->PlaySoundEffect(SEID_STABTAR);  break;
 				case T_MIST:
+				case T_MISTVENT:
 					g_pTheSound->PlaySoundEffect(SEID_PUFF_EXPLOSION); break;
 				case T_ROCKGOLEM:
 				case T_ROCKGIANT:

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -887,7 +887,8 @@ const
 					bIsDoor(wTileNo[0]) || bIsOpenDoor(wTileNo[0]) ||
 					bIsBridge(wTileNo[0]) || wTileNo[0] == T_HOT ||
 					wTileNo[0] == T_GOO || bIsTunnel(wTileNo[0]) ||
-					wTileNo[0] == T_PRESSPLATE || bIsPlatform(wTileNo[0])) &&
+					wTileNo[0] == T_PRESSPLATE || bIsPlatform(wTileNo[0]) ||
+					wTileNo[0] == T_MISTVENT) &&
 				(!pMonster || wTileNo[2] == M_CHARACTER);
 		case T_BRIAR_SOURCE: case T_BRIAR_DEAD: case T_BRIAR_LIVE:
 			//On normal floor, platforms, goo or water.
@@ -896,7 +897,7 @@ const
 						bIsOpenDoor(wTileNo[0]) || bIsBridge(wTileNo[0]) ||
 						bIsPlatform(wTileNo[0]) ||
 						wTileNo[0] == T_HOT || wTileNo[0] == T_GOO ||
-						bIsWater(wTileNo[0])) &&
+						bIsWater(wTileNo[0]) || wTileNo[0] == T_MISTVENT) &&
 					(!pMonster || wTileNo[2] == M_CHARACTER);
 		case T_MIRROR:
 		case T_CRATE:

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -9228,6 +9228,13 @@ bool CRoomWidget::UpdateDrawSquareInfo(
 				pTI->dirty = 1;
 				pTI->t = wTileImage;
 			}
+			if (bIsMistTI(wTileImage)) {
+				BYTE corners = GetMistCorners(this->pRoom, wCol, wRow);
+				if (corners != pTI->mistCorners) {
+					pTI->dirty = 1;
+					pTI->mistCorners = corners;
+				}
+			}
 
 			wTileImage = GetTileImageForTileNo(this->pRoom->GetCoveredTSquare(wCol, wRow));
 			if (wTileImage == CALC_NEEDED) {
@@ -9237,6 +9244,13 @@ bool CRoomWidget::UpdateDrawSquareInfo(
 			{
 				pTI->dirty = 1;
 				pTI->tCovered = wTileImage;
+			}
+			if (bIsMistTI(wTileImage)) {
+				BYTE corners = GetMistCorners(this->pRoom, wCol, wRow);
+				if (corners != pTI->mistCorners) {
+					pTI->dirty = 1;
+					pTI->mistCorners = corners;
+				}
 			}
 
 			}	//recalc

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -79,6 +79,7 @@ struct TileImages
 	BYTE damaged : 1;    //damaged tile must be updated on screen this frame
 	BYTE dirty : 1;      //tile is dirty and needs to be repainted
 	BYTE monster : 1;    //monster piece is on this tile
+	BYTE mistCorners: 4; //diagonally adjacent mist tiles
 };
 
 typedef USHORT LIGHTTYPE; //represents a light value on one color channel

--- a/drodrpg/DROD/TileImageCalcs.cpp
+++ b/drodrpg/DROD/TileImageCalcs.cpp
@@ -2024,6 +2024,25 @@ UINT CalcTileImageForMist(
 }
 
 //*****************************************************************************
+BYTE GetMistCorners(const CDbRoom* pRoom, const UINT wCol, const UINT wRow)
+{
+	BYTE corners = 0;
+	if (pRoom->IsValidColRow(wCol - 1, wRow - 1) && pRoom->IsEitherTSquare(wCol - 1, wRow - 1, T_MIST))
+		corners += 1;
+
+	if (pRoom->IsValidColRow(wCol + 1, wRow - 1) && pRoom->IsEitherTSquare(wCol + 1, wRow - 1, T_MIST))
+		corners += 2;
+
+	if (pRoom->IsValidColRow(wCol - 1, wRow + 1) && pRoom->IsEitherTSquare(wCol - 1, wRow + 1, T_MIST))
+		corners += 4;
+
+	if (pRoom->IsValidColRow(wCol + 1, wRow + 1) && pRoom->IsEitherTSquare(wCol + 1, wRow + 1, T_MIST))
+		corners += 8;
+
+	return corners;
+}
+
+//*****************************************************************************
 UINT CalcTileImageForToken(const BYTE tParam)
 //Calculate image for this type of token.
 {

--- a/drodrpg/DROD/TileImageCalcs.cpp
+++ b/drodrpg/DROD/TileImageCalcs.cpp
@@ -1177,7 +1177,7 @@ EDGETYPE CalcEdge(
 		case T_BRIDGE: case T_BRIDGE_H: case T_BRIDGE_V:
 		case T_FLOOR: case T_FLOOR_M: case T_FLOOR_IMAGE:
 		case T_FLOOR_ROAD: case T_FLOOR_GRASS: case T_FLOOR_DIRT: case T_FLOOR_ALT:
-		case T_HOT: case T_PRESSPLATE: case T_GOO:
+		case T_HOT: case T_PRESSPLATE: case T_GOO: case T_MISTVENT:
 			if (bIsWall(wAdjTileNo) || bIsCrumblyWall(wAdjTileNo) ||
 					bIsDoor(wAdjTileNo) || bIsOpenDoor(wAdjTileNo) ||
 					wAdjTileNo==T_OBSTACLE || bIsFallingTile(wAdjTileNo) ||
@@ -1196,7 +1196,7 @@ EDGETYPE CalcEdge(
 				return EDGE_WALL;
 			if ((side == N || side == W) &&
 					wTileNo != T_FLOOR_IMAGE && wAdjTileNo != T_FLOOR_IMAGE &&
-					wTileNo != T_GOO && wAdjTileNo != T_GOO)
+					wTileNo != T_GOO && wAdjTileNo != T_GOO && wAdjTileNo != T_MISTVENT)
 				return EDGE_FLOOR;
 			return EDGE_NONE;
 
@@ -1553,6 +1553,7 @@ UINT GetTileImageForTileNo(
 		TI_ARROW_OFF_W,   //T_ARROW_OFF_W
 		TI_ARROW_OFF_NW,  //T_ARROW_OFF_NW
 		CALC_NEEDED,      //T_MIST
+		TI_MISTVENT,      //T_MISTVENT
 	};
 
 	ASSERT(IsValidTileNo(wTileNo));

--- a/drodrpg/DROD/TileImageCalcs.h
+++ b/drodrpg/DROD/TileImageCalcs.h
@@ -77,6 +77,8 @@ WALLTYPE GetWallTypeAtSquare(const CDbRoom *pRoom, int nCol, int nRow);
 void GetObstacleStats(const CDbRoom *pRoom, const UINT wCol, const UINT wRow,
 		UINT& wObSizeIndex, UINT& xPos, UINT& yPos);
 
+BYTE GetMistCorners(const CDbRoom* pRoom, const UINT wCol, const UINT wRow);
+
 //Monster tiles.
 //Determined by orientation and animation frame.
 static const UINT DONT_USE = (UINT)-1;

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2447,4 +2447,8 @@ static inline bool bIsBriarTI(const UINT ti)
 		(ti >= TI_BRIAREDGE_SE && ti <= TI_BRIARROOT_NW);
 };
 
+static inline bool bIsMistTI(const UINT ti) {
+	return ti >= TI_MIST && ti <= TI_MIST_NW;
+}
+
 #endif //...#ifndef TILEIMAGECONSTANTS_H

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2438,7 +2438,9 @@
 #define TI_FLUFFBLOOD_1   2255
 #define TI_FLUFFBLOOD_2   2256
 
-static const UINT TI_COUNT = 2257;
+#define TI_MISTVENT       2257
+
+static const UINT TI_COUNT = 2258;
 
 static inline bool bIsBriarTI(const UINT ti)
 {

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3067,6 +3067,7 @@ void CCurrentGame::ProcessMonsterDefeat(
 	}
 
 	//Each time a monster is fought, briar roots expand.
+	this->pRoom->ExpandMist(CueEvents);
 	this->pRoom->ExpandBriars(CueEvents);
 }
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -811,6 +811,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ImageOverlayStrategy: strText = "Image overlay strategy"; break;
 		case MID_Mist: strText = "Mist"; break;
 		case MID_MistDestroyed: strText = "Mist destroyed"; break;
+		case MID_MistVent: strText = "Mist Vent"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -146,6 +146,7 @@ public:
 	Weather        weather;	//environmental weather conditions
 	CBridge        bridges;
 //	CBuilding      building; //tiles marked for building
+	CCoordSet      mistVents;
 
 	CCoordSet      geometryChanges, disabledLights; //for front end -- where lighting must be updated
 
@@ -222,6 +223,7 @@ public:
 
 	void           EnableForceArrow(const UINT wX, const UINT wY);
 	void           ExpandBriars(CCueEvents& CueEvents);
+	void           ExpandMist(CCueEvents& CueEvents);
 //	CMonster*      FindNextClone();
 	void           FixUnstableTar(CCueEvents& CueEvents);
 	void           FindOrbsToOpenDoor(CCoordSet& orbs, CCoordSet& doorSquares) const;
@@ -237,6 +239,7 @@ public:
 	void           GetConnectedTiles(const UINT wX, const UINT wY,
 			const CTileMask &tileMask, const bool b8Neighbor, CCoordSet& squares,
 			const CCoordSet* pIgnoreSquares=NULL, const CCoordSet* pRegionMask=NULL) const;
+	void           GetConnectedMistTiles(const UINT wX, const UINT wY, CCoordSet& mistSquares) const;
 	CCurrentGame*  GetCurrentGame() const {return this->pCurrentGame;}
 	UINT           GetExitIndexAt(const UINT wX, const UINT wY) const;
 	bool           GetExitEntranceIDAt(const UINT wX, const UINT wY, UINT &dwEntranceID) const;
@@ -419,6 +422,7 @@ private:
 	enum tartype {oldtar, newtar, notar};
 
 	void           AddPlatformPiece(const UINT wX, const UINT wY, CCoordIndex &plots);
+	bool           CanExpandMist(const UINT wX, const UINT wY) const;
 	void           Clear();
 	void           ClearPushInfo();
 	void           CloseDoor(const UINT wX, const UINT wY, CCueEvents& CueEvents);

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -163,8 +163,9 @@
 #define T_ARROW_OFF_W   113
 #define T_ARROW_OFF_NW  114
 #define T_MIST          115 //mist that nullifies DEF
+#define T_MISTVENT      116 //produces and expands mist
 
-#define TILE_COUNT     (116) //Number of tile constants from above list.
+#define TILE_COUNT     (117) //Number of tile constants from above list.
 static inline bool IsValidTileNo(const UINT t) {return t < TILE_COUNT;}
 
 //
@@ -183,7 +184,7 @@ static inline bool bIsFallingTile(const UINT t) { return bIsTrapdoor(t) || bIsTh
 static inline bool bIsPlainFloor(const UINT t) {return t==T_FLOOR || (t>=T_FLOOR_M && t<=T_FLOOR_ALT) || t==T_FLOOR_IMAGE;}
 
 static inline bool bIsFloor(const UINT t) {return bIsPlainFloor(t) ||
-		bIsTrapdoor(t) || bIsBridge(t) || bIsThinIce(t) || t==T_HOT || t==T_GOO || t==T_PRESSPLATE;}
+		bIsTrapdoor(t) || bIsBridge(t) || bIsThinIce(t) || t==T_HOT || t==T_GOO || t==T_PRESSPLATE || t==T_MISTVENT;}
 
 static inline bool bIsLight(const UINT t) {return t==T_LIGHT;}
 
@@ -279,7 +280,7 @@ static inline bool bIsTLayerCoveringItem(const UINT t) { return t == T_MIRROR ||
 
 static inline bool bIsDiggableBlock(const UINT t) { return t == T_DIRT1 || t == T_DIRT3 || t == T_DIRT5; }
 
-static inline bool bIsSolidOTile(const UINT t) { return bIsWall(t) || bIsCrumblyWall(t) || bIsDoor(t); }
+static inline bool bIsSolidOTile(const UINT t) { return bIsWall(t) || bIsCrumblyWall(t) || bIsDoor(t) || bIsDiggableBlock(t); }
 
 //Obstacle parameter bit format: <Top edge>:1 <Left edge>:1 <64 possible obstacle types>:6
 #define OBSTACLE_TOP (0x80)
@@ -523,6 +524,7 @@ static const UINT TILE_LAYER[TOTAL_EDIT_TILE_COUNT] =
 	LAYER_FLOOR, //T_ARROW_OFF_W
 	LAYER_FLOOR, //T_ARROW_OFF_NW
 	LAYER_TRANSPARENT, //T_MIST
+	LAYER_OPAQUE, //T_MISTVENT
 
 	LAYER_MONSTER, //M_ROACH         +0
 	LAYER_MONSTER, //M_QROACH        +1
@@ -686,6 +688,7 @@ static const UINT TILE_MID[TOTAL_EDIT_TILE_COUNT] =
 	MID_ForceArrowDisabled, //T_ARROW_OFF_W
 	MID_ForceArrowDisabled, //T_ARROW_OFF_NW
 	MID_Mist, //T_MIST
+	MID_MistVent, //T_MISTVENT
 
 	MID_Roach,        //M_ROACH         +0
 	MID_RoachQueen,   //M_QROACH        +1

--- a/drodrpg/Texts/EditScreens.uni
+++ b/drodrpg/Texts/EditScreens.uni
@@ -742,6 +742,10 @@ Dirt Block (5)
 [eng]
 Thin Ice
 
+[MID_MistVent]
+[eng]
+Mist Vent
+
 [MID_ForceArrowDisabled]
 [eng]
 Disabled force arrow

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -311,6 +311,7 @@ enum MID_CONSTANT {
   MID_ForceArrowDisabledSE = 1881,
   MID_ForceArrowDisabledSW = 1882,
   MID_Mist = 1885,
+  MID_MistVent = 1887,
   MID_FloorMosaic = 332,
   MID_FloorRoad = 333,
   MID_FloorGrass = 334,


### PR DESCRIPTION
Adds a new tile that generates and expands mist after a monster is battled. A vent with no T-layer item on its square will create a single tile of mist at its location. A vent with mist already on it will expand all connect mist. If multiple vents are attached to a group of connect mist tiles, only one expansion occurs.

There are a few mist-specific methods added, to support mist being able to connect via covered tiles.

This PR also includes a fix for mist drawing when new mist tiles are plotted diagonally adjacent to existing mist.