### PR TITLE
Add support for array script variables

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -185,6 +185,11 @@ const UINT TAG_VARCOMPLIST2 = 873;
 const UINT TAG_ORBAGENTLIST = 872;
 const UINT TAG_PLAYERBEHAVE_LIST = 871;
 const UINT TAG_PLAYERBEHAVESTATE_LIST = 870;
+const UINT TAG_ARRAYVARLIST = 869;
+const UINT TAG_ARRAYVAROPLIST = 868;
+const UINT TAG_ARRAYINDEX_LABEL = 867;
+const UINT TAG_ARRAYVAR_REMOVE = 866;
+const UINT TAG_ARRAYVAR_TEXTLABEL = 865;
 
 const UINT MAX_TEXT_LABEL_SIZE = 100;
 
@@ -328,6 +333,14 @@ void CRenameDialogWidget::OnDoubleClick(
 		}
 		break;
 
+		case TAG_ARRAYVARLIST:
+		{
+			CCharacterDialogWidget* pParent = DYN_CAST(CCharacterDialogWidget*,
+				CWidget*, this->pParent);
+			pParent->RenameVar(true);
+		}
+		break;
+
 		case TAG_CHARACTERLISTBOX:
 		{
 			CCharacterDialogWidget *pParent = DYN_CAST(CCharacterDialogWidget*,
@@ -421,6 +434,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	, pOnOffListBox(NULL), pOnOffListBox2(NULL), pOpenCloseListBox(NULL)
 	, pGotoLabelListBox(NULL), pMusicListBox(NULL)
 	, pVarListBox(NULL), pVarOpListBox(NULL), pVarCompListBox(NULL), pVarCompListBox2(NULL)
+	, pArrayVarListBox(NULL), pArrayVarOpListBox(NULL)
 	, pWaitFlagsListBox(NULL), pImperativeListBox(NULL), pBuildItemsListBox(NULL)
 	, pBuildMarkerListBox(NULL), pWaitForItemsListBox(NULL)
 	, pCharNameText(NULL), pCharListBox(NULL)
@@ -647,15 +661,17 @@ bool CCharacterDialogWidget::RenameCharacter()
 }
 
 //*****************************************************************************
-bool CCharacterDialogWidget::RenameVar()
+bool CCharacterDialogWidget::RenameVar(const bool bIsArrayVar)
 //Prompt the user to rename the selected hold variable.
 //
 //Returns: whether a var was renamed
 {
-	if (!this->pVarListBox->ClickedSelection())
+	CListBoxWidget* varListBox = bIsArrayVar ? this->pArrayVarListBox : this->pVarListBox;
+
+	if (!varListBox->ClickedSelection())
 		return false;
 
-	const UINT varID = this->pVarListBox->GetSelectedItem();
+	const UINT varID = varListBox->GetSelectedItem();
 	if (!varID)
 		return false;
 
@@ -674,7 +690,7 @@ bool CCharacterDialogWidget::RenameVar()
 	bool bGoodSyntax;
 	WSTRING wstr;
 	do {
-		wstr = this->pVarListBox->GetSelectedItemText();
+		wstr = varListBox->GetSelectedItemText();
 		const UINT answerTagNo = pEditRoomScreen->ShowTextInputMessage(
 				MID_RenameVariablePrompt, wstr, false, true);
 		if (answerTagNo != TAG_OK)
@@ -686,14 +702,19 @@ bool CCharacterDialogWidget::RenameVar()
 			pEditRoomScreen->ShowOkMessage(MID_VarNameSyntaxError);
 	} while (!bGoodSyntax);
 
+	if (ScriptVars::IsCharacterArrayVar(wstr) != bIsArrayVar) {
+		pEditRoomScreen->ShowOkMessage(L"Can't change var type");
+		return false;
+	}
+
 	if (!pEditRoomScreen->pHold->RenameVar(varID, wstr))
 	{
 		pEditRoomScreen->ShowOkMessage(MID_VarNameDuplicationError);
 		return false;
 	}
 
-	this->pVarListBox->SetSelectedItemText(wstr.c_str());
-	this->pVarListBox->Paint();
+	varListBox->SetSelectedItemText(wstr.c_str());
+	varListBox->Paint();
 	return true;
 }
 
@@ -1827,10 +1848,19 @@ void CCharacterDialogWidget::AddCommandDialog()
 			X_VARTEXTLABEL, Y_VARTEXTLABEL, CX_VARTEXTLABEL, CY_VARTEXTLABEL,
 			F_Small, g_pTheDB->GetMessageText(MID_VarNameText)));
 
+	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_ARRAYVAR_TEXTLABEL,
+		X_VARTEXTLABEL, Y_VARTEXTLABEL, CX_VARTEXTLABEL, CY_VARTEXTLABEL,
+		F_Small, L"Variable Name/Expression"));
+
 	this->pVarListBox = new CListBoxWidget(TAG_VARLIST,
 			X_VARLISTBOX, Y_VARLISTBOX, CX_VARLISTBOX, CY_VARLISTBOX, true);
 	this->pVarListBox->AddHotkey(SDLK_RETURN, TAG_OK);
 	this->pAddCommandDialog->AddWidget(this->pVarListBox);
+
+	this->pArrayVarListBox = new CListBoxWidget(TAG_ARRAYVARLIST,
+		X_VARLISTBOX, Y_VARLISTBOX, CX_VARLISTBOX, CY_VARLISTBOX, true);
+	this->pArrayVarListBox->AddHotkey(SDLK_RETURN, TAG_OK);
+	this->pAddCommandDialog->AddWidget(this->pArrayVarListBox);
 
 	CButtonWidget *pVarAddButton = new CButtonWidget(TAG_VARADD, X_VARADD,
 			Y_VARADD, CX_VARADD, CY_VARADD, g_pTheDB->GetMessageText(MID_VarAdd));
@@ -1838,6 +1868,9 @@ void CCharacterDialogWidget::AddCommandDialog()
 
 	CButtonWidget *pVarRemoveButton = new CButtonWidget(TAG_VARREMOVE, X_VARREMOVE,
 			Y_VARREMOVE, CX_VARREMOVE, CY_VARREMOVE, g_pTheDB->GetMessageText(MID_VarRemove));
+	this->pAddCommandDialog->AddWidget(pVarRemoveButton);
+	pVarRemoveButton = new CButtonWidget(TAG_ARRAYVAR_REMOVE, X_VARREMOVE,
+		Y_VARREMOVE, CX_VARREMOVE, CY_VARREMOVE, g_pTheDB->GetMessageText(MID_VarRemove));
 	this->pAddCommandDialog->AddWidget(pVarRemoveButton);
 
 	this->pVarOpListBox = new CListBoxWidget(TAG_VAROPLIST,
@@ -1853,6 +1886,18 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pVarOpListBox->AddItem(ScriptVars::DivideBy, g_pTheDB->GetMessageText(MID_VarDivideBy));
 	this->pVarOpListBox->AddItem(ScriptVars::Mod, g_pTheDB->GetMessageText(MID_VarMod));
 	this->pVarOpListBox->SelectLine(0);
+
+	this->pArrayVarOpListBox = new CListBoxWidget(TAG_ARRAYVAROPLIST,
+		X_VAROPLIST, Y_VAROPLIST, CX_VAROPLIST, CY_VAROPLIST - (2 * LIST_LINE_HEIGHT));
+	this->pAddCommandDialog->AddWidget(this->pArrayVarOpListBox);
+	this->pArrayVarOpListBox->AddHotkey(SDLK_RETURN, TAG_OK);
+	this->pArrayVarOpListBox->AddItem(ScriptVars::Assign, g_pTheDB->GetMessageText(MID_VarAssign));
+	this->pArrayVarOpListBox->AddItem(ScriptVars::Inc, g_pTheDB->GetMessageText(MID_VarInc));
+	this->pArrayVarOpListBox->AddItem(ScriptVars::Dec, g_pTheDB->GetMessageText(MID_VarDec));
+	this->pArrayVarOpListBox->AddItem(ScriptVars::MultiplyBy, g_pTheDB->GetMessageText(MID_VarMultiplyBy));
+	this->pArrayVarOpListBox->AddItem(ScriptVars::DivideBy, g_pTheDB->GetMessageText(MID_VarDivideBy));
+	this->pArrayVarOpListBox->AddItem(ScriptVars::Mod, g_pTheDB->GetMessageText(MID_VarMod));
+	this->pArrayVarOpListBox->SelectLine(0);
 
 	this->pVarCompListBox = new CListBoxWidget(TAG_VARCOMPLIST,
 			X_VARCOMPLIST, Y_VARCOMPLIST, CX_VARCOMPLIST, CY_VARCOMPLIST);
@@ -1882,6 +1927,10 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_VARVALUELABEL,
 			X_VARVALUELABEL, Y_VARVALUELABEL, CX_VARVALUELABEL, CY_VARVALUELABEL,
 			F_Small, g_pTheDB->GetMessageText(MID_VarOperand)));
