### PR TITLE
Restore fix to accept alternative arrow key bindings

### DIFF
--- a/DROD/RoomScreen.h
+++ b/DROD/RoomScreen.h
@@ -93,6 +93,7 @@ protected:
 
 private:
 	std::map<InputKey,int> InputKeyToCommandMap;
+	std::map<InputKey, int> AlternativeKeyToCommandMap;
 };
 
 #endif //...#ifndef ROOMSCREEN_H


### PR DESCRIPTION
During a merge between `tss-5.2-dev` and `master`, the fix from #483 got clobbered by the changes to support more rebindable keys. Since the underlying problem is still there, I've ported the fix to work with the new keybinding system.