### PR TITLE
RPG: Add fire trap element

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -3984,6 +3984,8 @@ void CCharacterDialogWidget::PopulateEventListBox()
 	this->pEventListBox->AddItem(CID_CutBriar, g_pTheDB->GetMessageText(MID_CutBriar));
 	this->pEventListBox->AddItem(CID_DrankPotion, g_pTheDB->GetMessageText(MID_DrankPotion));
 	this->pEventListBox->AddItem(CID_EvilEyeWoke, g_pTheDB->GetMessageText(MID_EvilEyeWoke));
+	this->pEventListBox->AddItem(CID_Firetrap, g_pTheDB->GetMessageText(MID_FiretrapBurning));
+	this->pEventListBox->AddItem(CID_FiretrapActivated, g_pTheDB->GetMessageText(MID_FiretrapActivated));
 	this->pEventListBox->AddItem(CID_FuseBurning, g_pTheDB->GetMessageText(MID_FuseBurning));
 	this->pEventListBox->AddItem(CID_GelBabyFormed, g_pTheDB->GetMessageText(MID_GelBabyFormed));
 //	this->pEventListBox->AddItem(CID_GelGrew, g_pTheDB->GetMessageText(MID_GelGrew));
@@ -4155,6 +4157,8 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(T_DOOR_BO, g_pTheDB->GetMessageText(MID_OpenBlackDoor));
 	pListBox->AddItem(T_DOOR_MONEY, g_pTheDB->GetMessageText(MID_MoneyDoor));
 	pListBox->AddItem(T_DOOR_MONEYO, g_pTheDB->GetMessageText(MID_OpenMoneyDoor));
+	pListBox->AddItem(T_FIRETRAP, g_pTheDB->GetMessageText(MID_Firetrap));
+	pListBox->AddItem(T_FIRETRAP_ON, g_pTheDB->GetMessageText(MID_FiretrapOn));
 	pListBox->AddItem(T_DIRT1, g_pTheDB->GetMessageText(MID_Dirt1));
 	pListBox->AddItem(T_DIRT3, g_pTheDB->GetMessageText(MID_Dirt3));
 	pListBox->AddItem(T_DIRT5, g_pTheDB->GetMessageText(MID_Dirt5));
@@ -4499,6 +4503,7 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_HOTTILE, g_pTheDB->GetMessageText(MID_VarHotTile));
 	this->pVarListBox->AddItem(ScriptVars::P_EXPLOSION, g_pTheDB->GetMessageText(MID_VarExplosion));
 	this->pVarListBox->AddItem(ScriptVars::P_BEAM, g_pTheDB->GetMessageText(MID_VarBeam));
+	this->pVarListBox->AddItem(ScriptVars::P_FIRETRAP, g_pTheDB->GetMessageText(MID_VarFiretrap));
 
 	this->pVarListBox->AddItem(ScriptVars::P_HP, g_pTheDB->GetMessageText(MID_VarHP));
 	this->pVarListBox->AddItem(ScriptVars::P_ATK, g_pTheDB->GetMessageText(MID_VarAtk));

--- a/drodrpg/DROD/DROD.2019.vcxproj
+++ b/drodrpg/DROD/DROD.2019.vcxproj
@@ -562,6 +562,7 @@
     <ClCompile Include="EquipmentDescription.cpp" />
     <ClCompile Include="ExplosionEffect.cpp" />
     <ClCompile Include="FaceWidget.cpp" />
+    <ClCompile Include="FiretrapEffect.cpp" />
     <ClCompile Include="GameScreen.cpp" />
     <ClCompile Include="HoldSelectScreen.cpp" />
     <ClCompile Include="IceMeltEffect.cpp" />
@@ -637,6 +638,7 @@
     <ClInclude Include="EquipmentDescription.h" />
     <ClInclude Include="ExplosionEffect.h" />
     <ClInclude Include="FaceWidget.h" />
+    <ClInclude Include="FiretrapEffect.h" />
     <ClInclude Include="GameScreen.h" />
     <ClInclude Include="HoldSelectScreen.h" />
     <ClInclude Include="IceMeltEffect.h" />

--- a/drodrpg/DROD/DrodEffect.h
+++ b/drodrpg/DROD/DrodEffect.h
@@ -67,6 +67,7 @@ enum EffectType
 	ERAINDROP,        //a falling rain drop
 	EDAMAGEPREVIEW,   //hovering enemy damage display
 	EIMAGEOVERLAY,    //image overlay
+	EFIRETRAP,        //fire trap
 };
 
 //*****************************************************************************
@@ -93,7 +94,8 @@ enum VisualEffectType
 	VET_JITTER=17,
 	VET_STRONGHIT=18,
 	VET_EQUIP=19,
-	VET_ICEMELT=20
+	VET_ICEMELT=20,
+	VET_FIRETRAP=21
 };
 
 #endif //...#ifndef DRODEFFECT_H