+
+	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_ARRAYINDEX_LABEL,
+		X_VARVALUELABEL, Y_VARVALUELABEL, CX_VARVALUELABEL, CY_VARVALUELABEL,
+		F_Small, L"Index"));
 
 	CTextBoxWidget *pVarOperand = new CTextBoxWidget(TAG_VARVALUE, X_VARVALUE, Y_VARVALUE,
 			CX_VARVALUE, CY_VARVALUE);
@@ -2220,12 +2269,8 @@ void CCharacterDialogWidget::EditCharacter(CCharacter* pCharacter)
 
 	PopulateMainGraphicList();
 
-	CWidget *pButton = this->pAddCommandDialog->GetWidget(TAG_VARREMOVE);
-	ASSERT(pButton);
-	const bool bEnable = this->pVarListBox->GetItemCount() > 0;
-	if (!bEnable && GetSelectedWidget() == pButton)
-		SelectNextWidget();
-	pButton->Enable(bEnable);
+	UpdateVarDeleteButton(TAG_VARREMOVE, this->pVarListBox);
+	UpdateVarDeleteButton(TAG_ARRAYVAR_REMOVE, this->pArrayVarListBox);
 
 	//Compile temporary commands list from character.
 	for (UINT wIndex=0; wIndex<pCharacter->commands.size(); ++wIndex)
@@ -2350,6 +2395,7 @@ void CCharacterDialogWidget::OnClick(
 					case TAG_TESTSOUND: TestSound(); break;
 					case TAG_VARADD: AddVar(); break;
 					case TAG_VARREMOVE: DeleteVar();	break;
+					case TAG_ARRAYVAR_REMOVE: DeleteVar(true);	break;
 					default:
 						bLoop = false;
 					break;
@@ -2932,14 +2978,16 @@ UINT CCharacterDialogWidget::AddVar(const WCHAR* pVarName)
 		pEditRoomScreen->ShowOkMessage(MID_VarNameDuplicationError);
 		return 0;
 	}
-	const UINT line = this->pVarListBox->AddItem(dwNewVarID, pVarName);
-	this->pVarListBox->SelectLine(line);
 
-	CWidget *pButton = this->pAddCommandDialog->GetWidget(TAG_VARREMOVE);
-	ASSERT(pButton);
-	pButton->Enable();
-	if (pButton->IsVisible() && this->pAddCommandDialog->IsVisible())
-		pButton->RequestPaint();
+	if (ScriptVars::IsCharacterArrayVar(pVarName)) {
+		const UINT line = this->pArrayVarListBox->AddItem(dwNewVarID, pVarName);
+		this->pArrayVarListBox->SelectLine(line);
+		UpdateVarDeleteButton(TAG_ARRAYVAR_REMOVE, this->pArrayVarListBox);
+	} else {
+		const UINT line = this->pVarListBox->AddItem(dwNewVarID, pVarName);
+		this->pVarListBox->SelectLine(line);
+		UpdateVarDeleteButton(TAG_VARREMOVE, this->pVarListBox);
+	}
 
 	return dwNewVarID;
 }
@@ -3027,10 +3075,11 @@ void CCharacterDialogWidget::DeleteCommands(
 }
 
 //*****************************************************************************
-void CCharacterDialogWidget::DeleteVar()
+void CCharacterDialogWidget::DeleteVar(const bool bArrayVar)
 //Delete selected hold var.
 {
-	ASSERT(this->pVarListBox->GetItemCount() > 0);
+	CListBoxWidget* varListBox = bArrayVar ? this->pArrayVarListBox : this->pVarListBox;
+	ASSERT(varListBox->GetItemCount() > 0);
 	CEditRoomScreen *pEditRoomScreen = DYN_CAST(CEditRoomScreen*, CScreen*,
 			g_pTheSM->GetScreen(SCR_EditRoom));
 	ASSERT(pEditRoomScreen);
@@ -3038,27 +3087,21 @@ void CCharacterDialogWidget::DeleteVar()
 	if (pEditRoomScreen->ShowYesNoMessage(MID_DeleteVarPrompt) != TAG_YES)
 		return;
 
-	const UINT dwVarID = this->pVarListBox->GetSelectedItem();
-	const UINT line = this->pVarListBox->GetSelectedLineNumber();
+	const UINT dwVarID = varListBox->GetSelectedItem();
+	const UINT line = varListBox->GetSelectedLineNumber();
 	if (pEditRoomScreen->pHold->DeleteVar(dwVarID))
 	{
 		PopulateVarList();
 
 		//Select closest var in list.
-		const UINT numLines = this->pVarListBox->GetItemCount();
+		const UINT numLines = varListBox->GetItemCount();
 		if (line < numLines)
-			this->pVarListBox->SelectLine(line);
+			varListBox->SelectLine(line);
 		else if (numLines > 0)
-			this->pVarListBox->SelectLine(numLines-1);
+			varListBox->SelectLine(numLines-1);
 
 		//Set button state.
-		CWidget *pButton = GetWidget(TAG_VARREMOVE);
-		ASSERT(pButton);
-		const bool bEnable = this->pVarListBox->GetItemCount() > 0;
-		if (!bEnable && GetSelectedWidget() == pButton)
-			SelectNextWidget();
-		pButton->Enable(bEnable);
-		pButton->RequestPaint();
+		UpdateVarDeleteButton(bArrayVar ? TAG_ARRAYVAR_REMOVE : TAG_VARREMOVE, varListBox);
 	}
 }
 
@@ -3098,6 +3141,7 @@ void CCharacterDialogWidget::EditClickedCommand()
 			case TAG_TESTSOUND: TestSound(); break;
 			case TAG_VARADD: AddVar(); break;
 			case TAG_VARREMOVE: DeleteVar();	break;
+			case TAG_ARRAYVAR_REMOVE: DeleteVar(true);	break;
 			default:
 				bLoop = false;
 			break;
@@ -3248,6 +3292,7 @@ void CCharacterDialogWidget::EditDefaultScriptForCustomNPC()
 						case TAG_TESTSOUND: TestSound(); break;
 						case TAG_VARADD: AddVar(); break;
 						case TAG_VARREMOVE: DeleteVar();	break;
+						case TAG_ARRAYVAR_REMOVE: DeleteVar(true);	break;
 						default:
 							bLoop = false;
 						break;
@@ -4183,7 +4228,7 @@ const
 		// no break
 		case CCharacterCommand::CC_VarSet:
 		{
-			UINT varId = command.command == CCharacterCommand::CC_VarSetAt ? command.w : command.x;
+			UINT varId = command.getVarID();
 			UINT operation = command.command == CCharacterCommand::CC_VarSetAt ? command.h : command.y;
 			const WCHAR *wszVarName = this->pVarListBox->GetTextForKey(varId);
 			wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
@@ -4242,6 +4287,46 @@ const
 						wstr += _itoW(command.w, temp, 10);
 				break;
 			}
+		}
+		break;
+
+		case CCharacterCommand::CC_ArrayVarSetAt:
+		{
+			wstr += wszLeftParen;
+			wstr += _itoW(command.x, temp, 10);
+			wstr += wszComma;
+			wstr += _itoW(command.y, temp, 10);
+			wstr += wszRightParen;
+			wstr += wszSpace;
+		}
+		//no break
+		case CCharacterCommand::CC_ArrayVarSet:
+		{
+			const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(command.w);
+			wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
+			wstr += wszLeftBracket;
+			wstr += _itoW(command.flags, temp, 10);
+			wstr += wszRightBracket;
+			wstr += wszSpace;
+			UINT operation = command.h;
+			switch (operation)
+			{
+				case ScriptVars::Assign: wstr += wszEqual; break;
+				case ScriptVars::Inc: wstr += wszPlus; break;
+				case ScriptVars::Dec: wstr += wszHyphen; break;
+				case ScriptVars::MultiplyBy: wstr += wszAsterisk; break;
+				case ScriptVars::DivideBy: wstr += wszForwardSlash; break;
+				case ScriptVars::Mod: wstr += wszPercent; break;
+				default: wstr += wszQuestionMark; break;
+			}
+			wstr += wszSpace;
+			wstr += command.label;
+		}
+		break;
+		case CCharacterCommand::CC_ClearArrayVar:
+		{
+			const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(command.x);
+			wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
 		}
 		break;
 
@@ -4503,6 +4588,7 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 			case CCharacterCommand::CC_ChallengeCompleted:
 			case CCharacterCommand::CC_Return:
 			case CCharacterCommand::CC_ResetOverrides:
+			case CCharacterCommand::CC_ClearArrayVar:
 				if (bLastWasIfCondition || wLogicNestDepth)
 					wstr += wszQuestionMark;	//questionable If condition
 				break;
@@ -4552,6 +4638,30 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 					break;
 				}
 				if (pCommand->command == CCharacterCommand::CC_VarSetAt && wLogicNestDepth)
