### PR TITLE
RPG: Add powder keg element

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4203,6 +4203,7 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(T_TAR, g_pTheDB->GetMessageText(MID_Tar));
 	pListBox->AddItem(T_MIRROR, g_pTheDB->GetMessageText(MID_Mirror));
 	pListBox->AddItem(T_CRATE, g_pTheDB->GetMessageText(MID_Crate));
+	pListBox->AddItem(T_POWDER_KEG, g_pTheDB->GetMessageText(MID_PowderKeg));
 	pListBox->AddItem(T_MIST, g_pTheDB->GetMessageText(MID_Mist));
 	pListBox->AddItem(T_MISTVENT, g_pTheDB->GetMessageText(MID_MistVent));
 	pListBox->AddItem(T_HEALTH_HUGE, g_pTheDB->GetMessageText(MID_HugeHealth));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1485,6 +1485,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBehaviorListBox->AddItem(ScriptFlag::AttackFirst, g_pTheDB->GetMessageText(MID_AttackFirst));
 	this->pBehaviorListBox->AddItem(ScriptFlag::AttackLast, g_pTheDB->GetMessageText(MID_AttackLast));
 	this->pBehaviorListBox->AddItem(ScriptFlag::RemovesSword, g_pTheDB->GetMessageText(MID_RemovesSword));
+	this->pBehaviorListBox->AddItem(ScriptFlag::ExplosiveSafe, g_pTheDB->GetMessageText(MID_ExplosiveSafe));
 	this->pBehaviorListBox->AddItem(ScriptFlag::DropTrapdoors, g_pTheDB->GetMessageText(MID_DropTrapdoors));
 	this->pBehaviorListBox->AddItem(ScriptFlag::MoveIntoSwords, g_pTheDB->GetMessageText(MID_MoveIntoSwords));
 	this->pBehaviorListBox->AddItem(ScriptFlag::PushObjects, g_pTheDB->GetMessageText(MID_PushObjects));