--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -33,6 +33,7 @@
 #include "BloodEffect.h"
 #include "DebrisEffect.h"
 #include "ExplosionEffect.h"
+#include "FiretrapEffect.h"
 #include "IceMeltEffect.h"
 #include "ImageOverlayEffect.h"
 #include "RoomWidget.h"
@@ -465,6 +466,18 @@ void CDrodScreen::AddVisualCues(CCueEvents& CueEvents, CRoomWidget* pRoomWidget,
 					new CFluffStabEffect(pRoomWidget, *pCoord,
 						GetEffectDuration(pGame, 6), GetParticleSpeed(pGame, 2)));
 			break;
+		}
+	}
+
+	if (CueEvents.HasOccurred(CID_Firetrap)) {
+		pRoomWidget->RemoveMLayerEffectsOfType(EFIRETRAP);
+		const UINT duration = GetEffectDuration(pGame, 450);
+		for (pObj = CueEvents.GetFirstPrivateData(CID_Firetrap);
+			pObj != NULL; pObj = CueEvents.GetNextPrivateData())
+		{
+			const CCoord* pCoord = DYN_CAST(const CCoord*, const CAttachableObject*, pObj);
+			pRoomWidget->AddMLayerEffect(
+				new CFiretrapEffect(pRoomWidget, *pCoord, GetEffectDuration(pGame, duration)));
 		}
 	}
 

--- a/drodrpg/DROD/DrodSound.cpp
+++ b/drodrpg/DROD/DrodSound.cpp
@@ -129,6 +129,8 @@ const
 		case SEID_DOOROPEN:     strKeyName="DoorOpen"; break;
 		case SEID_EVILEYEWOKE:  strKeyName="EvilEyeWoke"; break;
 		case SEID_FALLING:  strKeyName="Falling"; break;
+		case SEID_FIRETRAP: strKeyName = "Firetrap"; break;
+		case SEID_FIRETRAP_START: strKeyName = "FiretrapStart"; break;
 		case SEID_FROZEN:  strKeyName="Frozen"; break;
 
 		case SEID_SLAYERKILL:      strKeyName="SlayerKill"; break;
@@ -348,6 +350,8 @@ bool CDrodSound::LoadSoundEffects()
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_DOOROPEN );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_EVILEYEWOKE );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_FALLING );
+	SHARED_CHANNEL_SOUNDEFFECT( SEID_FIRETRAP );
+	SHARED_CHANNEL_SOUNDEFFECT( SEID_FIRETRAP_START );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_FROZEN );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_HIT );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_ICEMELT );

--- a/drodrpg/DROD/DrodSound.h
+++ b/drodrpg/DROD/DrodSound.h
@@ -141,6 +141,8 @@ enum SEID
 	SEID_DIG,
 	SEID_ICEMELT,
 	SEID_PUFF_EXPLOSION,
+	SEID_FIRETRAP,
+	SEID_FIRETRAP_START,
 
 	//Grouped sound effects -- may only play one at a time -- designated private channels.
 	//Channel n+1--Tendry's voice.

--- a/drodrpg/DROD/EditRoomScreen.h
+++ b/drodrpg/DROD/EditRoomScreen.h
@@ -169,6 +169,7 @@ private:
 	bool     RemoveMonster(CMonster *pMonster);
 	bool     RemoveObjectAt(const UINT wX, const UINT wY, const UINT wPlottedObject,
 			bool &bSpecialTileRemoved, bool &bTarRemoved, bool &bStairsRemoved);
+	void     RemoveOrbAssociationAt(const UINT wX, const UINT wY);
 	void     RepairDoors(const UINT doorType);
 	void     ResetAdjacentRooms();
 	void     ResetMembers();

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -594,7 +594,7 @@ const
 		//Floor types can replace themselves,
 		//except for doors: to facilitate editing them when clicked on.
 		if (bIsPlainFloor(wTileNo)) return true; //anything can replace floor
-		if (wTileNo == T_HOT || wTileNo == T_GOO) return true;
+		if (wTileNo == T_HOT || wTileNo == T_GOO || bIsFiretrap(wTileNo)) return true;
 		if (bIsWall(wTileNo) && bIsWall(wObject)) return true;
 		if (bIsCrumblyWall(wTileNo) && bIsCrumblyWall(wObject)) return true;
 		if (bIsTunnel(wTileNo) && bIsTunnel(wObject)) return true;
@@ -759,6 +759,7 @@ const
 		case T_THINICE:
 		case T_GOO:
 		case T_HOT:
+		case T_FIRETRAP: case T_FIRETRAP_ON:
 			//Anything can be on these.
 			return true;
 		case T_FLOOR: case T_FLOOR_M:
@@ -877,7 +878,8 @@ const
 						bIsWall(wTileNo[0]) || bIsCrumblyWall(wTileNo[0]) ||
 						bIsBridge(wTileNo[0]) || wTileNo[0] == T_HOT ||
 						wTileNo[0] == T_GOO || bIsTunnel(wTileNo[0]) ||