+					wstr += wszQuestionMark; //questionable logic condition
+			}
+			break;
+			case CCharacterCommand::CC_ArrayVarSet:
+				if (bLastWasIfCondition || wLogicNestDepth)
+					wstr += wszQuestionMark;	//questionable If condition
+				//no break
+			case CCharacterCommand::CC_ArrayVarSetAt:
+			{
+				vector<WSTRING> expressions = WCSExplode(pCommand->label, *wszSemicolon);
+				CEditRoomScreen* pEditRoomScreen = DYN_CAST(CEditRoomScreen*, CScreen*,
+					g_pTheSM->GetScreen(SCR_EditRoom));
+				ASSERT(pEditRoomScreen);
+				ASSERT(pEditRoomScreen->pHold);
+				for (vector<WSTRING>::const_iterator expression = expressions.begin();
+					expression != expressions.end(); ++expression) {
+					UINT validationIndex = 0;
+					if (!CCharacter::IsValidExpression(expression->c_str(), validationIndex, pEditRoomScreen->pHold)) {
+						wstr += wszAsterisk; //expression is not valid
+						break;
+					}
+				}
+
+				if (pCommand->command == CCharacterCommand::CC_ArrayVarSetAt && wLogicNestDepth)
 					wstr += wszQuestionMark; //questionable logic condition
 			}
 			break;
@@ -4798,6 +4908,9 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetPlayerBehavior, L"Set player behavior");
 	this->pActionListBox->AddItem(CCharacterCommand::CC_VarSet, g_pTheDB->GetMessageText(MID_VarSet));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_VarSetAt, g_pTheDB->GetMessageText(MID_VarSetAt));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSet, L"Set array var");
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSetAt, L"Set array var at");
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ClearArrayVar, L"Clear array var");
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Speech, g_pTheDB->GetMessageText(MID_Speech));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_StartGlobalScript, g_pTheDB->GetMessageText(MID_StartGlobalScript));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_TeleportTo, g_pTheDB->GetMessageText(MID_TeleportTo));
@@ -5356,13 +5469,20 @@ void CCharacterDialogWidget::PopulateVarList()
 //Compile active hold's current var list.
 {
 	this->pVarListBox->Clear();
+	this->pArrayVarListBox->Clear();
 	CEditRoomScreen *pEditRoomScreen = DYN_CAST(CEditRoomScreen*, CScreen*,
 			g_pTheSM->GetScreen(SCR_EditRoom));
 	ASSERT(pEditRoomScreen);
 	ASSERT(pEditRoomScreen->pHold);
-	for (vector<HoldVar>::const_iterator var = pEditRoomScreen->pHold->vars.begin();
-			var != pEditRoomScreen->pHold->vars.end(); ++var)
-		this->pVarListBox->AddItem(var->dwVarID, var->varNameText.c_str());
+	const CDbHold* pHold = pEditRoomScreen->pHold;
+	for (vector<HoldVar>::const_iterator var = pHold->vars.begin();
+		var != pHold->vars.end(); ++var) {
+		if (ScriptVars::IsCharacterArrayVar(var->varNameText)) {
+			this->pArrayVarListBox->AddItem(var->dwVarID, var->varNameText.c_str());
+		} else {
+			this->pVarListBox->AddItem(var->dwVarID, var->varNameText.c_str());
+		}
+	}
 
 	//Add hard-coded global vars to the end of the list.
 	this->pVarListBox->SortAlphabetically(false);
@@ -5409,6 +5529,25 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_RAIN, g_pTheDB->GetMessageText(MID_RoomRain));
 
 	this->pVarListBox->SortAlphabetically(true);
+	this->pArrayVarListBox->SortAlphabetically(true);
+}
+
+//*****************************************************************************
+void CCharacterDialogWidget::UpdateVarDeleteButton(
+	UINT widgetTag, CListBoxWidget* varListBox
+)
+//Update the enabled state of widget based on the content of a list box.
+//Intended for the Delete Var buttons.
+{
+	CWidget* pButton = GetWidget(widgetTag);
+	ASSERT(pButton);
+	const bool bEnable = varListBox->GetItemCount() > 0;
+	if (!bEnable && GetSelectedWidget() == pButton)
+		SelectNextWidget();
+	pButton->Enable(bEnable);
+
+	if (pButton->IsVisible() && this->pAddCommandDialog->IsVisible())
+		pButton->RequestPaint();
 }
 
 //*****************************************************************************
@@ -5529,6 +5668,9 @@ void CCharacterDialogWidget::SetCommandColor(
 		case CCharacterCommand::CC_VarSet:
 		case CCharacterCommand::CC_VarSetAt:
 		case CCharacterCommand::CC_ResetOverrides:
+		case CCharacterCommand::CC_ArrayVarSet:
+		case CCharacterCommand::CC_ArrayVarSetAt:
+		case CCharacterCommand::CC_ClearArrayVar:
 			pListBox->SetItemColorAtLine(line, FullRed);
 		break;
 		case CCharacterCommand::CC_Wait: 
@@ -5576,7 +5718,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 {
 	//Code is structured in this way to facilitate quick addition of
 	//additional action parameters.
-	static const UINT NUM_WIDGETS = 60;
+	static const UINT NUM_WIDGETS = 63;
 	static const UINT widgetTag[NUM_WIDGETS] = {
 		TAG_WAIT, TAG_EVENTLISTBOX, TAG_DELAY, TAG_SPEECHTEXT,
 		TAG_SPEAKERLISTBOX, TAG_MOODLISTBOX, TAG_ADDSOUND, TAG_TESTSOUND, TAG_DIRECTIONLISTBOX,
@@ -5595,7 +5737,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_VARNAMETEXTINPUT, TAG_GRAPHICLISTBOX3, TAG_WAITFORITEMLISTBOX, TAG_BUILDMARKERITEMLISTBOX,
 		TAG_NATURAL_TARGET_TYPES, TAG_WEAPON_FLAGBOX, TAG_BEHAVIOR_LISTBOX, TAG_REMAINS_LISTBOX,
 		TAG_MOVETYPELISTBOX, TAG_IGNOREFLAGSLISTBOX, TAG_COLOR_LISTBOX, TAG_WEAPON_LISTBOX2,
-		TAG_VARCOMPLIST2, TAG_ORBAGENTLIST, TAG_PLAYERBEHAVE_LIST, TAG_PLAYERBEHAVESTATE_LIST
+		TAG_VARCOMPLIST2, TAG_ORBAGENTLIST, TAG_PLAYERBEHAVE_LIST, TAG_PLAYERBEHAVESTATE_LIST,
+		TAG_ARRAYVARLIST, TAG_ARRAYVAROPLIST, TAG_ARRAYVAR_REMOVE
 	};
 
 	static const UINT NO_WIDGETS[] =    {0};
@@ -5649,6 +5792,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT EXPRESSION[] = { TAG_VARNAMETEXTINPUT, TAG_VARCOMPLIST2, TAG_VARVALUE, 0 };
 	static const UINT ORBAGENTS[] = { TAG_ORBAGENTLIST, 0 };
 	static const UINT PLAYERBEHAVIOR[] = {TAG_PLAYERBEHAVE_LIST, TAG_PLAYERBEHAVESTATE_LIST, 0};
+	static const UINT ARRAYVARSET[] = { TAG_VARNAMETEXTINPUT, TAG_VARADD, TAG_ARRAYVAR_REMOVE, TAG_ARRAYVARLIST, TAG_ARRAYVAROPLIST, TAG_VARVALUE, 0 };
+	static const UINT CLEARARRAYVAR[] = { TAG_ARRAYVARLIST };
 
 	static const UINT* activeWidgets[CCharacterCommand::CC_Count] = {
 		NO_WIDGETS,         //CC_Appear
@@ -5758,10 +5903,13 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_WIDGETS,         //CC_ResetOverrides
 		GRAPHIC,            //CC_CountEntityType
 		WAIT_FOR_ITEMS,     //CC_CountItem
-		PLAYERBEHAVIOR      //CC_SetPlayerBehavior
+		PLAYERBEHAVIOR,     //CC_SetPlayerBehavior
+		ARRAYVARSET,        //CC_ArrayVarSet
+		ARRAYVARSET,        //CC_ArrayVarSetAt
+		CLEARARRAYVAR       //CC_ClearArrayVar
 	};
 
-	static const UINT NUM_LABELS = 32;
+	static const UINT NUM_LABELS = 34;
 	static const UINT labelTag[NUM_LABELS] = {
 		TAG_EVENTLABEL, TAG_WAITLABEL, TAG_DELAYLABEL, TAG_SPEAKERLABEL,
 		TAG_MOODLABEL, TAG_TEXTLABEL, TAG_DIRECTIONLABEL, TAG_SOUNDNAME_LABEL,
@@ -5771,7 +5919,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_SKIPENTRANCELABEL, TAG_DIRECTIONLABEL2, TAG_SOUNDEFFECTLABEL,
 		TAG_X_COORD_LABEL, TAG_Y_COORD_LABEL, TAG_COLOR_LABEL, TAG_INPUTLABEL,
 		TAG_IMAGEOVERLAY_LABEL, TAG_SINGLESTEP2, TAG_KEEPBEHAVIOR_LABEL,
-		TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL
+		TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, TAG_ARRAYINDEX_LABEL,
+		TAG_ARRAYVAR_TEXTLABEL
 	};
 
 	static const UINT NO_LABELS[] =      {0};
@@ -5802,6 +5951,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT NPC_GRAPHIC_L[] =  { TAG_KEEPBEHAVIOR_LABEL, 0 };
 	static const UINT OPEN_TILE_L[] =    { TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, 0 };
 	static const UINT EXPRESSION_L[] =     { TAG_VARVALUELABEL, 0 };
+	static const UINT ARRAYSET_L[] =     { TAG_ARRAYINDEX_LABEL, TAG_ARRAYVAR_TEXTLABEL, 0 };
 
 	static const UINT* activeLabels[CCharacterCommand::CC_Count] = {
 		NO_LABELS,          //CC_Appear
@@ -5912,6 +6062,9 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_CountEntityType
 		NO_LABELS,          //CC_CountItem
 		NO_LABELS,          //CC_SetPlayerBehavior
+		ARRAYSET_L,         //CC_ArrayVarSet
+		ARRAYSET_L,         //CC_ArrayVarSetAt
+		NO_LABELS,          //CC_ClearArrayVar
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -6807,6 +6960,39 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		}
 		break;
 
+		case CCharacterCommand::CC_ArrayVarSet:
+		case CCharacterCommand::CC_ArrayVarSetAt:
+		{
+			this->pCommand->w = this->pArrayVarListBox->GetSelectedItem();
+			this->pCommand->h = this->pArrayVarOpListBox->GetSelectedItem();
+
+			CTextBoxWidget* pVarOperand = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_VARVALUE));
+			ASSERT(pVarOperand);
+			const WCHAR* pOperandText = pVarOperand->GetText();
+			ASSERT(pOperandText);
+			this->pCommand->flags = _Wtoi(pOperandText);
+
+			CTextBoxWidget* pVarText = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_VARNAMETEXTINPUT));
+			ASSERT(pVarText);
+			this->pCommand->label = pVarText->GetText();
+
+			if (this->pCommand->command == CCharacterCommand::CC_ArrayVarSetAt) {
+				QueryXY();
+			} else {
+				AddCommand();
+			}
+		}
+		break;
+
+		case CCharacterCommand::CC_ClearArrayVar:
+		{
+			this->pCommand->x = this->pArrayVarListBox->GetSelectedItem();
+			AddCommand();
+		}
+		break;
+
 		case CCharacterCommand::CC_WaitForExpression:
 		{
 			CTextBoxWidget* pAmount = DYN_CAST(CTextBoxWidget*, CWidget*,
@@ -7375,6 +7561,27 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 			}
 		}
 		break;