--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -488,7 +488,7 @@ void CDrodScreen::AddVisualCues(CCueEvents& CueEvents, CRoomWidget* pRoomWidget,
 	{
 		const CMoveCoord *pCoord = DYN_CAST(const CMoveCoord*, const CAttachableObject*, pObj);
 		const UINT wTSquare = pGame->pRoom->GetTSquare(pCoord->wX, pCoord->wY);
-		if (wTSquare == T_FUSE || wTSquare == T_BOMB)	//needed to avoid effects
+		if (bIsCombustibleItem(wTSquare))	//needed to avoid effects
 					//where fuses have already disappeared since the cue event fired
 		{
 			pRoomWidget->AddTLayerEffect(

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -4647,7 +4647,7 @@ void CEditRoomScreen::PasteRegion(
 						}
 						break;
 
-						case T_MIRROR: case T_CRATE:
+						case T_MIRROR: case T_CRATE: case T_POWDER_KEG:
 						{
 							const UINT coveredTLayerObject = pSrcRoom->GetCoveredTSquare(xSrc, ySrc);
 							if (coveredTLayerObject == T_FUSE || coveredTLayerObject == T_MIST)

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -248,6 +248,7 @@ const UINT MenuDisplayTiles[TOTAL_EDIT_TILE_COUNT][4] =
 	{ TI_MISTVENT },                                   //T_MISTVENT
 	{ TI_FIRETRAP },                                   //T_FIRETRAP
 	{ TI_FIRETRAP_ON },                                //T_FIRETRAP_ON
+	{ TI_POWDER_KEG},                                  //T_POWDER_KEG
 
 	//monsters
 	{TI_ROACH_S},
@@ -418,6 +419,7 @@ const bool SinglePlacement[TOTAL_EDIT_TILE_COUNT] =
 	0, //T_MISTVENT      116
 	0, //T_FIRETRAP      117
 	0, //T_FIRETRAP_ON   118
+	0, //T_POWDER_KEG    119
 
 	0, //T_ROACH         +0
 	0, //T_QROACH        +1
@@ -485,6 +487,7 @@ const UINT wItemX[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, 1, 1, 1, 1, 1, 1,  //8 disabled arrows
 	1, 1, //mist, vent
 	1, 1, //firetraps
+	1, //powder keg
 	1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
 	1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1, 1, //M+13
 	2, 1, 1 //psuedo tiles
@@ -512,6 +515,7 @@ const UINT wItemY[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, 1, 1, 1, 1, 1, 1,  //8 disabled arrows
 	1, 1, //mist, vent
 	1, 1, //firetraps
+	1, //powder keg
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+13
 	1, 1, 1 //pseudo tiles
@@ -606,13 +610,13 @@ const UINT fLayerEntries[numFLayerEntries] = {
 	T_SWORDSMAN
 };
 
-const UINT numTLayerEntries = 23;
+const UINT numTLayerEntries = 24;
 const UINT tLayerEntries[numTLayerEntries] = {
 	T_SWORD, T_SHIELD, T_ACCESSORY, T_SCROLL, T_MAP,
 	T_ATK_UP, T_DEF_UP, T_HEALTH_SM, T_KEY, T_SHOVEL1,
-	T_FUSE, T_BOMB, T_MIRROR, T_CRATE, T_TOKEN,
-	T_BRIAR_SOURCE, T_BRIAR_LIVE, T_BRIAR_DEAD, T_ORB, T_LIGHT,
-	T_TAR, T_OBSTACLE, T_MIST
+	T_FUSE, T_BOMB, T_MIRROR, T_CRATE, T_POWDER_KEG,
+	T_TOKEN, T_BRIAR_SOURCE, T_BRIAR_LIVE, T_BRIAR_DEAD, T_ORB,
+	T_TAR, T_OBSTACLE, T_MIST, T_LIGHT
 };
 
 const UINT numMLayerEntries = 31;  //35
@@ -4525,7 +4529,7 @@ void CEditRoomScreen::PasteRegion(
 				{
 					if (wSrcTile == T_ORB || bIsTar(wSrcTile) || wSrcTile == T_BOMB ||
 							bIsBriar(wSrcTile) || wSrcTile == T_MIRROR || wSrcTile == T_CRATE ||
-							wSrcTile == T_LIGHT) // || wSrcTile == T_STATION)
+							wSrcTile == T_POWDER_KEG || wSrcTile == T_LIGHT) // || wSrcTile == T_STATION)
 						bPasteAllowed = false;
 				}
 				if (bPasteAllowed)
@@ -5374,6 +5378,7 @@ void CEditRoomScreen::PlotObjects()
 				case T_FUSE:
 					g_pTheSound->PlaySoundEffect(SEID_STARTFUSE);   break;
 				case T_BOMB:
+				case T_POWDER_KEG:
 					g_pTheSound->PlaySoundEffect(SEID_BOMBEXPLODE); break;
 				case T_KEY: case T_SWORD: case T_SHIELD: case T_ACCESSORY:
 					g_pTheSound->PlaySoundEffect(SEID_TRAPDOOR);
@@ -5528,7 +5533,7 @@ bool CEditRoomScreen::PlotObjectAt(
 				case T_ACCESSORY:
 					this->pRoom->SetTParam(wX,wY, this->wSelAccessoryType);
 				break;
-				case T_MIRROR: case T_CRATE:
+				case T_MIRROR: case T_CRATE: case T_POWDER_KEG:
 					//Allow items to be covered
 					if (tTile != T_EMPTY)
 						this->pRoom->coveredTSquares.Add(wX, wY, tTile);

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -1545,31 +1545,14 @@ void CEditRoomWidget::HandleMouseUp(
 		}
 */
 
-	switch (this->pRoom->GetTSquare(x2,y2))
+	UINT tTile = this->pRoom->GetTSquare(x2, y2);
+	switch (tTile)
 	{
 		case T_BOMB:
-		{
-			//Show all explosions caused by this bomb.
+		case T_POWDER_KEG:
+			//Show all explosions caused by this explosion.
 			this->pLastLayerEffects->RemoveEffectsOfType(ESHADE);
-
-			CCueEvents CueEvents;
-			CDbRoom room(*this->pRoom);
-			room.InitRoomStats();
-			room.ExplodeBomb(CueEvents, x2, y2);
-
-			CCoordSet coords;
-			const CCoord *pCoord = DYN_CAST(const CCoord*, const CAttachableObject*,
-				CueEvents.GetFirstPrivateData(CID_Explosion));
-			while (pCoord)
-			{
-				coords.insert(pCoord->wX, pCoord->wY);
-				pCoord = DYN_CAST(const CCoord*, const CAttachableObject*,
-						CueEvents.GetNextPrivateData());
-			}
-			static const SURFACECOLOR ExpColor = {224, 160, 0};
-			for (CCoordSet::const_iterator coord=coords.begin(); coord!=coords.end(); ++coord)
-				AddShadeEffect(coord->wX, coord->wY, ExpColor);
-		}
+			HighlightBombExplosion(x2, y2, tTile);
 		return;
 		default: break;
 	}

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -904,6 +904,7 @@ const
 					(!pMonster || wTileNo[2] == M_CHARACTER);
 		case T_MIRROR:
 		case T_CRATE:
+		case T_POWDER_KEG:
 			//Only on floor, doors or platforms.
 			return !bSwordsmanAt &&
 					(bIsFloor(wTileNo[0]) || bIsWall(wTileNo[0]) || bIsCrumblyWall(wTileNo[0]) ||
@@ -1044,7 +1045,7 @@ const
 					!(wTileNo[1] == T_ORB || bIsTar(wTileNo[1]) || wTileNo[1] == T_BOMB ||
 							wTileNo[1] == T_OBSTACLE ||
 							bIsBriar(wTileNo[1]) || wTileNo[1] == T_LIGHT || wTileNo[1] == T_MIRROR ||
-							wTileNo[1] == T_CRATE );// || wTileNo[1] == T_STATION);
+							wTileNo[1] == T_CRATE || wTileNo[1] == T_POWDER_KEG);// || wTileNo[1] == T_STATION);
 
 		case T_SEEP:
 			//Wall movement types
@@ -1061,7 +1062,7 @@ const
 					!(wTileNo[1] == T_ORB || bIsTar(wTileNo[1]) || wTileNo[1] == T_BOMB ||
 							wTileNo[1] == T_OBSTACLE || //wTileNo[1] == T_STATION ||
 							bIsBriar(wTileNo[1]) || wTileNo[1] == T_LIGHT || wTileNo[1] == T_MIRROR ||
-							wTileNo[1] == T_CRATE));
+							wTileNo[1] == T_CRATE || wTileNo[1] == T_POWDER_KEG));
 
 		case T_CHARACTER:
 			//Can't go on monsters.
@@ -1554,8 +1555,7 @@ void CEditRoomWidget::HandleMouseUp(
 			CCueEvents CueEvents;
 			CDbRoom room(*this->pRoom);
 			room.InitRoomStats();
-			CCoordStack bombs(x2,y2);
-			room.BombExplode(CueEvents, bombs);
+			room.ExplodeBomb(CueEvents, x2, y2);
 
 			CCoordSet coords;
 			const CCoord *pCoord = DYN_CAST(const CCoord*, const CAttachableObject*,

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -208,6 +208,13 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 		text += g_pTheDB->GetMessageText(MID_NoEnemyDefense);
 		needSeparator = true;
 	}
+	if (pCharacter->IsExplosiveSafe())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_ExplosiveSafe);
+		needSeparator = true;
+	}
 	if (pCharacter->HasCustomDescription()) {
 		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
 

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1411,6 +1411,7 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 			}
 			break;
 			case T_BOMB:
+			case T_POWDER_KEG:
 				if (this->pCurrentGame)
 				{
 					wstr += wszSpace;
@@ -1426,6 +1427,10 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 						wstr += wszSpace;
 						wstr += g_pTheDB->GetMessageText(MID_MonsterHP);
 						wstr += wszRightParen;
+					}
+					else {
+						wstr += wszSpace;
+						wstr += g_pTheDB->GetMessageText(MID_MonsterHP);
 					}
 				}
 			break;
@@ -4455,6 +4460,7 @@ void CRoomWidget::DrawTLayerTile(
 			break;
 			case T_MIRROR:
 			case T_CRATE:
+			case T_POWDER_KEG:
 				//Render moving objects later.
 				if (this->dwMovementStepsLeft && this->pRoom->GetPushedObjectAt(wX, wY) != NULL) {
 					bIsMoving = true;

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1950,6 +1950,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 	bool bAttackInFrontWhenBack = pMonster->wType == M_GOBLIN || pMonster->wType == M_GOBLINKING;
 	bool bSpawnEggs = pMonster->wType == M_QROACH;
 	bool bCustomWeakness = false, bCustomDescription = false;
+	bool bExplosiveSafe = pMonster->IsExplosiveSafe();;
 
 	if (pMonster->wType == M_CHARACTER)
 	{
@@ -2061,6 +2062,15 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 			wstr += wszSpace;
 		}
 		wstr += g_pTheDB->GetMessageText(MID_RoachQueenAbility);
+		++count;
+	}
+	if (bExplosiveSafe) {
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_ExplosiveSafe);
 		++count;
 	}
 	if (bCustomWeakness) {

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -910,7 +910,8 @@ void CRoomWidget::HighlightSelectedTile()
 		}
 		break;
 		case T_BOMB:
-			DrawInvisibilityRange(wX, wY, NULL, NULL, 3);
+		case T_POWDER_KEG:
+			HighlightBombExplosion(wX, wY, tTile);
 		break;
 		case T_BRIAR_SOURCE:
 		case T_BRIAR_LIVE: case T_BRIAR_DEAD:
@@ -976,6 +977,35 @@ void CRoomWidget::HighlightSelectedTile()
 
 	//Nothing is being highlighted.
 	RemoveHighlight();
+}
+
+//*****************************************************************************
+void CRoomWidget::HighlightBombExplosion(const UINT x, const UINT y, const UINT tTile)
+//
+{
+	CCueEvents CueEvents;
+	CDbRoom room(*this->pRoom, false);
+	room.InitRoomStats();
+	CCoordStack bombs, powder_kegs;
+	switch (tTile) {
+		case T_BOMB: bombs.Push(x, y); break;
+		case T_POWDER_KEG: powder_kegs.Push(x, y); break;
+		default: break;
+	}
+	room.DoExplode(CueEvents, bombs, powder_kegs);
+
+	CCoordSet coords;
+	const CCoord* pCoord = DYN_CAST(const CCoord*, const CAttachableObject*,
+		CueEvents.GetFirstPrivateData(CID_Explosion));
+	while (pCoord)
+	{
+		coords.insert(pCoord->wX, pCoord->wY);
+		pCoord = DYN_CAST(const CCoord*, const CAttachableObject*,
+			CueEvents.GetNextPrivateData());
+	}
+	static const SURFACECOLOR ExpColor = { 224, 160, 0 };
+	for (CCoordSet::const_iterator coord = coords.begin(); coord != coords.end(); ++coord)
+		AddShadeEffect(coord->wX, coord->wY, ExpColor);
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -281,6 +281,7 @@ public:
 	void           HideCheckpoints() {this->bShowCheckpoints = false;}
 	void           HidePlayer() {this->bShowingPlayer = false;}
 	void           HighlightSelectedTile();
+	void           HighlightBombExplosion(const UINT x, const UINT y, const UINT tTile);
 	virtual bool   IsDoubleClickable() const {return false;}
 	bool           IsLightingRendered() const;
 	bool           IsMonsterInvolvedInDeath(CMonster *pMonster) const;

--- a/drodrpg/DROD/TileImageCalcs.cpp
+++ b/drodrpg/DROD/TileImageCalcs.cpp
@@ -1556,6 +1556,7 @@ UINT GetTileImageForTileNo(
 		TI_MISTVENT,      //T_MISTVENT
 		TI_FIRETRAP,      //T_FIRETRAP
 		TI_FIRETRAP_ON,   //T_FIRETRAP_ON
+		TI_POWDER_KEG,    //T_POWDER_KEG
 	};
 
 	ASSERT(IsValidTileNo(wTileNo));

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2447,7 +2447,9 @@
 #define TI_FIRETRAP_UP2   2261
 #define TI_FIRETRAP_UP3   2262
 
-static const UINT TI_COUNT = 2263;
+#define TI_POWDER_KEG     2263
+
+static const UINT TI_COUNT = 2264;
 
 static inline bool bIsBriarTI(const UINT ti)
 {

--- a/drodrpg/DRODLib/BuildUtil.cpp
+++ b/drodrpg/DRODLib/BuildUtil.cpp
@@ -187,7 +187,7 @@ bool BuildUtil::CanBuildAt(CDbRoom& room, const UINT tile, const UINT x, const U
 		//Most items can be replaced.
 		if (wTTile == T_EMPTY || wTTile == T_BOMB || wTTile == T_FUSE ||
 			bIsPowerUp(wTTile) || bIsBriar(wTTile) || wTTile == T_MIRROR ||
-			wTTile == T_CRATE ||
+			wTTile == T_CRATE || wTTile == T_POWDER_KEG ||
 			bIsEquipment(wTTile) || wTTile == T_KEY || wTTile == T_LIGHT ||
 			wTTile == T_SCROLL || bIsMap(wTTile) || wTTile == T_ORB ||
 			wTTile == T_TOKEN || bIsTar(wTTile) || bIsShovel(wTTile))
@@ -244,8 +244,7 @@ bool BuildUtil::BuildVirtualTile(CDbRoom& room, const UINT tile, const UINT x, c
 			room.ProcessExplosionSquare(CueEvents, x, y);
 			if (bBombHere)
 			{
-				CCoordStack bombs(x, y);
-				room.BombExplode(CueEvents, bombs);
+				room.ExplodeBomb(CueEvents, x, y);
 			}
 			room.ConvertUnstableTar(CueEvents);
 
@@ -265,7 +264,7 @@ bool BuildUtil::BuildVirtualTile(CDbRoom& room, const UINT tile, const UINT x, c
 		//(Same logic as the t-layer check for real tiles.)
 		if (wTTile == T_EMPTY || wTTile == T_BOMB || wTTile == T_FUSE ||
 			bIsPowerUp(wTTile) || bIsBriar(wTTile) || wTTile == T_MIRROR ||
-			wTTile == T_CRATE ||
+			wTTile == T_CRATE || wTTile == T_POWDER_KEG ||
 			bIsEquipment(wTTile) || wTTile == T_KEY || wTTile == T_LIGHT ||
 			wTTile == T_SCROLL || bIsMap(wTTile) || wTTile == T_ORB ||
 			wTTile == T_TOKEN || bIsTar(wTTile) || bIsShovel(wTTile))

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -130,6 +130,7 @@ const UINT MAX_ANSWERS = 9;
 #define PushObjectsStr "PushObjects"
 #define SpawnEggsStr "SpawnEggs"
 #define RemovesSwordStr "RemovesSword"
+#define ExplosiveKegSafeStr "ExplosiveSafe"
 #define MovementTypeStr "MovementType"
 
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
@@ -246,7 +247,7 @@ CCharacter::CCharacter(
 	, bMetal(false), bLuckyGR(false), bLuckyXP(false), bBriar(false), bNoEnemyDEF(false)
 	, bAttackFirst(false), bAttackLast(false)
 	, bDropTrapdoors(false), bMoveIntoSwords(false), bPushObjects(false), bSpawnEggs(false)
-	, bRemovesSword(false)
+	, bRemovesSword(false) , bExplosiveSafe(false)
 
 	, wJumpLabel(0)
 	, bWaitingForCueEvent(false)
@@ -2645,6 +2646,7 @@ void CCharacter::Process(
 						this->bMetal = this->bLuckyGR = this->bLuckyXP = this->bBriar = this->bNoEnemyDEF =
 						this->bAttackFirst = this->bAttackLast = this->bRemovesSword =
 						this->bDropTrapdoors = this->bMoveIntoSwords = this->bPushObjects = this->bSpawnEggs =
+						this->bExplosiveSafe =
 							false;
 						this->movementIQ = SmartDiagonalOnly;
 					break;
@@ -2731,6 +2733,9 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::RemovesSword:
 						this->bRemovesSword = true;
+					break;
+					case ScriptFlag::ExplosiveSafe:
+						this->bExplosiveSafe = true;
 					break;
 
 					default:
@@ -5455,6 +5460,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bPushObjects = vars.GetVar(PushObjectsStr, this->bPushObjects);
 	this->bSpawnEggs = vars.GetVar(SpawnEggsStr, this->bSpawnEggs);
 	this->bRemovesSword = vars.GetVar(RemovesSwordStr, this->bRemovesSword);
+	this->bExplosiveSafe = vars.GetVar(ExplosiveKegSafeStr, this->bExplosiveSafe);
 
 	if (vars.DoesVarExist(MovementTypeStr)) {
 		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
@@ -5604,7 +5610,9 @@ const
 	if (this->bSpawnEggs)
 		vars.SetVar(SpawnEggsStr, this->bSpawnEggs);
 	if (this->bRemovesSword)
-		vars.SetVar(RemovesSwordStr, this->bSpawnEggs);
+		vars.SetVar(RemovesSwordStr, this->bRemovesSword);
+	if (this->bExplosiveSafe)
+		vars.SetVar(ExplosiveKegSafeStr, this->bExplosiveSafe);
 	if (this->eMovement)
 		vars.SetVar(MovementTypeStr, this->eMovement);
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2140,8 +2140,7 @@ void CCharacter::Process(
 						if (pGame->wTurnNo > 0) //not on room entrance, since the player could die immediately
 						{
 							//Explode a bomb immediately.  Doesn't expend a turn.
-							CCoordStack bomb(px, py);
-							room.BombExplode(CueEvents, bomb);
+							room.ExplodeBomb(CueEvents, px, py);
 							if (IsAlive())
 								bProcessNextCommand = true;
 						} else {
@@ -2149,6 +2148,18 @@ void CCharacter::Process(
 							STOP_COMMAND;
 						}
 					break;
+					case T_POWDER_KEG:
+						if (pGame->wTurnNo > 0) //not on room entrance, since the player could die immediately
+						{
+							//Explode a keg immediately.  Doesn't expend a turn.
+							room.ExplodePowderKeg(CueEvents, px, py);
+							if (IsAlive())
+								bProcessNextCommand = true;
+						} else {
+							//Pause script until after first turn to explode the keg.
+							STOP_COMMAND;
+						}
+						break;
 					case T_FUSE:
 						//Light fuse.  Doesn't expend a turn.
 						room.LightFuse(CueEvents, px, py,
@@ -4765,6 +4776,7 @@ const
 		{
 			case T_MIRROR:
 			case T_CRATE:
+			case T_POWDER_KEG:
 				if (this->bPushObjects)
 				{
 					const int dx = (int)wCol - (int)this->wX;
@@ -5932,7 +5944,7 @@ void CCharacter::MoveCharacter(
 
 		//Process any and all of these item interactions.
 		UINT tTile = room.GetTSquare(this->wX, this->wY);
-		if (tTile==T_MIRROR || tTile==T_CRATE)
+		if (tTile==T_MIRROR || tTile==T_CRATE || tTile==T_POWDER_KEG)
 		{
 			room.PushObject(this->wX, this->wY, this->wX + dx, this->wY + dy, CueEvents);
 			tTile = room.GetTSquare(this->wX, this->wY); //also check what was under the object

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -143,6 +143,7 @@ public:
 	virtual bool   IsDamageableAt(const UINT wX, const UINT wY) const;
 	bool           IsDoorStateAt(const CCharacterCommand& command, const CDbRoom& room) const;
 	bool           IsEntityAt(const CCharacterCommand& command, const CDbRoom& room, const CSwordsman& player) const;
+	virtual bool   IsExplosiveSafe() const { return bExplosiveSafe; }
 	virtual bool   IsFriendly() const;
 	bool           IsGhostImage() const {return this->bGhostImage;}
 	bool           IsInvisibleInspectable() const {return this->bInvisibleInspectable;}
@@ -309,6 +310,7 @@ private:
 	bool bPushObjects;         //can push movable objects
 	bool bSpawnEggs;           //will spawn eggs in reaction to combats
 	bool bRemovesSword;        //prevents player having sword when equipped
+	bool bExplosiveSafe;       //sword does not detonate powder kegs
 
 	UINT wJumpLabel;			//if non-zero, jump to the label if this command is satisfied
 	bool bWaitingForCueEvent;

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -143,6 +143,7 @@ namespace ScriptFlag
 		BeamBlock=24,           //blocks beam attacks
 		SpawnEggs=25,           //will spawn eggs in reaction to combats
 		RemovesSword=26,        //prevents player having sword when equipped
+		ExplosiveSafe=27,       //sword does not detonate powder kegs
 	};
 
 	//Inventory and global script types.

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -2178,12 +2178,12 @@ bool CCurrentGame::UseAccessory(CCueEvents &CueEvents)
 			//Generate a 3x3 explosion that doesn't affect the player tile.
 			const UINT wX = this->pPlayer->wX, wY = this->pPlayer->wY;
 			CCoordSet explosion; //what tiles are affected by the explosion
-			CCoordStack bombs, coords;
+			CCoordStack bombs, powder_kegs, coords;
 			for (int y = -1; y <= 1; ++y)
 				for (int x = -1; x <= 1; ++x)
 				{
 					this->pRoom->ExpandExplosion(CueEvents, coords, wX, wY,
-							wX + x, wY + y, bombs, explosion);
+							wX + x, wY + y, bombs, powder_kegs, explosion, 1);
 				}
 
 			//Now process the effects of the explosion.
@@ -2195,8 +2195,8 @@ bool CCurrentGame::UseAccessory(CCueEvents &CueEvents)
 
 			//If bombs were set off, explode them now.
 			//These could harm the player.
-			if (bombs.GetSize())
-				this->pRoom->BombExplode(CueEvents, bombs);
+			if (bombs.GetSize() || powder_kegs.GetSize())
+				this->pRoom->DoExplode(CueEvents, bombs, powder_kegs);
 
 			this->pRoom->ConvertUnstableTar(CueEvents);
 		}
@@ -2503,6 +2503,8 @@ void CCurrentGame::ProcessCommand(
 	CueEvents.Clear();
 	this->pRoom->ClearPlotHistory();
 
+	this->pRoom->InitStateForThisTurn();
+
 	if (this->Commands.IsFrozen())
 	{
 		//While replaying a command sequence, synthesize combat tick commands until combat is done.
@@ -2689,6 +2691,8 @@ void CCurrentGame::ProcessCommand(
 			//If a monster caused a room exit, then process nothing else for the current turn.
 			if (CueEvents.HasOccurred(CID_ExitRoom))
 				return;
+
+			this->pRoom->ExplodeStabbedPowderKegs(CueEvents);
 
 			//Check for stuff falling as a result of monster moves now.
 			if (CPlatform::fallTilesPending())
@@ -3694,8 +3698,15 @@ void CCurrentGame::ProcessSwordHit(
 		   //Explode bomb immediately (could damage player).
 			if (this->wTurnNo)   //don't explode bomb and damage/kill player on room entrance
 			{
-				CCoordStack bomb(wSX, wSY);
-				this->pRoom->BombExplode(CueEvents, bomb);
+				this->pRoom->ExplodeBomb(CueEvents, wSX, wSY);
+			}
+		break;
+
+		case T_POWDER_KEG:
+			//Explode keg immediately (could damage player).
+			if (this->wTurnNo)   //don't explode bomb and damage/kill player on room entrance
+			{
+				this->pRoom->ExplodePowderKeg(CueEvents, wSX, wSY);
 			}
 		break;
 
@@ -4047,6 +4058,8 @@ void CCurrentGame::TeleportPlayer(
 	this->pPlayer->wSwordMovement = NO_ORIENTATION;
 
 	SetPlayer(wSetX, wSetY);
+
+	this->pRoom->ExplodeStabbedPowderKegs(CueEvents);
 
 	this->pPlayer->SetSwordSheathed();
 
@@ -5139,7 +5152,11 @@ void CCurrentGame::ProcessMonsters(
 					}
 				break;
 			}
+
 		}
+
+		// Kegs stabbed by pushes should explode after each monster
+		this->pRoom->ExplodeStabbedPowderKegs(CueEvents);
 	}
 
 	//Run global scripts.
@@ -5339,8 +5356,9 @@ CheckTLayer:
 		case T_BRIAR_SOURCE: case T_BRIAR_DEAD: case T_BRIAR_LIVE:
 		break;
 
-		//Can push mirror, if possible.
+		//Can push mirror/keg, if possible.
 		case T_MIRROR:
+		case T_POWDER_KEG:
 			if (room.CanPlayerMoveOnThisElement(p.wAppearance,
 					this->pRoom->GetOSquare(destX, destY),
 					bIsElevatedTile(wOTileNo)) &&
@@ -5755,6 +5773,7 @@ CheckFLayer:
 
 			case T_MIRROR:
 			case T_CRATE:
+			case T_POWDER_KEG:
 			{
 				//Player ran into pushable object.  Push if possible.
 				const bool bPrevTileHasCrate = wTTileNo == T_CRATE;
@@ -5769,6 +5788,7 @@ CheckFLayer:
 						bNotAnObstacle = true;
 						switch (wNewTTile) {
 							case T_MIRROR:
+							case T_POWDER_KEG:
 								bPushingTLayerObject = true;
 								break;
 							case T_CRATE:
@@ -5868,6 +5888,9 @@ MakeMove:
 	//  movement in order to update the player's prev coords.
 	if (!bEnteredTunnel && !bMoved)
 		bMoved = SetPlayer(wOldX + dx, wOldY + dy);
+
+	pRoom->ExplodeStabbedPowderKegs(CueEvents);
+
 	const UINT wNewOSquare = pRoom->GetOSquare(p.wX, p.wY);
 
 	//These exclude the wait move executed on entering a room.

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -297,6 +297,7 @@ public:
 	bool     IsPlayerAccessoryDisabled() const;
 	bool     IsPlayerShieldDisabled() const;
 	bool     IsPlayerSwordDisabled() const;
+	bool     IsPlayerSwordExplosiveSafe() const;
 	bool     IsSwordMetal(const UINT type) const;
 	bool     IsShieldMetal(const UINT type) const;
 	bool     IsSwordStrongAgainst(const CMonster* pMonster) const;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -817,6 +817,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarFiretrap: strText = "_Firetrap"; break;
 		case MID_FiretrapBurning: strText = "Fire trap burning"; break;
 		case MID_FiretrapActivated: strText = "Fire trap activated"; break;
+		case MID_PowderKeg: strText = "Powder Keg"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -818,6 +818,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_FiretrapBurning: strText = "Fire trap burning"; break;
 		case MID_FiretrapActivated: strText = "Fire trap activated"; break;
 		case MID_PowderKeg: strText = "Powder Keg"; break;
+		case MID_ExplosiveSafe: strText = "Explosive safe"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -826,6 +826,19 @@ CDbRoom::CDbRoom(const CDbRoom &Src)
 	SetMembers(Src);
 }
 
+//*****************************************************************************
+CDbRoom::CDbRoom(const CDbRoom& Src, const bool copyGame)
+//Set pointers to NULL so Clear() won't try to delete them.
+	: CDbBase()
+	, pszOSquares(NULL), pszFSquares(NULL), pszTSquares(NULL), pszTParams(NULL)
+	, pFirstMonster(NULL), pLastMonster(NULL)
+	, pMonsterSquares(NULL)
+	, pCurrentGame(NULL)
+	//Constructor.
+{
+	SetMembers(Src, true, copyGame);
+}
+
 //
 //CDbRoom protected methods.
 //
@@ -9229,7 +9242,8 @@ bool CDbRoom::SetMembers(
 //
 //Params:
 	const CDbRoom &Src,        //(in)
-	const bool bCopyLocalInfo) //(in) default = true
+	const bool bCopyLocalInfo, //(in) default = true
+	const bool bCopyGame)      //(in) default = true
 {
 	try {
 	
@@ -9313,7 +9327,9 @@ bool CDbRoom::SetMembers(
 	this->pressurePlateIndex = Src.pressurePlateIndex;
 	this->weather = Src.weather;
 
-	this->pCurrentGame = Src.pCurrentGame;	
+	if (bCopyGame) {
+		this->pCurrentGame = Src.pCurrentGame;
+	}
 
 	//Monster data
 	this->pFirstMonster = this->pLastMonster = NULL;

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -4970,7 +4970,7 @@ void CDbRoom::PushObject(
 		this->stationary_powder_kegs.erase(wSrcX, wSrcY);
 
 		//Check for a weapon at destination location that might explode the keg
-		if (this->pCurrentGame->IsPlayerSwordAt(wDestX, wDestY)) {
+		if (this->pCurrentGame->IsPlayerSwordAt(wDestX, wDestY) && !this->pCurrentGame->IsPlayerSwordExplosiveSafe()) {
 			this->stabbed_powder_kegs.Push(wDestX, wDestY);
 			return;
 		}
@@ -4980,7 +4980,7 @@ void CDbRoom::PushObject(
 			if (nO != NO_ORIENTATION && nO != wO)
 			{
 				CMonster* pMonster = GetMonsterAtSquare(wDestX - nGetOX(nO), wDestY - nGetOY(nO));
-				if (pMonster && pMonster->HasSwordAt(wDestX, wDestY)) {
+				if (pMonster && !pMonster->IsExplosiveSafe() && pMonster->HasSwordAt(wDestX, wDestY)) {
 					this->stabbed_powder_kegs.Push(wDestX, wDestY);
 					return;
 				}

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -86,6 +86,7 @@ protected:
 
 public:
 	CDbRoom(const CDbRoom &Src);
+	CDbRoom(const CDbRoom &Src, const bool copyGame);
 	CDbRoom &operator= (const CDbRoom &Src) {
 		SetMembers(Src);
 		return *this;
@@ -475,7 +476,7 @@ private:
 	void           SaveExits(c4_View &ExitsView) const;
 	void           SetCurrentGameForMonsters(const CCurrentGame *pSetCurrentGame);
 	void           SetExtraVarsFromMembers();
-	bool           SetMembers(const CDbRoom &Src, const bool bCopyLocalInfo=true);
+	bool           SetMembers(const CDbRoom &Src, const bool bCopyLocalInfo=true, const bool bCopyGame=true);
 	void           SetMembersFromExtraVars();
 
 	bool           UnpackTileLights(const BYTE *pSrc, const UINT dwSrcSize);

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -168,7 +168,6 @@ public:
 	bool           AddPressurePlateTiles(COrbData* pPlate);
 	bool           AddScroll(CScrollData *pScroll);
 	bool           AddExit(CExitData *pExit);
-	void           BombExplode(CCueEvents &CueEvents, CCoordStack& bombs);
 	void           BurnFuses(CCueEvents &CueEvents);
 	void           BurnFuseEvents(CCueEvents &CueEvents);
 //	bool           BrainSensesSwordsman() const;
@@ -218,6 +217,10 @@ public:
 	bool           DoesSquareContainPathMapObstacle(const UINT wX, const UINT wY,
 			const MovementType eMovement) const;
 */
+	void           DoExplode(CCueEvents& CueEvents, CCoordStack& bombs, CCoordStack& powder_kegs);
+	void           DoExplodeTile(CCueEvents& CueEvents, CCoordStack& bombs, CCoordStack& powder_kegs,
+		CCoordSet& explosion, UINT wCol, UINT wRow, UINT explosion_radius,
+		bool bAddCueEvent = true);
 	bool           DoesSquareContainPlayerObstacle(const UINT wX, const UINT wY,
 			const UINT wO, const bool bRaisedSrc,
 			const bool bCrateSrc=false, const bool bAllowCrateClimbing=false) const;
@@ -286,6 +289,7 @@ public:
 	void           IncTrapdoor(CCueEvents& CueEvents);
 	void           InitCoveredTiles();
 	void           InitRoomStats(const bool bSkipPlatformInit=false);
+	void           InitStateForThisTurn();
 	UINT           GetBrainsPresent() const;
 	bool           IsDisarmTokenActive() const;
 	bool           IsDoorOpen(const int nCol, const int nRow);
@@ -350,7 +354,10 @@ public:
 	void           ProcessTurn(CCueEvents &CueEvents, const bool bFullMove);
 	void           ExpandExplosion(CCueEvents &CueEvents, CCoordStack& cs,
 			const UINT wBombX, const UINT wBombY, const UINT wX, const UINT wY,
-			CCoordStack& bombs, CCoordSet& explosion);
+			CCoordStack& bombs, CCoordStack& powder_kegs, CCoordSet& explosion, const UINT radius);
+	void           ExplodeBomb(CCueEvents& CueEvents, const UINT x, const UINT y) { CCoordStack bombs(x, y); CCoordStack cs; DoExplode(CueEvents, bombs, cs); }
+	void           ExplodePowderKeg(CCueEvents& CueEvents, const UINT x, const UINT y) { CCoordStack cs; CCoordStack powder_kegs(x, y); DoExplode(CueEvents, cs, powder_kegs); }
+
 	void           ProcessExplosionSquare(CCueEvents &CueEvents, const UINT wX, const UINT wY,
 			const bool bHarmsPlayer=true);
 	void           ProcessAumtlichGaze(CCueEvents &CueEvents);
@@ -431,6 +438,7 @@ private:
 	bool           CanExpandMist(const UINT wX, const UINT wY) const;
 	void           Clear();
 	void           ClearPushInfo();
+	void           ClearStateVarsUsedDuringTurn();
 	void           CloseDoor(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 //	void           DeletePathMaps();
 	CMonster*      FindLongMonster(const UINT wX, const UINT wY,
@@ -439,6 +447,8 @@ private:
 			const int dx, const int dy, const bool bAbbrev=false);
 	UINT           GetLocalID() const;
 	void           GetNumber_English(const UINT num, WCHAR *str);
+	CCoordStack    GetPowderKegsStillOnHotTiles() const;
+	void           ExplodeStabbedPowderKegs(CCueEvents& CueEvents);
 	bool           LoadOrbs(c4_View &OrbsView);
 	bool           LoadMonsters(c4_View &MonstersView);
 	bool           LoadScrolls(c4_View &ScrollsView);
@@ -479,6 +489,8 @@ private:
 	vector<UINT> deletedDataIDs;    //data IDs to be deleted on Update
 	CCurrentGame * pCurrentGame;
 //	bool           bCheckForHoldMastery;
+	CCoordSet   stationary_powder_kegs;
+	CCoordStack stabbed_powder_kegs;
 };
 
 //******************************************************************************************

--- a/drodrpg/DRODLib/GameConstants.cpp
+++ b/drodrpg/DRODLib/GameConstants.cpp
@@ -53,7 +53,7 @@ const UINT NEXT_VERSION_NUMBER = 500;
 const WCHAR wszVersionReleaseNumber[] = WS("1.3.0.") WS(STRFY_EXPAND(DROD_VERSION_REVISION));
 #else
 const WCHAR wszVersionReleaseNumber[] = {
-	We('1'),We('.'),We('3'),We('.'),We('0'),We('.'),We('5'),We('1'),We('1'),We(0)   // 1.3.0.* -- full version number plus build number
+	We('1'),We('.'),We('3'),We('.'),We('0'),We('.'),We('5'),We('8'),We('3'),We(0)   // 1.3.0.* -- full version number plus build number
 };
 #endif
 

--- a/drodrpg/DRODLib/Mimic.cpp
+++ b/drodrpg/DRODLib/Mimic.cpp
@@ -110,7 +110,8 @@ const
 		switch (wLookTileNo)
 		{
 			case T_MIRROR:
-			case T_CRATE: 
+			case T_CRATE:
+			case T_POWDER_KEG:
 			{
 				const int dx = (int)wCol - (int)this->wX;
 				const int dy = (int)wRow - (int)this->wY;
@@ -249,7 +250,7 @@ void CMimic::Process(
 */
 			//Process any and all of these item interactions.
 			UINT tTile = room.GetTSquare(this->wX, this->wY);
-			if (tTile==T_MIRROR || tTile==T_CRATE)
+			if (tTile==T_MIRROR || tTile==T_CRATE || tTile==T_POWDER_KEG)
 			{
 				room.PushObject(this->wX, this->wY, this->wX + dx, this->wY + dy, CueEvents);
 				tTile = room.GetTSquare(this->wX, this->wY); //also check what was under the object

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -2338,6 +2338,7 @@ bool CMonster::GetNextGaze(
 		case T_OBSTACLE:
 		case T_MIRROR:
 		case T_CRATE:
+		case T_POWDER_KEG:
 			//These objects stop gaze.
 			return false;
 		case T_FUSE:

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -225,6 +225,7 @@ public:
 	virtual bool  IsAttackableTarget() const {return false;}
 	virtual bool  IsCombatable() const;
 	virtual bool  IsDamageableAt(const UINT /*wX*/, const UINT /*wY*/) const {return true;}
+	virtual bool  IsExplosiveSafe() const { return false; }
 	virtual bool  IsFlying() const {return this->eMovement == AIR;}
 	virtual bool  IsFriendly() const {return false;}
 	virtual bool  IsLongMonster() const {return false;}

--- a/drodrpg/DRODLib/Swordsman.cpp
+++ b/drodrpg/DRODLib/Swordsman.cpp
@@ -301,6 +301,7 @@ bool CSwordsman::IsOpenMove(const UINT wX, const UINT wY, const int dx, const in
 			{
 				case T_ORB:
 				case T_BOMB:
+				case T_POWDER_KEG:
 					return false;
 				case T_MIRROR:
 					if (!this->bIntraRoomPath)
@@ -376,7 +377,7 @@ const
 			return false;
 		if (bIsPowerUp(wLookTileNo) || bIsEquipment(wLookTileNo) ||
 				bIsMap(wLookTileNo) || bIsShovel(wLookTileNo) ||
-				wLookTileNo == T_KEY || wLookTileNo == T_MIRROR || wLookTileNo == T_CRATE)
+				wLookTileNo == T_KEY || wLookTileNo == T_MIRROR || wLookTileNo == T_CRATE || wLookTileNo == T_POWDER_KEG)
 			return false;
 
 		//Accessory-specific paths.

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -166,8 +166,9 @@
 #define T_MISTVENT      116 //produces and expands mist
 #define T_FIRETRAP      117
 #define T_FIRETRAP_ON   118
+#define T_POWDER_KEG    119
 
-#define TILE_COUNT     (119) //Number of tile constants from above list.
+#define TILE_COUNT     (120) //Number of tile constants from above list.
 static inline bool IsValidTileNo(const UINT t) {return t < TILE_COUNT;}
 
 //
@@ -281,7 +282,11 @@ static inline bool bIsDEFUp(const UINT t) { return t == T_DEF_UP || t == T_DEF_U
 
 static inline bool bIsShovel(const UINT t) { return t == T_SHOVEL1 || t == T_SHOVEL3 || t == T_SHOVEL10; }
 
-static inline bool bIsTLayerCoveringItem(const UINT t) { return t == T_MIRROR || t == T_CRATE; }
+static inline bool bIsTLayerCoveringItem(const UINT t) { return t == T_MIRROR || t == T_CRATE || t == T_POWDER_KEG; }
+
+static inline bool bIsFuseConnected(const UINT t) { return t == T_FUSE || t == T_BOMB; }
+static inline bool bIsCombustibleItem(const UINT t) { return t == T_FUSE || t == T_BOMB || t == T_POWDER_KEG; }
+static inline bool bIsExplodingItem(const UINT t) { return t == T_BOMB || t == T_POWDER_KEG; }
 
 static inline bool bIsDiggableBlock(const UINT t) { return t == T_DIRT1 || t == T_DIRT3 || t == T_DIRT5; }
 
@@ -532,6 +537,7 @@ static const UINT TILE_LAYER[TOTAL_EDIT_TILE_COUNT] =
 	LAYER_OPAQUE, //T_MISTVENT
 	LAYER_OPAQUE, //T_FIRETRAP
 	LAYER_OPAQUE, //T_FIRETRAP_ON
+	LAYER_TRANSPARENT, //T_POWDER_KEG
 
 	LAYER_MONSTER, //M_ROACH         +0
 	LAYER_MONSTER, //M_QROACH        +1
@@ -698,6 +704,7 @@ static const UINT TILE_MID[TOTAL_EDIT_TILE_COUNT] =
 	MID_MistVent, //T_MISTVENT
 	MID_Firetrap,      //T_FIRETRAP
 	MID_FiretrapOn,    //T_FIRETRAP_ON
+	MID_PowderKeg,     //T_POWDER_KEG
 
 	MID_Roach,        //M_ROACH         +0
 	MID_RoachQueen,   //M_QROACH        +1

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -587,6 +587,8 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
   <li><a name="be_pushobjects"><u>Push Objects</u></a>:
 	  Allows the NPC to push mirrors and move platforms.
 	  Otherwise, it is not allowed (default).</li>
+  <li><a name="be_explodesafe"><u>Explosive safe</u></a>:
+	  A piece of equipment with this behavior will prevent the player's sword from detonating bombs and powder kegs, allowing kegs to be pushed with the sword. An NPC with this behavior will not detonate bombs or kegs with their sword.</li>
   <li><a name="be_directonlymovement"><u>Direct-only movement</u></a>: If the
       target is in a diagonal direction from the NPC, but
 	  diagonal movement is blocked, then don't move at all.  If the target is

--- a/drodrpg/Texts/EditScreens.uni
+++ b/drodrpg/Texts/EditScreens.uni
@@ -754,6 +754,10 @@ Fire Trap
 [eng]
 Fire Trap (active)
 
+[MID_PowderKeg]
+[eng]
+Powder Keg
+
 [MID_ForceArrowDisabled]
 [eng]
 Disabled force arrow

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1538,6 +1538,7 @@ enum MID_CONSTANT {
   MID_CustomAspect = 1829,
   MID_StrongAgainstAspect = 1830,
   MID_RemovesSword = 1832,
+  MID_ExplosiveSafe = 1894,
   MID_CharOptionsTitle = 1836,
   MID_CharOptions = 1837,
   MID_ProcessingSequence = 1838,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -314,6 +314,7 @@ enum MID_CONSTANT {
   MID_MistVent = 1887,
   MID_Firetrap = 1888,
   MID_FiretrapOn = 1889,
+  MID_PowderKeg = 1893,
   MID_FloorMosaic = 332,
   MID_FloorRoad = 333,
   MID_FloorGrass = 334,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1340,6 +1340,10 @@ Strong against %s
 [eng]
 Removes sword
 
+[MID_ExplosiveSafe]
+[eng]
+Explosive safe
+
 [MID_CharOptionsTitle]
 [eng]
 Character Options


### PR DESCRIPTION
Ports the powder keg element to DROD RPG, along with the changes to explosion processing to make that possible. Additional, a new script behavior has been added that can prevent a player or character's sword from detonating explosive objects, and an "explosive safe" weapon is able to push kegs.