-						wTileNo[0] == T_PRESSPLATE || bIsPlatform(wTileNo[0])) &&
+						wTileNo[0] == T_PRESSPLATE || bIsPlatform(wTileNo[0]) ||
+						bIsFiretrap(wTileNo[0])) &&
 					(!pMonster || wTileNo[2] == M_CHARACTER);
 		case T_BOMB:
 			//On normal floor, wall, goo, tunnels, or pressure plates.
@@ -888,7 +890,7 @@ const
 					bIsBridge(wTileNo[0]) || wTileNo[0] == T_HOT ||
 					wTileNo[0] == T_GOO || bIsTunnel(wTileNo[0]) ||
 					wTileNo[0] == T_PRESSPLATE || bIsPlatform(wTileNo[0]) ||
-					wTileNo[0] == T_MISTVENT) &&
+					wTileNo[0] == T_MISTVENT || bIsFiretrap(wTileNo[0])) &&
 				(!pMonster || wTileNo[2] == M_CHARACTER);
 		case T_BRIAR_SOURCE: case T_BRIAR_DEAD: case T_BRIAR_LIVE:
 			//On normal floor, platforms, goo or water.
@@ -897,7 +899,8 @@ const
 						bIsOpenDoor(wTileNo[0]) || bIsBridge(wTileNo[0]) ||
 						bIsPlatform(wTileNo[0]) ||
 						wTileNo[0] == T_HOT || wTileNo[0] == T_GOO ||
-						bIsWater(wTileNo[0]) || wTileNo[0] == T_MISTVENT) &&
+						bIsWater(wTileNo[0]) || wTileNo[0] == T_MISTVENT ||
+						bIsFiretrap(wTileNo[0])) &&
 					(!pMonster || wTileNo[2] == M_CHARACTER);
 		case T_MIRROR:
 		case T_CRATE:
@@ -906,7 +909,7 @@ const
 					(bIsFloor(wTileNo[0]) || bIsWall(wTileNo[0]) || bIsCrumblyWall(wTileNo[0]) ||
 						bIsOpenDoor(wTileNo[0]) || bIsDoor(wTileNo[0]) ||
 						bIsTunnel(wTileNo[0]) || bIsPlatform(wTileNo[0]) ||
-						wTileNo[0] == T_GOO) &&
+						wTileNo[0] == T_GOO || bIsFiretrap(wTileNo[0])) &&
 						(!pMonster || wTileNo[2] == M_CHARACTER);
 		case T_LIGHT:
 			//Light -- only on floor, walls, pit.

--- a/drodrpg/DROD/FiretrapEffect.cpp
+++ b/drodrpg/DROD/FiretrapEffect.cpp
@@ -1,0 +1,65 @@
+// $Id$
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2002, 2005
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s): Mike Rimer (mrimer)
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#include "FiretrapEffect.h"
+#include "DrodEffect.h"
+#include "TileImageConstants.h"
+#include <FrontEndLib/BitmapManager.h>
+
+//********************************************************************************
+CFiretrapEffect::CFiretrapEffect(
+//Constructor.
+//
+//Params:
+	CWidget *pSetWidget,    //(in)   Should be a room widget.
+	const CCoord &SetCoord,    //(in)   Location of effect.
+	const UINT duration)
+	: CAnimatedTileEffect(pSetWidget,SetCoord,duration,0,false, EFIRETRAP)
+{
+}
+
+//********************************************************************************
+bool CFiretrapEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
+{
+	static const UINT frames = 9;
+
+	const UINT frame = UINT(GetRemainingFraction() * frames);
+	switch (frame % 3) {
+	case 0:
+		this->wTileNo = TI_FIRETRAP_UP1; break;
+	case 1:
+		this->wTileNo = TI_FIRETRAP_UP2; break;
+	case 2:
+		this->wTileNo = TI_FIRETRAP_UP3; break;
+	default:
+		ASSERT(!"Unsupported firetrap frame");
+		break;
+	}
+
+	this->nOpacity = g_pTheBM->bAlpha ? (BYTE)(GetRemainingFraction() * 255.0) : 255;
+
+	return true;
+}

--- a/drodrpg/DROD/FiretrapEffect.h
+++ b/drodrpg/DROD/FiretrapEffect.h
@@ -1,0 +1,42 @@
+// $Id$
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2002, 2005, 2012
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s): Mike Rimer (mrimer)
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#ifndef FIRETRAPEFFECT_H
+#define FIRETRAPEFFECT_H
+
+#include <FrontEndLib/AnimatedTileEffect.h>
+
+//****************************************************************************************
+class CFiretrapEffect : public CAnimatedTileEffect
+{
+public:
+	CFiretrapEffect(CWidget *pSetWidget, const CCoord &SetCoord, const UINT duration=300);
+
+protected:
+	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
+};
+
+#endif //...#ifndef FIRETRAPEFFECT_H