+		case CCharacterCommand::CC_ArrayVarSet:
+		case CCharacterCommand::CC_ArrayVarSetAt:
+		{
+			this->pArrayVarListBox->SelectItem(this->pCommand->w);
+			this->pArrayVarOpListBox->SelectItem(this->pCommand->h);
+
+			CTextBoxWidget* pVarOperand = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_VARVALUE));
+			ASSERT(pVarOperand);
+			CTextBoxWidget* pVarText = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_VARNAMETEXTINPUT));
+			ASSERT(pVarText);
+			pVarOperand->SetText(_itoW(this->pCommand->flags, temp, 10));
+			pVarText->SetText(this->pCommand->label.c_str());
+		}
+		break;
+		case CCharacterCommand::CC_ClearArrayVar:
+		{
+			this->pArrayVarListBox->SelectItem(this->pCommand->x);
+		}
+		break;
 		case CCharacterCommand::CC_WaitForExpression:
 		{
 			CTextBoxWidget* pAmount = DYN_CAST(CTextBoxWidget*, CWidget*,
@@ -7722,6 +7929,23 @@ bool getTextUpTo(const WCHAR* pText, UINT& pos, WCHAR c)
 	while (pText[pos] && pText[pos] != c)
 		++pos;
 	return pText[pos] == c;
+}
+
+//******************************************************************************
+UINT parseOperatorSymbol(char varOperator)
+{
+	switch (varOperator)
+	{
+	default: //robust default for bad operator char
+	case '=': return ScriptVars::Assign; break;
+	case '+': return ScriptVars::Inc; break;
+	case '-': return ScriptVars::Dec; break;
+	case '*': return ScriptVars::MultiplyBy; break;
+	case '/': return ScriptVars::DivideBy; break;
+	case '%': return ScriptVars::Mod; break;
+	case ':': return ScriptVars::AssignText; break;
+	case ';': return ScriptVars::AppendText; break;
+	}
 }
 
 //*****************************************************************************
@@ -8365,20 +8589,8 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 			return NULL;
 		}
 		const char varOperator = char(WCv(pText[pos]));
-		UINT operation;
+		UINT operation = parseOperatorSymbol(varOperator);
 		++pos;
-		switch (varOperator)
-		{
-			default: //robust default for bad operator char
-			case '=': operation = ScriptVars::Assign; break;
-			case '+': operation = ScriptVars::Inc; break;
-			case '-': operation = ScriptVars::Dec; break;
-			case '*': operation = ScriptVars::MultiplyBy; break;
-			case '/': operation = ScriptVars::DivideBy; break;
-			case '%': operation = ScriptVars::Mod; break;
-			case ':': operation = ScriptVars::AssignText; break;
-			case ';': operation = ScriptVars::AppendText; break;
-		}
 
 		if (pCommand->command == CCharacterCommand::CC_VarSetAt)
 			pCommand->h = operation;
@@ -8486,6 +8698,71 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 					pCommand->label = pText + pos; //get text expression
 			}
 			break;
+		}
+	}
+	break;
+
+	case CCharacterCommand::CC_ArrayVarSetAt:
+	{
+		parseNumber(pCommand->x); skipComma;
+		parseNumber(pCommand->y); skipComma;
+	}
+	// no break
+	case CCharacterCommand::CC_ArrayVarSet:
+	{
+		parseNumber(pCommand->flags);
+		skipComma;
+
+		parseChar('"');
+		WSTRING varName;
+		const bool bRes = getTextToLastQuote(pText, pos, varName);
+		if (!bRes)
+		{
+			delete pCommand;
+			return NULL;
+		}
+
+		UINT tempIndex = 0;
+		pCommand->w = findTextMatch(this->pVarListBox, varName.c_str(), tempIndex, bFound);
+		if (!bFound)
+		{
+			pCommand->w = AddVar(varName.c_str());
+			if (!pCommand->w)
+			{
+				delete pCommand;
+				return NULL;
+			}
+		}
+		skipWhitespace;
+		const char varOperator = char(WCv(pText[pos]));
+		pCommand->h = parseOperatorSymbol(varOperator);
+		++pos;
+		skipWhitespace;
+		pCommand->label = pText + pos;
+	}
+	break;
+
+	case CCharacterCommand::CC_ClearArrayVar:
+	{
+		parseChar('"');
+		WSTRING varName;
+		const bool bRes = getTextToLastQuote(pText, pos, varName);
+		if (!bRes)
+		{
+			delete pCommand;
+			return NULL;
+		}
+
+		UINT tempIndex = 0;
+		pCommand->x = findTextMatch(this->pVarListBox, varName.c_str(), tempIndex, bFound);
+		if (!bFound)
+		{
+			pCommand->x = AddVar(varName.c_str());
+			if (!pCommand->x)
+			{
+				delete pCommand;
+				return NULL;
+			}
 		}
 	}
 	break;
