### PR TITLE
RPG: Fix bad save of empty default script

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5186,14 +5186,16 @@ void CCharacter::SaveCommands(CDbPackedVars& ExtraVars, const COMMAND_VECTOR& co
 	SaveSpeech(commands);
 
 	const UINT wNumCommands = commands.size();
-	if (wNumCommands)
-		ExtraVars.SetVar(numCommandsStr, wNumCommands);
+	ExtraVars.SetVar(numCommandsStr, wNumCommands);
 
 	//Serialize commands into a single buffer.
 	string buffer;
 	SerializeCommands(buffer, commands);
-	if (!buffer.empty())
+	if (!buffer.empty()) {
 		ExtraVars.SetVar(commandStr, (void*)(buffer.c_str()), buffer.size(), UVT_byte_buffer);
+	} else {
+		ExtraVars.Unset(commandStr);
+	}
 }
 
 //*****************************************************************************
@@ -5203,14 +5205,16 @@ void CCharacter::SaveCommands(CDbPackedVars& ExtraVars, const COMMANDPTR_VECTOR&
 	SaveSpeech(commands);
 
 	const UINT wNumCommands = commands.size();
-	if (wNumCommands)
-		ExtraVars.SetVar(numCommandsStr, wNumCommands);
+	ExtraVars.SetVar(numCommandsStr, wNumCommands);
 
 	//Serialize commands into a single buffer.
 	string buffer;
 	SerializeCommands(buffer, commands);
-	if (!buffer.empty())
+	if (!buffer.empty()) {
 		ExtraVars.SetVar(commandStr, (void*)(buffer.c_str()), buffer.size(), UVT_byte_buffer);
+	} else {
+		ExtraVars.Unset(commandStr);
+	}
 }
 
 //********************* Current serialization ********************************/

--- a/drodrpg/DRODLib/DbPackedVars.cpp
+++ b/drodrpg/DRODLib/DbPackedVars.cpp
@@ -103,6 +103,14 @@ void CDbPackedVars::SetMembers(const CDbPackedVars &Src)
 }
 
 //*******************************************************************************************
+void CDbPackedVars::Unset(const char* pszVarName)
+{
+	this->vars.erase(pszVarName);
+
+	this->varIter = this->vars.end(); //invalidate
+}
+
+//*******************************************************************************************
 void * CDbPackedVars::GetVar(
 //Gets value of a variable.
 //

--- a/drodrpg/DRODLib/DbPackedVars.h
+++ b/drodrpg/DRODLib/DbPackedVars.h
@@ -137,6 +137,8 @@ public:
 	UNPACKEDVARTYPE GetVarType(const char *pszVarName) const;
 	UINT       GetVarValueSize(const char *pszVarName) const;
 
+	void Unset(const char* pszVarName);
+
 	void *         SetVar(const char *pszVarName, const void *pValue, UINT dwValueSize, const UNPACKEDVARTYPE eType);
 	char *         SetVar(const char *pszVarName, const char *pszValue)
 	{


### PR DESCRIPTION
When an empty default script is serialized, both values saved to `ExtraVars` are skipped if the script is empty. This causes a problem when all commands are removed from a default script, as the change will not be saved.

To avoid this problem, we can always save the script size, and unset the packed command buffer if no commands are in the script when saving.