--- a/drodrpg/DROD/Main.cpp
+++ b/drodrpg/DROD/Main.cpp
@@ -1941,6 +1941,8 @@ void RepairMissingINIKeys(const bool bFullVersion)
 	AddIfMissing(INISection::Waves, "DoorOpen", "hugedoor.ogg");
 	AddIfMissing(INISection::Waves, "EvilEyeWoke", "hmm.ogg");
 	AddIfMissing(INISection::Waves, "Falling", "whoosh.ogg");
+	AddIfMissing(INISection::Waves, "Firetrap", "firetrap.ogg");
+	AddIfMissing(INISection::Waves, "FiretrapStart", "firetrap_start.ogg");
 	AddIfMissing(INISection::Waves, "Frozen", "frozen.ogg");
 	AddIfMissing(INISection::Waves, "Fuse", "fuselighting.ogg");
 	AddIfMissing(INISection::Waves, "Hit", "hit.ogg");

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -447,7 +447,7 @@ bool CRoomWidget::AddDoorEffect(
 
 	//Only works for doors and lights.
 	const bool bDoor = bIsDoor(wOriginalTileNo) || bIsOpenDoor(wOriginalTileNo);
-	const bool bItem = bIsLight(this->pRoom->GetTSquare(wX, wY)) ||
+	const bool bItem = bIsLight(this->pRoom->GetTSquare(wX, wY)) || bIsFiretrap(wOriginalTileNo) ||
 		(!bDoor && bIsAnyArrow(this->pRoom->GetFSquare(wX, wY)));
 	if (!bDoor && !bItem)
 		return false;
@@ -968,6 +968,7 @@ void CRoomWidget::HighlightSelectedTile()
 			DisplayDoorAgents(wX, wY, wOSquare);
 		break;
 		case T_DOOR_MONEY: case T_DOOR_MONEYO:
+		case T_FIRETRAP: case T_FIRETRAP_ON:
 			DisplayAgentsAffectingTiles(CCoordSet(wX, wY));
 		break;
 		default: break;
@@ -1493,13 +1494,14 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 	const UINT oTile = this->pRoom->GetOSquare(wX, wY);
 	switch (oTile)
 	{
-		case T_HOT:
+		case T_HOT: case T_FIRETRAP_ON:
 			mid = 0; //no text to append later
 			AppendLine(TILE_MID[oTile]);
 			if (this->pCurrentGame)
 			{
 				wstr += wszSpace;
-				int val = this->pCurrentGame->pPlayer->st.hotTileVal;
+				PlayerStats& st = this->pCurrentGame->pPlayer->st;
+				int val = oTile == T_HOT ? st.hotTileVal : st.firetrapVal;
 				wstr += _itoW(val, temp, 10);
 				if (val >= 0)
 				{
@@ -1511,6 +1513,10 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 					wstr += wszSpace;
 					wstr += g_pTheDB->GetMessageText(MID_MonsterHP);
 					wstr += wszRightParen;
+				}
+				else {
+					wstr += wszSpace;
+					wstr += g_pTheDB->GetMessageText(MID_MonsterHP);
 				}
 			}
  		break;

--- a/drodrpg/DROD/TileImageCalcs.cpp
+++ b/drodrpg/DROD/TileImageCalcs.cpp
@@ -1554,6 +1554,8 @@ UINT GetTileImageForTileNo(
 		TI_ARROW_OFF_NW,  //T_ARROW_OFF_NW
 		CALC_NEEDED,      //T_MIST
 		TI_MISTVENT,      //T_MISTVENT
+		TI_FIRETRAP,      //T_FIRETRAP
+		TI_FIRETRAP_ON,   //T_FIRETRAP_ON
 	};
 
 	ASSERT(IsValidTileNo(wTileNo));

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2440,7 +2440,14 @@
 
 #define TI_MISTVENT       2257
 
-static const UINT TI_COUNT = 2258;
+#define TI_FIRETRAP       2258
+#define TI_FIRETRAP_ON    2259
+
+#define TI_FIRETRAP_UP1   2260
+#define TI_FIRETRAP_UP2   2261
+#define TI_FIRETRAP_UP3   2262
+
+static const UINT TI_COUNT = 2263;
 
 static inline bool bIsBriarTI(const UINT ti)
 {

--- a/drodrpg/DROD/drod.2019.vcxproj.filters
+++ b/drodrpg/DROD/drod.2019.vcxproj.filters
@@ -238,6 +238,9 @@
     <ClCompile Include="ImageOverlayEffect.cpp">
       <Filter>Effects</Filter>
     </ClCompile>
+    <ClCompile Include="FiretrapEffect.cpp">
+      <Filter>Effects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Chat.h">
@@ -460,6 +463,9 @@
       <Filter>Effects</Filter>
     </ClInclude>
     <ClInclude Include="ImageOverlayEffect.h">
+      <Filter>Effects</Filter>
+    </ClInclude>
+    <ClInclude Include="FiretrapEffect.h">
       <Filter>Effects</Filter>
     </ClInclude>
   </ItemGroup>

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -815,6 +815,7 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 					case (UINT)ScriptVars::P_HOTTILE:
 					case (UINT)ScriptVars::P_EXPLOSION:
 					case (UINT)ScriptVars::P_BEAM:
+					case (UINT)ScriptVars::P_FIRETRAP:
 					case (UINT)ScriptVars::P_MUD_SPAWN:
 					case (UINT)ScriptVars::P_TAR_SPAWN:
 					case (UINT)ScriptVars::P_GEL_SPAWN:

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -680,6 +680,16 @@ enum CUEEVENT_ID
 	//Private data: CMoveCoord *pSquareDestroyedAt (one or more)
 	CID_MistDestroyed,
 
+	//Firetrap burning this turn.
+	//
+	//Private data: CCoord *pSquare (one or more)
+	CID_Firetrap,
+
+	//Firetrap has been activated.
+	//
+	//Private data: CCoord *pSquare (one or more)
+	CID_FiretrapActivated,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1476,6 +1476,7 @@ void CCurrentGame::InitRPGStats(PlayerStats& s)
 	s.hotTileVal = 5;     //5% damage
 	s.explosionVal = 100; //100% damage (kill)
 	s.beamVal = 50;       //50% damage
+	s.firetrapVal = UINT(-1000); //1000 damage
 
 	s.totalMoves = s.totalTime = 0;
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -812,6 +812,11 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_Mist: strText = "Mist"; break;
 		case MID_MistDestroyed: strText = "Mist destroyed"; break;
 		case MID_MistVent: strText = "Mist Vent"; break;
+		case MID_Firetrap: strText = "Fire Trap"; break;
+		case MID_FiretrapOn: strText = "Fire Trap (active)"; break;
+		case MID_VarFiretrap: strText = "_Firetrap"; break;
+		case MID_FiretrapBurning: strText = "Fire trap burning"; break;
+		case MID_FiretrapActivated: strText = "Fire trap activated"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -147,6 +147,7 @@ public:
 	CBridge        bridges;
 //	CBuilding      building; //tiles marked for building
 	CCoordSet      mistVents;
+	CCoordSet      activeFiretraps;
 
 	CCoordSet      geometryChanges, disabledLights; //for front end -- where lighting must be updated
 
@@ -155,6 +156,7 @@ public:
 	inline UINT    ROOMINDEX_TO_X(const UINT index) const { return index % this->wRoomCols; }
 	inline UINT    ROOMINDEX_TO_Y(const UINT index) const { return index / this->wRoomCols; }
 
+	void           ActivateFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	void           ActivateOrb(const UINT wX, const UINT wY,
 			CCueEvents &CueEvents, const OrbActivationType eActivationType);
 	void           ActivateToken(CCueEvents &CueEvents, const UINT wX, const UINT wY);
@@ -195,6 +197,7 @@ public:
 */
 	bool           CropRegion(UINT& x1, UINT &y1, UINT &x2, UINT &y2) const;
 
+	void           DamageMonster(CMonster* pMonster, int damageVal, CCueEvents& CueEvents);
 	int            DangerLevel() const;
 //	void           DecMonsterCount();
 	void           DecTrapdoor(CCueEvents &CueEvents);
@@ -207,6 +210,7 @@ public:
 	void           DestroyTar(const UINT wX, const UINT wY, CCueEvents &CueEvents);
 	void           DestroyTrapdoor(const UINT wX, const UINT wY, CCueEvents &CueEvents);
 	void           Dig(const UINT wX, const UINT wY, const UINT wO, CCueEvents& CueEvents);
+	void           DisableFiretrap(const UINT wX, const UINT wY);
 	void           DisableForceArrow(const UINT wX, const UINT wY);
 /*	bool           DoesMonsterEnterRoomLater(const UINT wX, const UINT wY,
 			const UINT wMonsterType) const;
@@ -221,6 +225,7 @@ public:
 			const int dx, const int dy) const;
 	bool           DoesSquareContainTeleportationObstacle(const UINT wX, const UINT wY, const UINT wIdentity) const;
 
+	void           EnableFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	void           EnableForceArrow(const UINT wX, const UINT wY);
 	void           ExpandBriars(CCueEvents& CueEvents);
 	void           ExpandMist(CCueEvents& CueEvents);
@@ -400,6 +405,7 @@ public:
 	void           SwitchTarstuff(const UINT wType1, const UINT wType2);
 	bool           SwordfightCheck() const;
 	void           ToggleBlackGates(CCueEvents& CueEvents);
+	void           ToggleFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	void           ToggleForceArrow(const UINT wX, const UINT wY);
 	void           ToggleDoor(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	bool           ToggleTiles(const UINT wOldTile, const UINT wNewTile);
@@ -448,6 +454,7 @@ private:
 	void           OpenDoor(const UINT wX, const UINT wY);
 	c4_Bytes *     PackSquares(const bool bSaveGameData=false) const;
 	c4_Bytes *     PackTileLights() const;
+	void           ProcessActiveFiretraps(CCueEvents& CueEvents);
 	void           ReevalBriarNear(const UINT wX, const UINT wY, const UINT wTileNo);
 	void           ReflectSquare(const bool bHoriz, UINT &wSquare) const;
 //	bool           RemoveLongMonsterPieces(CMonster *pMonster);

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -2309,6 +2309,7 @@ bool CMonster::GetNextGaze(
 		case T_DOOR_MONEYO:
 		case T_TUNNEL_E: case T_TUNNEL_W: case T_TUNNEL_N: case T_TUNNEL_S:
 		case T_TRAPDOOR: case T_TRAPDOOR2: case T_PRESSPLATE: case T_THINICE:
+		case T_MISTVENT: case T_FIRETRAP: case T_FIRETRAP_ON:
 			//Gaze can go over these objects.
 		break;
 		default:

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -46,7 +46,7 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][16] =
 	"", "", "",
 	"",
 	"_Shovels", "_ScoreShovels", "_ItemShovelMult", "",
-	"_Beam"
+	"_Beam", "_Firetrap"
 };
 
 //Message texts corresponding to the above short var texts.
@@ -79,7 +79,7 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarLevelMultiplier, MID_VarRoomX, MID_VarRoomY,
 	MID_VarMyDescription,
 	MID_VarShovels, MID_VarScoreShovels, MID_VarItemShovelMult, MID_VarMyItemShovelMult,
-	MID_VarBeam,
+	MID_VarBeam, MID_VarFiretrap,
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call
@@ -114,6 +114,7 @@ const Predefined ScriptVars::globals[numGlobals] = {
 	P_HOTTILE,
 	P_EXPLOSION,
 	P_BEAM,
+	P_FIRETRAP,
 	P_TOTALMOVES,
 	P_TOTALTIME,
 	P_MUD_SPAWN,
@@ -167,6 +168,7 @@ const UINT ScriptVars::globalVarMIDs[numGlobals] = {
 	predefinedVarMIDs[43], //damage modifiers
 	predefinedVarMIDs[44],
 	predefinedVarMIDs[97],
+	predefinedVarMIDs[98],
 
 	predefinedVarMIDs[36], //tally stats
 	predefinedVarMIDs[37],
@@ -224,6 +226,7 @@ const char* ScriptVars::globalVarShortNames[numGlobals] = {
 	predefinedVarTexts[43], //damage modifiers
 	predefinedVarTexts[44],
 	predefinedVarTexts[97],
+	predefinedVarTexts[98],
 
 	predefinedVarTexts[36], //tally stats
 	predefinedVarTexts[37],
@@ -331,6 +334,8 @@ UINT ScriptVars::getVarDefault(const ScriptVars::Predefined var)
 			return 30;
 		case P_BEAM:
 			return 50;
+		case P_FIRETRAP:
+			return UINT(-1000);
 		default:
 			return 0;
 	}
@@ -461,6 +466,7 @@ UINT PlayerStats::getVar(const Predefined var) const
 		case P_HOTTILE: return this->hotTileVal;
 		case P_EXPLOSION: return this->explosionVal;
 		case P_BEAM: return this->beamVal;
+		case P_FIRETRAP: return this->firetrapVal;
 
 		case P_TOTALMOVES: return this->totalMoves;
 		case P_TOTALTIME: return this->totalTime;
@@ -524,6 +530,7 @@ void PlayerStats::setVar(const Predefined var, const UINT val)
 		case P_HOTTILE: this->hotTileVal = val; break;
 		case P_EXPLOSION: this->explosionVal = val; break;
 		case P_BEAM: this->beamVal = val; break;
+		case P_FIRETRAP: this->firetrapVal = val; break;
 
 		case P_TOTALMOVES: this->totalMoves = val; break;
 		case P_TOTALTIME: this->totalTime = val; break;
@@ -563,7 +570,7 @@ bool PlayerStats::IsGlobalStatIndex(UINT i)
 		(i >= 73 && i <= 76) ||
 		(i >= 79 && i <= 87) ||
 		(i >= 93 && i <= 95) ||
-		i == 97;
+		i == 97 || i == 98;
 		;
 }
 
@@ -612,6 +619,7 @@ void PlayerStats::Pack(CDbPackedVars& stats)
 			case 43: val = this->hotTileVal; break;
 			case 44: val = this->explosionVal; break;
 			case 97: val = this->beamVal; break;
+			case 98: val = this->firetrapVal; break;
 
 			case 36: val = this->totalMoves; break;
 			case 37: val = this->totalTime; break;
@@ -698,6 +706,7 @@ void PlayerStats::Unpack(CDbPackedVars& stats)
 			case 43: this->hotTileVal = val; break;
 			case 44: this->explosionVal = val; break;
 			case 97: this->beamVal = val; break;
+			case 98: this->firetrapVal = val; break;
 
 			case 36: this->totalMoves = val; break;
 			case 37: this->totalTime = val; break;

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -153,7 +153,8 @@ namespace ScriptVars
 		P_ITEM_SHOVEL_MULT = -96,
 		P_SCRIPT_ITEM_SHOVEL_MULT = -97,
 		P_BEAM = -98,
-		FirstPredefinedVar = P_BEAM, //set this to the last var in the enumeration
+		P_FIRETRAP = -99,
+		FirstPredefinedVar = P_FIRETRAP, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 
@@ -199,7 +200,7 @@ namespace ScriptVars
 	extern const char primitiveNames[PrimitiveCount][11]; //expand buffer size as needed
 
 	//Global game var subset quick reference.
-	static const UINT numGlobals=43;
+	static const UINT numGlobals=44;
 	extern const Predefined globals[numGlobals];
 	extern const UINT globalVarMIDs[numGlobals];
 	extern const char* globalVarShortNames[numGlobals];
@@ -222,7 +223,7 @@ public:
 		sword = shield = accessory = 0;
 		monsterHPmult = monsterATKmult = monsterDEFmult = monsterGRmult = monsterXPmult = 0;
 		itemMult = itemHPmult = itemATKmult = itemDEFmult = itemGRmult = itemShovelMult = 0;
-		hotTileVal = explosionVal = beamVal = 0;
+		hotTileVal = explosionVal = beamVal = firetrapVal = 0;
 		totalMoves = totalTime = 0;
 		priorRoomID = priorX = priorY = priorO = 0;
 		mudSpawnID = tarSpawnID = gelSpawnID = queenSpawnID = UINT(-1); //negative indicates default
@@ -253,7 +254,7 @@ public:
 	//Global modifiers
 	UINT monsterHPmult, monsterATKmult, monsterDEFmult, monsterGRmult, monsterXPmult; //global monster stat modifiers
 	UINT itemMult, itemHPmult, itemATKmult, itemDEFmult, itemGRmult, itemShovelMult; //global item value modifiers
-	UINT hotTileVal, explosionVal, beamVal; //damage modifiers
+	UINT hotTileVal, explosionVal, beamVal, firetrapVal; //damage modifiers
 
 	//Prior location before level warp.
 	UINT priorRoomID, priorX, priorY, priorO;

--- a/drodrpg/DRODLib/Swordsman.cpp
+++ b/drodrpg/DRODLib/Swordsman.cpp
@@ -364,6 +364,7 @@ const
 		wLookTileNo==T_TOKEN ||
 		wLookTileNo==T_MIST ||
 		wLookTileNo==T_PRESSPLATE ||
+		wLookTileNo==T_FIRETRAP ||
 		(bIsFallingTile(wLookTileNo) && !CanDropTrapdoor(wLookTileNo)) //won't drop trapdoors
 	)
 		return false;

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -164,8 +164,10 @@
 #define T_ARROW_OFF_NW  114
 #define T_MIST          115 //mist that nullifies DEF
 #define T_MISTVENT      116 //produces and expands mist
+#define T_FIRETRAP      117
+#define T_FIRETRAP_ON   118
 
-#define TILE_COUNT     (117) //Number of tile constants from above list.
+#define TILE_COUNT     (119) //Number of tile constants from above list.
 static inline bool IsValidTileNo(const UINT t) {return t < TILE_COUNT;}
 
 //
@@ -181,10 +183,13 @@ static inline bool bIsTrapdoor(const UINT t) {return t==T_TRAPDOOR || t==T_TRAPD
 static inline bool bIsThinIce(const UINT t) { return t == T_THINICE; }
 static inline bool bIsFallingTile(const UINT t) { return bIsTrapdoor(t) || bIsThinIce(t); }
 
+static inline bool bIsFiretrap(const UINT t) { return t == T_FIRETRAP || t == T_FIRETRAP_ON; }
+static inline UINT getToggledFiretrap(const UINT t) { return t == T_FIRETRAP ? T_FIRETRAP_ON : T_FIRETRAP; }
+
 static inline bool bIsPlainFloor(const UINT t) {return t==T_FLOOR || (t>=T_FLOOR_M && t<=T_FLOOR_ALT) || t==T_FLOOR_IMAGE;}
 
 static inline bool bIsFloor(const UINT t) {return bIsPlainFloor(t) ||
-		bIsTrapdoor(t) || bIsBridge(t) || bIsThinIce(t) || t==T_HOT || t==T_GOO || t==T_PRESSPLATE || t==T_MISTVENT;}
+		bIsFallingTile(t) || bIsBridge(t) || bIsFiretrap(t) || t==T_HOT || t==T_GOO || t==T_PRESSPLATE || t==T_MISTVENT;}
 
 static inline bool bIsLight(const UINT t) {return t==T_LIGHT;}
 
@@ -525,6 +530,8 @@ static const UINT TILE_LAYER[TOTAL_EDIT_TILE_COUNT] =
 	LAYER_FLOOR, //T_ARROW_OFF_NW
 	LAYER_TRANSPARENT, //T_MIST
 	LAYER_OPAQUE, //T_MISTVENT
+	LAYER_OPAQUE, //T_FIRETRAP
+	LAYER_OPAQUE, //T_FIRETRAP_ON
 
 	LAYER_MONSTER, //M_ROACH         +0
 	LAYER_MONSTER, //M_QROACH        +1
@@ -689,6 +696,8 @@ static const UINT TILE_MID[TOTAL_EDIT_TILE_COUNT] =
 	MID_ForceArrowDisabled, //T_ARROW_OFF_NW
 	MID_Mist, //T_MIST
 	MID_MistVent, //T_MISTVENT
+	MID_Firetrap,      //T_FIRETRAP
+	MID_FiretrapOn,    //T_FIRETRAP_ON
 
 	MID_Roach,        //M_ROACH         +0
 	MID_RoachQueen,   //M_QROACH        +1

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -706,6 +706,8 @@ The variable names are case-insensitive.
   </tr><tr>
     <td>_Beam</td><td>beam damage(<a href="#damage">*</a>)</td><td>50 (percent)</td><td>-MAX,100</td>
   </tr><tr>
+    <td>_Firetrap</td><td>fire trap damage(<a href="#damage">*</a>)</td><td>-1000</td><td>-MAX,100</td>
+  </tr><tr>
     <td>_MudSpawn</td><td>global mud spawn entity ID(<a href="#mudspawn">*</a>)</td><td>-1 (default)</td><td>valid entity ID</td>
   </tr><tr>
     <td>_TarSpawn</td><td>global tar spawn entity ID(<a href="#tarspawn">*</a>)</td><td>-1 (default)</td><td>valid entity ID</td>
@@ -869,7 +871,7 @@ The variable names are case-insensitive.
 </p>
 <p><a name="roompositionvars"><b>*_RoomX, _RoomY</b></a> - These values contain the X and Y position of the current room in the level. The entrance is at (0,0), with East and South being positive directions, and North and West being negative directions. These are read-only values.
 </p>
-<p><a name="damage"><b>*_HotTile, _Explosion, _Beam</b></a> - When damage is set to a
+<p><a name="damage"><b>*_HotTile, _Explosion, _Beam, _Firetrap</b></a> - When damage is set to a
   positive value, it indicates the percentage of HP the target will
   lose.  A negative value indicates a flat damage to inflict.
   When the player is hasted by a Speed Potion, expected damage is halved.

--- a/drodrpg/Texts/EditScreens.uni
+++ b/drodrpg/Texts/EditScreens.uni
@@ -746,6 +746,14 @@ Thin Ice
 [eng]
 Mist Vent
 
+[MID_Firetrap]
+[eng]
+Fire Trap
+
+[MID_FiretrapOn]
+[eng]
+Fire Trap (active)
+
 [MID_ForceArrowDisabled]
 [eng]
 Disabled force arrow

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -312,6 +312,8 @@ enum MID_CONSTANT {
   MID_ForceArrowDisabledSW = 1882,
   MID_Mist = 1885,
   MID_MistVent = 1887,
+  MID_Firetrap = 1888,
+  MID_FiretrapOn = 1889,
   MID_FloorMosaic = 332,
   MID_FloorRoad = 333,
   MID_FloorGrass = 334,
@@ -1547,6 +1549,8 @@ enum MID_CONSTANT {
   MID_ImageOverlay = 1883,
   MID_ImageOverlayStrategy = 1884,
   MID_MistDestroyed = 1886,
+  MID_FiretrapBurning = 1891,
+  MID_FiretrapActivated = 1892,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,
@@ -1642,6 +1646,7 @@ enum MID_CONSTANT {
   MID_VarItemShovelMult = 1864,
   MID_VarMyItemShovelMult = 1865,
   MID_VarBeam = 1866,
+  MID_VarFiretrap = 1890,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1387,3 +1387,11 @@ Image overlay strategy
 [MID_MistDestroyed]
 [eng]
 Mist destroyed
+
+[MID_FiretrapBurning]
+[eng]
+Fire trap burning
+
+[MID_FiretrapActivated]
+[eng]
+Fire trap activated

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -369,3 +369,7 @@ _MyItemShovelMult
 [MID_VarBeam]
 [eng]
 _Beam
+
+[MID_VarFiretrap]
+[eng]
+_Firetrap


### PR DESCRIPTION
Ports the fire trap element to DROD RPG. They come in activate and inactive versions, and can have their state changed up orbs. Active fire traps activate at the end of each full turn, which cause a number of interactions:

- Players and monsters take damage
- Tarstuff and mist is destroyed
- Orbs are activated
- Bombs are exploded
- Fuses are lit

The damage from fire traps can be configured with the `_Firetrap` variable. The default value is `-1000`, leading to a fixed amount of damage.

A small divergence from DROD is that serpents can only be burned at the head, even though their tail is damagable. This is to avoid introducing a behaviour that depends on fire trap processing order, as in RPG the damage is not certain to be lethal.