@@ -9136,7 +9413,7 @@ WSTRING CCharacterDialogWidget::toText(
 	// no break
 	case CCharacterCommand::CC_VarSet:
 	{
-		UINT varId = c.command == CCharacterCommand::CC_VarSetAt ? c.w : c.x;
+		UINT varId = c.getVarID();
 		UINT operation = c.command == CCharacterCommand::CC_VarSetAt ? c.h : c.y;
 		const WCHAR *wszVarName = this->pVarListBox->GetTextForKey(varId);
 		wstr += wszQuote;
@@ -9199,6 +9476,46 @@ WSTRING CCharacterDialogWidget::toText(
 					concatNum(c.w);
 			break;
 		}
+	}
+	break;
+
+	case CCharacterCommand::CC_ArrayVarSetAt:
+	{
+		concatNumWithComma(c.x);
+		concatNumWithComma(c.y);
+	}
+	case CCharacterCommand::CC_ArrayVarSet:
+	{
+		concatNumWithComma(c.flags);
+		UINT varId = c.w;
+		UINT operation = c.h;
+		const WCHAR* wszVarName = this->pVarListBox->GetTextForKey(varId);
+		wstr += wszQuote;
+		wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
+		wstr += wszQuote;
+		wstr += wszSpace;
+		switch (operation)
+		{
+			case ScriptVars::Assign: wstr += wszEqual; break;
+			case ScriptVars::Inc: wstr += wszPlus; break;
+			case ScriptVars::Dec: wstr += wszHyphen; break;
+			case ScriptVars::MultiplyBy: wstr += wszAsterisk; break;
+			case ScriptVars::DivideBy: wstr += wszForwardSlash; break;
+			case ScriptVars::Mod: wstr += wszPercent; break;
+			default: wstr += wszQuestionMark; break;
+		}
+		wstr += wszSpace;
+		wstr += c.label;
+	}
+	break;
+
+	case CCharacterCommand::CC_ClearArrayVar:
+	{
+		UINT varId = c.x;
+		const WCHAR* wszVarName = this->pVarListBox->GetTextForKey(varId);
+		wstr += wszQuote;
+		wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
+		wstr += wszQuote;
 	}
 	break;
 

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -4665,6 +4665,15 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 					wstr += wszQuestionMark; //questionable logic condition
 			}
 			break;
+			case CCharacterCommand::CC_WaitForExpression:
+			{
+				CEditRoomScreen* pEditRoomScreen = DYN_CAST(CEditRoomScreen*, CScreen*,
+					g_pTheSM->GetScreen(SCR_EditRoom));
+				UINT index = 0;
+				if (!CCharacter::IsValidExpression(pCommand->label.c_str(), index, pEditRoomScreen->pHold))
+					wstr += wszAsterisk; //expression is not valid
+			}
+			break;
 
 			//Deprecated commands.
 			case CCharacterCommand::CC_GotoIf:

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -703,7 +703,7 @@ bool CCharacterDialogWidget::RenameVar(const bool bIsArrayVar)
 	} while (!bGoodSyntax);
 
 	if (ScriptVars::IsCharacterArrayVar(wstr) != bIsArrayVar) {
-		pEditRoomScreen->ShowOkMessage(L"Can't change var type");
+		pEditRoomScreen->ShowOkMessage(g_pTheDB->GetMessageText(MID_CantChangeVarType));
 		return false;
 	}
 
@@ -1850,7 +1850,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 
 	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_ARRAYVAR_TEXTLABEL,
 		X_VARTEXTLABEL, Y_VARTEXTLABEL, CX_VARTEXTLABEL, CY_VARTEXTLABEL,
-		F_Small, L"Variable Name/Expression"));
+		F_Small, g_pTheDB->GetMessageText(MID_ArrayVarNameExpression)));
 
 	this->pVarListBox = new CListBoxWidget(TAG_VARLIST,
 			X_VARLISTBOX, Y_VARLISTBOX, CX_VARLISTBOX, CY_VARLISTBOX, true);
@@ -1930,7 +1930,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 
 	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_ARRAYINDEX_LABEL,
 		X_VARVALUELABEL, Y_VARVALUELABEL, CX_VARVALUELABEL, CY_VARVALUELABEL,
-		F_Small, L"Index"));
+		F_Small, g_pTheDB->GetMessageText(MID_ArrayIndexLabel)));
 
 	CTextBoxWidget *pVarOperand = new CTextBoxWidget(TAG_VARVALUE, X_VARVALUE, Y_VARVALUE,
 			CX_VARVALUE, CY_VARVALUE);
@@ -4914,12 +4914,12 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetPlayerStealth, g_pTheDB->GetMessageText(MID_SetPlayerStealth));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetPlayerWeapon, g_pTheDB->GetMessageText(MID_SetPlayerWeapon));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetWaterTraversal, g_pTheDB->GetMessageText(MID_SetWaterTraversal));
-	this->pActionListBox->AddItem(CCharacterCommand::CC_SetPlayerBehavior, L"Set player behavior");
+	this->pActionListBox->AddItem(CCharacterCommand::CC_SetPlayerBehavior, g_pTheDB->GetMessageText(MID_SetPlayerBehavior));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_VarSet, g_pTheDB->GetMessageText(MID_VarSet));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_VarSetAt, g_pTheDB->GetMessageText(MID_VarSetAt));
-	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSet, L"Set array var");
-	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSetAt, L"Set array var at");
-	this->pActionListBox->AddItem(CCharacterCommand::CC_ClearArrayVar, L"Clear array var");
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSet, g_pTheDB->GetMessageText(MID_ArrayVarSet));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSetAt, g_pTheDB->GetMessageText(MID_ArrayVarSetAt));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ClearArrayVar, g_pTheDB->GetMessageText(MID_ClearArrayVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Speech, g_pTheDB->GetMessageText(MID_Speech));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_StartGlobalScript, g_pTheDB->GetMessageText(MID_StartGlobalScript));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_TeleportTo, g_pTheDB->GetMessageText(MID_TeleportTo));

--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -77,7 +77,7 @@ public:
 	virtual void   OnBetweenEvents();
 
 	bool RenameCharacter();
-	bool RenameVar();
+	bool RenameVar(const bool bIsArrayVar = false);
 
 	static const UINT INDENT_PREFIX_SIZE;
 	static const UINT INDENT_TAB_SIZE;
@@ -95,7 +95,7 @@ private:
 	void  ClearPasteBuffer();
 	void  DeleteCommands(CListBoxWidget *pActiveCommandList, COMMANDPTR_VECTOR& commands);
 	void  DeleteCustomCharacter();
-	void  DeleteVar();
+	void  DeleteVar(const bool bArrayVar = false);
 	void  EditCustomCharacters();
 	UINT  findStartTextMatch(CListBoxWidget* pListBoxWidget, const WCHAR* pText, UINT& index, bool& bFound) const;
 	UINT  findTextMatch(CListBoxWidget* pListBoxWidget, const WCHAR* pText, const UINT index, bool& bFound) const;
@@ -143,6 +143,7 @@ private:
 	void  PopulateMainGraphicList();
 	void  PopulateSpeakerList(CListBoxWidget *pListBox);
 	void  PopulateVarList();
+	void  UpdateVarDeleteButton(UINT widgetTag, CListBoxWidget* varListBox);
 
 	void  prepareForwardReferences(const COMMANDPTR_VECTOR& newCommands);
 
@@ -200,7 +201,8 @@ private:
 	CListBoxWidget *pMusicListBox;
 	CListBoxWidget *pVarListBox, *pVarOpListBox, *pVarCompListBox, *pWaitFlagsListBox,
 		*pImperativeListBox, *pBuildItemsListBox, *pBuildMarkerListBox, *pWaitForItemsListBox,
-		*pNaturalTargetTypesListBox, *pBehaviorListBox, *pRemainsListBox, *pVarCompListBox2;
+		*pNaturalTargetTypesListBox, *pBehaviorListBox, *pRemainsListBox, *pVarCompListBox2,
+		*pArrayVarListBox, *pArrayVarOpListBox;
 	CTextBoxWidget *pCharNameText;
 	CListBoxWidget *pCharListBox;
 	CListBoxWidget *pDisplayFilterListBox;

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -6475,35 +6475,14 @@ void CCharacter::SaveCommands(CDbPackedVars& ExtraVars, const COMMANDPTR_VECTOR&
 UINT CCharacter::readBpUINT(const BYTE* buffer, UINT& index)
 //Deserialize 1..5 bytes --> UINT
 {
-	const BYTE *buffer2 = buffer + (index++);
-	ASSERT(*buffer2); // should not be zero (indicating a negative number)
-	UINT n = 0;
-	for (;;index++)
-	{
-		n = (n << 7) + *buffer2;
-		if (*buffer2++ & 0x80)
-			break;
-	}
-
-	return n - 0x80;
+	return CDbSavedGame::readBpUINT(buffer, index);
 }
 
 //*****************************************************************************
 void CCharacter::writeBpUINT(string& buffer, UINT n)
 //Serialize UINT --> 1..5 bytes
 {
-	int s = 7;
-	while (s < 32 && (n >> s))
-		s += 7;
-
-	while (s)
-	{
-		s -= 7;
-		BYTE b = BYTE((n >> s) & 0x7f);
-		if (!s)
-			b |= 0x80;
-		buffer.append(1, b);
-	}
+	CDbSavedGame::writeBpUINT(buffer, n);
 }
 
 //*****************************************************************************

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -308,6 +308,7 @@ private:
 	void setPredefinedVarInt(UINT varIndex, const UINT val, CCueEvents& CueEvents);
 	void setPredefinedVarString(UINT varIndex, const WSTRING val, CCueEvents& CueEvents);
 	void SetVariable(const CCharacterCommand& command, CCurrentGame *pGame, CCueEvents& CueEvents);
+	void SetArrayVariable(const CCharacterCommand& command, CCurrentGame *pGame, CCueEvents& CueEvents);
 	void SetLocalVar(const WSTRING& varName, const WSTRING& val);
 
 	void GenerateEntity(const UINT identity, const UINT wX, const UINT wY, const UINT wO, CCueEvents& CueEvents);
@@ -369,6 +370,8 @@ private:
 
 	typedef map<WSTRING, WSTRING> LocalScriptMap;
 	LocalScriptMap localScriptVars;
+	typedef map<UINT, map<int, int>> ScriptArrayMap;
+	ScriptArrayMap localScriptArrays;
 };
 
 class CFiredCharacterCommand : public CAttachableObject

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -87,6 +87,7 @@ enum CharacterDisplayMode {
 
 class CSwordsman;
 struct HoldCharacter;
+typedef map<UINT, map<int, int>> ScriptArrayMap;
 
 class CCharacter : public CPlayerDouble
 {
@@ -161,6 +162,8 @@ public:
 
 	int getLocalVarInt(const WSTRING& varName) const;
 	WSTRING getLocalVarString(const WSTRING& varName) const;
+
+	static int getArrayValue(const ScriptArrayMap& scriptArrays, const UINT& varId, const int arrayIndex);
 
 	int            CountEntityType(const CCharacterCommand& command, const CDbRoom& room, const CSwordsman& player) const;
 	int            CountTile(const CCharacterCommand& command) const;
@@ -370,7 +373,6 @@ private:
 
 	typedef map<WSTRING, WSTRING> LocalScriptMap;
 	LocalScriptMap localScriptVars;
-	typedef map<UINT, map<int, int>> ScriptArrayMap;
 	ScriptArrayMap localScriptArrays;
 };
 

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -92,6 +92,40 @@ bool CCharacterCommand::IsLogicalWaitCondition() const {
 	}
 }
 
+UINT CCharacterCommand::getVarID() const
+{
+	switch (command) {
+		case CC_VarSet:
+		case CC_WaitForVar:
+		case CC_ClearArrayVar:
+			return x;
+		case CC_VarSetAt:
+		case CC_ArrayVarSet:
+		case CC_ArrayVarSetAt:
+			return w;
+		default:
+			return 0;
+	}
+}
+
+void CCharacterCommand::setVarID(const UINT varID)
+{
+	switch (command) {
+		case CC_VarSet:
+		case CC_WaitForVar:
+		case CC_ClearArrayVar:
+			x = varID;
+		break;
+		case CC_VarSetAt:
+		case CC_ArrayVarSet:
+		case CC_ArrayVarSetAt:
+			w = varID;
+		break;
+		default:
+		break;
+	}
+}
+
 //*****************************************************************************
 SPEAKER getSpeakerType(const MONSTERTYPE eType)
 //Return: corresponding speaker enumeration for monster type, if supported.

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -381,6 +381,9 @@ public:
 		CC_CountEntityType,     //Count how many entities of a specific type in flag are in rect (x,y,w,h)
 		CC_CountItem,           //Count number of game element (flags) that exist in rect (x,y,w,h).
 		CC_SetPlayerBehavior,   //Set player behavior X to behavior state Y
+		CC_ArrayVarSet,         //Set array var W with operation H using expressions, starting at index f
+		CC_ArrayVarSetAt,       //Remotely invoke ArrayVarSet with NPC at (x,y)
+		CC_ClearArrayVar,       //Reset array var X
 
 		CC_Count
 	};
@@ -419,6 +422,13 @@ public:
 		return command == CC_LogicalWaitEnd ||
 			IsLogicalWaitCommand() || IsLogicalWaitCondition();
 	}
+
+	// If the command has a variable reference, return it. Otherwise returns zero.
+	UINT getVarID() const;
+
+	// Set the variable reference for a command.
+	// Has no effect on commands that don't reference a variable.
+	void setVarID(const UINT varID);
 };
 
 class CDbMessageText;

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -2024,6 +2024,7 @@ void CCurrentGame::DeserializeScriptArrays()
 		while (size) {
 			int key = (int)readBpUINT(buffer, index);
 			int value = (int)readBpUINT(buffer, index);
+			ASSERT(value != 0);
 			scriptArray[key] = value;
 			--size;
 		}

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -356,6 +356,7 @@ public:
 	bool     bContinueCutScene;
 	bool     bWaitedOnHotFloorLastTurn;
 	CDbPackedVars statsAtRoomStart; //stats when room was begun
+	map<UINT, map<int, int>> scriptArraysAtRoomStart; //
 	vector<CMoveCoordEx> ambientSounds;  //ambient sounds playing now
 	vector<SpeechLog> roomSpeech; //speech played up to this moment in the current room
 	bool     bRoomExitLocked; //safety to prevent player from exiting room when set
@@ -395,6 +396,7 @@ private:
 	void     DeleteLeakyCueEvents(CCueEvents &CueEvents);
 	void     DrankPotion(CCueEvents &CueEvents, const UINT wDoubleType,
 							const UINT wPotionX, const UINT wPotionY);
+	void     DeserializeScriptArrays();
 	void     FlagChallengesCompleted(CCueEvents &CueEvents);
 	bool     IsActivatingTemporalSplit() const;
 	bool     IsSwordsmanTired();

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -968,6 +968,12 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_UseSoldierHorn: strText = "Blow Soldier Horn"; break;
 	case MID_FaceMovementDirection: strText = "Face Movement Direction"; break;
 	case MID_BodyAttackImmune: strText = "Body Attack Immunity"; break;
+	case MID_SetPlayerBehavior: strText = "Set player behavior"; break;
+	case MID_ArrayVarSet: strText = "Set array var"; break;
+	case MID_ArrayVarSetAt: strText = "Set array var at"; break;
+	case MID_ClearArrayVar: strText = "Clear array var"; break;
+	case MID_ArrayVarNameExpression: strText = "Variable Name/Expression"; break;
+	case MID_ArrayIndexLabel: strText = "Index"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -974,6 +974,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_ClearArrayVar: strText = "Clear array var"; break;
 	case MID_ArrayVarNameExpression: strText = "Variable Name/Expression"; break;
 	case MID_ArrayIndexLabel: strText = "Index"; break;
+	case MID_CantChangeVarType: strText = "Var type can't be changed between array and non-array"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbHolds.cpp
+++ b/DRODLib/DbHolds.cpp
@@ -1902,7 +1902,8 @@ bool CDbHold::IsVarNameGoodSyntax(const WCHAR* pName)
 {
 	if (!pName)
 		return false;
-	if (!iswalpha(*pName) && *pName != W_t('.')) //first char must be a letter or period
+	//first char must be a letter, period, hash or at symbol
+	if (!(iswalpha(*pName) || *pName == W_t('.') || *pName == W_t('#') || *pName == W_t('@')))
 		return false;
 	++pName;
 	while (WCv(*pName))
@@ -2417,6 +2418,8 @@ bool CDbHold::LoadVars(
 		//In-play optimization: not kept current during hold var editing
 		if (ScriptVars::IsCharacterLocalVar(name))
 			this->localScriptVars[varID] = name;
+		if (ScriptVars::IsCharacterArrayVar(name))
+			this->arrayScriptVars[varID] = name;
 	}
 
 	return true;
@@ -3230,6 +3233,7 @@ bool CDbHold::SetMembers(
 	}
 	this->vars = Src.vars;
 	this->localScriptVars = Src.localScriptVars;
+	this->arrayScriptVars = Src.arrayScriptVars;
 	this->worldMaps = Src.worldMaps;
 	for (vector<HoldCharacter*>::const_iterator chIter = Src.characters.begin();
 			chIter != Src.characters.end(); ++chIter)
@@ -4124,6 +4128,7 @@ void CDbHold::Clear()
 	ClearEntrances();
 	this->vars.clear();
 	this->localScriptVars.clear();
+	this->arrayScriptVars.clear();
 
 	for (vector<HoldCharacter*>::iterator chIt=this->characters.begin();
 			chIt!=this->characters.end(); ++chIt)

--- a/DRODLib/DbHolds.cpp
+++ b/DRODLib/DbHolds.cpp
@@ -1497,19 +1497,24 @@ void CDbHolds::CheckForVarRefs(
 				AddScriptVarRef(varMap, c.label.c_str(), pRoom, pCharacter, characterName);
 		break;
 		case CCharacterCommand::CC_VarSet:
+		case CCharacterCommand::CC_VarSetAt:
 		case CCharacterCommand::CC_WaitForVar:
+		case CCharacterCommand::CC_ArrayVarSet:
+		case CCharacterCommand::CC_ArrayVarSetAt:
+		case CCharacterCommand::CC_ClearArrayVar:
 		{
 			if (bChallenges)
 				break;
 
+			UINT refVarID = c.getVarID();
 			const WCHAR *pVarName;
 			WSTRING wstr;
-			if (c.x >= (UINT)ScriptVars::FirstPredefinedVar)
+			if (refVarID >= (UINT)ScriptVars::FirstPredefinedVar)
 			{
-				wstr = ScriptVars::getVarNameW(ScriptVars::Predefined(c.x));
+				wstr = ScriptVars::getVarNameW(ScriptVars::Predefined(refVarID));
 				pVarName = wstr.c_str();
 			} else {
-				pVarName = pHold->GetVarName(c.x);
+				pVarName = pHold->GetVarName(refVarID);
 			}
 
 			AddScriptVarRef(varMap, pVarName, pRoom, pCharacter, characterName);
@@ -1538,7 +1543,7 @@ void CDbHolds::CheckForVarRefs(
 					break;
 					default: break;
 				}
-			} else {
+			} else if (c.command == CCharacterCommand::CC_WaitForVar) {
 				switch (c.y)
 				{
 					case ScriptVars::Equals:
@@ -1563,6 +1568,20 @@ void CDbHolds::CheckForVarRefs(
 			}
 		}
 		break;
+		case CCharacterCommand::CC_WaitForExpression:
+		{
+			//Search for a variable name in the expression.
+			if (!c.label.empty())
+			{
+				//parse expression
+				ScriptVars::Predefined varID = ScriptVars::parsePredefinedVar(c.label);
+				if (varID != ScriptVars::P_NoVar || pHold->GetVarID(c.label.c_str()))
+				{
+					//Mark reference to variable.
+					AddScriptVarRef(varMap, c.label.c_str(), pRoom, pCharacter, characterName);
+				}
+			}
+		}
 		default: break;
 	}
 }

--- a/DRODLib/DbHolds.h
+++ b/DRODLib/DbHolds.h
@@ -118,6 +118,8 @@ public:
 	HoldWorldMap::DisplayType GetWorldMapDisplayType(const UINT worldMapID) const;
 	WSTRING     GetWorldMapName(const UINT worldMapID) const;
 	void        InsertLevel(CDbLevel *pLevel);
+	bool        IsArrayVar(UINT varID) const { return this->arrayScriptVars.count(varID); }
+	bool        IsLocalVar(UINT varID) const { return this->localScriptVars.count(varID); }
 	static bool IsOfficialHold(HoldStatus holdstatus);
 	static bool IsVarNameGoodSyntax(const WCHAR* pName);
 	static bool IsVarCharValid(WCHAR wc);
@@ -205,6 +207,7 @@ private:
 	vector<UINT> deletedSpeechIDs; //speech IDs to be deleted on Update
 
 	map<UINT, WSTRING> localScriptVars; //in-game optimization: IDs and names of local script vars
+	map<UINT, WSTRING> arrayScriptVars;
 };
 
 //******************************************************************************************

--- a/DRODLib/DbSavedGames.cpp
+++ b/DRODLib/DbSavedGames.cpp
@@ -649,6 +649,41 @@ void CDbSavedGame::Clear(
 	this->wVersionNo = 0;
 }
 
+//*****************************************************************************
+UINT CDbSavedGame::readBpUINT(const BYTE* buffer, UINT& index)
+//Deserialize 1..5 bytes --> UINT
+{
+	const BYTE* buffer2 = buffer + (index++);
+	ASSERT(*buffer2); // should not be zero (indicating a negative number)
+	UINT n = 0;
+	for (;; index++)
+	{
+		n = (n << 7) + *buffer2;
+		if (*buffer2++ & 0x80)
+			break;
+	}
+
+	return n - 0x80;
+}
+
+//*****************************************************************************
+void CDbSavedGame::writeBpUINT(string& buffer, UINT n)
+//Serialize UINT --> 1..5 bytes
+{
+	int s = 7;
+	while (s < 32 && (n >> s))
+		s += 7;
+
+	while (s)
+	{
+		s -= 7;
+		BYTE b = BYTE((n >> s) & 0x7f);
+		if (!s)
+			b |= 0x80;
+		buffer.append(1, b);
+	}
+}
+
 //
 //CDbSavedGame private methods.
 //

--- a/DRODLib/DbSavedGames.h
+++ b/DRODLib/DbSavedGames.h
@@ -96,6 +96,10 @@ public:
 
 	bool    OnWorldMap() const { return worldMapID != 0; }
 
+	//Read/write UINT and UINT shaped types to/from buffer
+	static UINT  readBpUINT(const BYTE* buffer, UINT& index);
+	static void  writeBpUINT(string& buffer, UINT n);
+
 	UINT    dwSavedGameID;
 	UINT    dwRoomID;
 	UINT    worldMapID; //While set, level/room/entrance data structures in play are ignored.

--- a/DRODLib/DbSavedGames.h
+++ b/DRODLib/DbSavedGames.h
@@ -128,6 +128,8 @@ public:
 		//level tallies ("<id>[d|k|m|t]"), hold var values ("v*"),
 		//and world map music ("wm<id>[c]")
 	UINT    dwLevelDeaths, dwLevelKills, dwLevelMoves, dwLevelTime;  //used for active level
+	typedef map<UINT, map<int, int>> ScriptArrayMap;
+	ScriptArrayMap scriptArrays; //unpacked hold array var values
 	UINT     wVersionNo;
 
 	WorldMapsIcons worldMapIcons;
@@ -146,6 +148,7 @@ private:
 
 	void     DeserializeBehaviorOverrides();
 	void     SerializeBehaviorOverrides();
+	void     SerializeScriptArrays();
 
 	bool     SetMembers(const CDbSavedGame &Src);
 	bool     UpdateExisting();

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -185,7 +185,17 @@ bool ScriptVars::IsCharacterLocalVar(const WSTRING& wstr)
 
 bool ScriptVars::IsCharacterLocalVar(const WCHAR* wstr)
 {
-	return wstr && wstr[0] == '.';
+	return wstr && (wstr[0] == '.' || wstr[0] == '@');
+}
+
+bool ScriptVars::IsCharacterArrayVar(const WSTRING& wstr)
+{
+	return IsCharacterArrayVar(wstr.c_str());
+}
+
+bool ScriptVars::IsCharacterArrayVar(const WCHAR* wstr)
+{
+	return wstr && (wstr[0] == '#' || wstr[0] == '@');
 }
 
 //*****************************************************************************

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -124,6 +124,8 @@ namespace ScriptVars
 
 	bool IsCharacterLocalVar(const WSTRING& wstr);
 	bool IsCharacterLocalVar(const WCHAR* wstr);
+	bool IsCharacterArrayVar(const WSTRING& wstr);
+	bool IsCharacterArrayVar(const WCHAR* wstr);
 
 	//All predefined vars.
 	extern const UINT predefinedVarMIDs[PredefinedVarCount];

--- a/Data/Help/1/myscript.html
+++ b/Data/Help/1/myscript.html
@@ -49,6 +49,9 @@
 <tr><td><b>Set ceiling darkness</b></td> <td>Rect X</td>       <td>Rect Y</td>        <td>Rect Width</td>   <td>Rect Height</td>  <td>Darkness level</td></tr>
 <tr><td><b>Set ceiling light</b></td>    <td>Rect X</td>       <td>Rect Y</td>        <td>Rect Width</td>   <td>Rect Height</td>  <td>Light color</td></tr>
 <tr><td><b>Set wall light</b></td>       <td>X</td>            <td>Y</td>             <td>Intensity</td>    <td></td>           <td>Light color</td></tr>
+<tr><td><b>Set var at</b></td><td>Target X</td>     <td>Target Y</td>      <td></td>             <td></td>             <td></td></tr>
+<tr><td><b>Set array var</b></td><td></td>     <td></td>      <td></td>             <td></td>             <td>Starting Index</td></tr>
+<tr><td><b>Set array var at</b></td><td>Target X</td>     <td>Target Y</td>      <td></td>             <td></td>             <td>Starting Index</td></tr>
 <tr><td><b>Teleport Player</b></td>      <td>Target X</td>     <td>Target Y</td>      <td></td>             <td></td>             <td></td></tr>
 <tr><td><b>Teleport To</b></td>          <td>Target X</td>     <td>Target Y</td>      <td></td>             <td></td>             <td></td></tr>
 <tr><td><b>Wait</b></td>                 <td>Wait turns</td>   <td>Y</td>             <td> </td>            <td> </td>            <td> </td></tr>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -240,9 +240,10 @@ interacts with its environment.</p>
       of zero or more variables, named by you.  Use these variables to track
       persistent game state information across rooms during play. To add a variable
       to a hold, type its name into the uppermost text box and click "Add".<br />
-	 <u>Syntax</u>: Variable names must begin with a letter or period and not contain any punctuation
+	 <u>Syntax</u>: Variable names must begin with a letter, period, hash (#) or at symbol and not contain any punctuation
 	  except underscore ('_').  <a href="localvars">Starting</a> a variable name with a period ('.') configures it as a local variable instead of a global. This means each NPC will have its own version of a variable with this name and there is no value sharing among them.<br />
-      <u>Modifying variables</u>: <a name="varops">Select</a> a hold variable from the list, choose an
+     <u>Arrays</u>: Starting a variable name with a hash (#) or at symbol (@) configures it as an array variable. See <a href="scriptarray.html">Script arrays</a> for more information.<br/>
+     <u>Modifying variables</u>: <a name="varops">Select</a> a hold variable from the list, choose an
       operation and a value. Variables may either store an integer or text. If
       the operation you specify is "Assign text" or "Add text", the variable you
       select will be set to store the text you provide. You may also reference
@@ -881,6 +882,7 @@ DROD Script supports several movement types, including ones not used by normal m
 
 <hr />
 <a href="character.html">Character Scripting</a><br />
+<a href="scriptarray.html">Script arrays</a><br/>
 <a href="myscript.html">_MyScript Variable Injection</a><br />
 <a href="editroom.html">Room Editor</a><br />
 <a href="editselect.html">Level Editor</a><br />

--- a/Data/Help/1/scriptarray.html
+++ b/Data/Help/1/scriptarray.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+    <title>Help for Deadly Rooms of Death</title>
+</head>
+<body bgcolor="#FFFFFF">
+<img src="images/drodlogo.jpg" />
+<hr />
+<h3><u>Using Arrays in Scripts</u></h3>
+    <p>Script variables can be configured as arrays, by starting the variable name with a hash (#) or an at symbol (@). 
+    Variables starting with a hash a global arrays, while variables starting with an at symbol are local to individual characters. 
+    Once a variable is created, you cannot change if it is an array variable (but its locality can be changed). Array variables can only store integer values, not text.</p>
+    <p>An array variable is effectively a list of values, each associated with a specific index. Therefore, an arbitary number of values can be stored under a single variable name. 
+    In character scripts, all array indexes are integers, however unlike many programming languages, arrays allow negative indexes to be used.</p>
+
+    <p><u>Setting array values</u></p>
+    <p>Values can be set in an array variable using the <b>Set array var</b> command. The value at a specified index can be set either to an integer value, or an expression that will resolve to such a value.</p>
+    <p>Additionally, multiple array values can be set by providing multiple values or expressions, separated by a semi-colon (;). The first value will be assigned at the specified index, 
+    and seach subsequent value will be assigned to the next index. For example, if the specified index is 3, the first value is assigned to the third array position, the second value to the forth array position, and so on.</p>
+    <p>The <b>Set array var at</b> command works in the same way, but allows for remote variable assignment, as with <a href="script.html#setvarat">Set var at</a>.</p>
+
+    <p><u>Accessing array values</u></p>
+    <p>Like any other script variable, an array value can be used anywhere an integer value is expected. 
+    The one different is that the variable name must be followed by a pair of square brackets ([]) containing an index value. This can be a numeric value, or an another expression that resolves to such a value. 
+    If an index that has not been set is accessed, a value of zero is returned.</p>
+
+    <p><u>Examples of valid array expressions</u></p>
+    <ul>
+        <li>#Array[2]</li>
+        <li>#Array[-1]</li>
+        <li>#Array[_X]</li>
+        <li>#Array[_MyY * 2]</li>
+        <li>@Array[1]</li>
+        <li>@Array[_min(5, _MyX) + 1]</li>
+    </ul>
+
+    <p><u>Clearing arrays</u></p>
+    <p>The <b>Clear array var</b> command can be used to reset all values in an array variable to zero.</p>
+<hr />
+<a href="script.html">Command list</a><br />
+<a href="character.html">Character Scripting</a><br />
+</body>
+</html>

--- a/Data/Help/1/scriptarray.html
+++ b/Data/Help/1/scriptarray.html
@@ -6,22 +6,22 @@
 <img src="images/drodlogo.jpg" />
 <hr />
 <h3><u>Using Arrays in Scripts</u></h3>
-    <p>Script variables can be configured as arrays, by starting the variable name with a hash (#) or an at symbol (@). 
-    Variables starting with a hash a global arrays, while variables starting with an at symbol are local to individual characters. 
-    Once a variable is created, you cannot change if it is an array variable (but its locality can be changed). Array variables can only store integer values, not text.</p>
-    <p>An array variable is effectively a list of values, each associated with a specific index. Therefore, an arbitary number of values can be stored under a single variable name. 
+    <p> Script variables can be configured as arrays by starting the variable name with a hash (#) or an at symbol (@).
+    Variables starting with a hash are global arrays, while variables starting with an at symbol are local to individual characters.
+    Once a variable is created, you cannot change whether it is an array variable (but its locality can be changed). Array variables can only store integer values, not text.</p>
+    <p> An array variable is effectively a set of index-value pairs, where each index has a value (defaulting to 0). Therefore, an arbitary number of values can be stored under a single variable name.
     In character scripts, all array indexes are integers, however unlike many programming languages, arrays allow negative indexes to be used.</p>
 
     <p><u>Setting array values</u></p>
     <p>Values can be set in an array variable using the <b>Set array var</b> command. The value at a specified index can be set either to an integer value, or an expression that will resolve to such a value.</p>
     <p>Additionally, multiple array values can be set by providing multiple values or expressions, separated by a semi-colon (;). The first value will be assigned at the specified index, 
-    and seach subsequent value will be assigned to the next index. For example, if the specified index is 3, the first value is assigned to the third array position, the second value to the forth array position, and so on.</p>
+    and each subsequent value will be assigned to the next index. For example, if the specified index is 3, the first value is assigned to the at position 3, the second value to position 4, and so on.</p>
     <p>The <b>Set array var at</b> command works in the same way, but allows for remote variable assignment, as with <a href="script.html#setvarat">Set var at</a>.</p>
 
-    <p><u>Accessing array values</u></p>
+    <p><u>Querying array values</u></p>
     <p>Like any other script variable, an array value can be used anywhere an integer value is expected. 
-    The one different is that the variable name must be followed by a pair of square brackets ([]) containing an index value. This can be a numeric value, or an another expression that resolves to such a value. 
-    If an index that has not been set is accessed, a value of zero is returned.</p>
+    The one difference is that the variable name must be followed by a pair of square brackets ([]) containing an index value. This can be a numeric value or an expression that resolves to such a value. 
+    If an index that has not been set is accessed, a default value of 0 is returned.</p>
 
     <p><u>Examples of valid array expressions</u></p>
     <ul>

--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -205,8 +205,8 @@ UINT CListBoxWidget::AddItem_Insert(
 	}
 
 	//Recalc areas of widget since they may have changed.
-	CalcAreas();
 	this->UpdateFilter(this->wstrActiveFilter);
+	CalcAreas();
 	return wIndex;
 }
 

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1867,6 +1867,7 @@ enum MID_CONSTANT {
   MID_ClearArrayVar = 2091,
   MID_ArrayVarNameExpression = 2092,
   MID_ArrayIndexLabel = 2093,
+  MID_CantChangeVarType = 2094,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1861,6 +1861,12 @@ enum MID_CONSTANT {
   MID_CustomSpeechColor = 2071,
   MID_CountEntityType = 2072,
   MID_CountItem = 2073,
+  MID_SetPlayerBehavior = 2088,
+  MID_ArrayVarSet = 2089,
+  MID_ArrayVarSetAt = 2090,
+  MID_ClearArrayVar = 2091,
+  MID_ArrayVarNameExpression = 2092,
+  MID_ArrayIndexLabel = 2093,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3357,3 +3357,27 @@ Count entity type
 [MID_CountItem]
 [eng]
 Count item
+
+[MID_SetPlayerBehavior]
+[eng]
+Set player behavior
+
+[MID_ArrayVarSet]
+[eng]
+Set array var
+
+[MID_ArrayVarSetAt]
+[eng]
+Set array var at
+
+[MID_ClearArrayVar]
+[eng]
+Clear array var
+
+[MID_ArrayVarNameExpression]
+[eng]
+Variable Name/Expression
+
+[MID_ArrayIndexLabel]
+[eng]
+Index

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3381,3 +3381,7 @@ Variable Name/Expression
 [MID_ArrayIndexLabel]
 [eng]
 Index
+
+[MID_CantChangeVarType]
+[eng]
+Var type can't be changed between array and non-array


### PR DESCRIPTION
Adds new functionality to scripts by allowing arrays. A script variable starting with a `#` becomes a global array, and a variable starting with a `@` becomes a local variable. To avoid weird issues with serialization, once a variable is created, it can't be renamed in a way that changes its "arrayness".

Internally, arrays are technically maps, as they can be non-continuous. Negative indexes are also supported, although this is not unheard of in some languages.

Global arrays are serialized back to the packed stats object when saving. The number of active items in the array is saved as the first value, followed by a sequence of key/value pairs. The `readBpUINT` and `writeBpUINT` functions have been moved to `CDbSavedGame` to allow them to reused for this. To save space, values of zero are not packed when serializing (as getting an int value from a map will return zero is no value is assigned to that key).

New script commands have been added to write to arrays. Reading from arrays is handled by expression parsing functions.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=46113