### PR TITLE
RPG: Add more tile + crate interactions

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -3988,6 +3988,7 @@ void CCharacterDialogWidget::PopulateEventListBox()
 	this->pEventListBox->AddItem(CID_EvilEyeWoke, g_pTheDB->GetMessageText(MID_EvilEyeWoke));
 	this->pEventListBox->AddItem(CID_Firetrap, g_pTheDB->GetMessageText(MID_FiretrapBurning));
 	this->pEventListBox->AddItem(CID_FiretrapActivated, g_pTheDB->GetMessageText(MID_FiretrapActivated));
+	this->pEventListBox->AddItem(CID_FiretrapHit, g_pTheDB->GetMessageText(MID_FiretrapHit));
 	this->pEventListBox->AddItem(CID_FuseBurning, g_pTheDB->GetMessageText(MID_FuseBurning));
 	this->pEventListBox->AddItem(CID_GelBabyFormed, g_pTheDB->GetMessageText(MID_GelBabyFormed));
 //	this->pEventListBox->AddItem(CID_GelGrew, g_pTheDB->GetMessageText(MID_GelGrew));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -3981,6 +3981,7 @@ void CCharacterDialogWidget::PopulateEventListBox()
 	this->pEventListBox->AddItem(CID_BombExploded, g_pTheDB->GetMessageText(MID_BombExploded));
 	this->pEventListBox->AddItem(CID_BriarExpanded, g_pTheDB->GetMessageText(MID_BriarExpanded));
 	this->pEventListBox->AddItem(CID_BumpedLockedDoor, g_pTheDB->GetMessageText(MID_BumpedLockedDoor));
+	this->pEventListBox->AddItem(CID_CrateDestroyed, g_pTheDB->GetMessageText(MID_CrateDestroyed));
 	this->pEventListBox->AddItem(CID_CrumblyWallDestroyed, g_pTheDB->GetMessageText(MID_CrumblyWallDestroyed));
 	this->pEventListBox->AddItem(CID_CutBriar, g_pTheDB->GetMessageText(MID_CutBriar));
 	this->pEventListBox->AddItem(CID_DrankPotion, g_pTheDB->GetMessageText(MID_DrankPotion));

--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -297,6 +297,14 @@ void CDrodScreen::AddVisualCues(CCueEvents& CueEvents, CRoomWidget* pRoomWidget,
 				new CDebrisEffect(pRoomWidget, *pCoord, 10,
 						GetEffectDuration(pGame, 7), GetParticleSpeed(pGame, 4)));
 	}
+	for (pObj = CueEvents.GetFirstPrivateData(CID_CrateDestroyed);
+		pObj != NULL; pObj = CueEvents.GetNextPrivateData())
+	{
+		const CMoveCoord* pCoord = DYN_CAST(const CMoveCoord*, const CAttachableObject*, pObj);
+		pRoomWidget->AddTLayerEffect(
+			new CDebrisEffect(pRoomWidget, *pCoord, 12,
+				GetEffectDuration(pGame, 7), GetParticleSpeed(pGame, 4)));
+	}
 	for (pObj = CueEvents.GetFirstPrivateData(CID_BombExploded);
 			pObj != NULL; pObj = CueEvents.GetNextPrivateData())
 	{

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -6229,6 +6229,18 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 				new CFiretrapEffect(pRoomWidget, *pCoord, duration));
 		}
 	}
+	for (pObj = CueEvents.GetFirstPrivateData(CID_FiretrapHit);
+		pObj != NULL; pObj = CueEvents.GetNextPrivateData())
+	{
+		const CCoord* pCoord = DYN_CAST(const CCoord*, const CAttachableObject*, pObj);
+
+		this->fPos[0] = static_cast<float>(pCoord->wX);
+		this->fPos[1] = static_cast<float>(pCoord->wY);
+		PlaySoundEffect(SEID_HIT, this->fPos);
+
+		this->pRoomWidget->AddMLayerEffect(
+			new CFadeTileEffect(this->pRoomWidget, *pCoord, TI_STRONGHIT, 300));
+	}
 
 	//Remove old sparks before drawing the current ones.
 	this->pRoomWidget->RemoveTLayerEffectsOfType(ESPARK);

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -6078,6 +6078,19 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 				new CDebrisEffect(this->pRoomWidget, *pCoord, 10,
 						GetEffectDuration(7), GetParticleSpeed(4))); //!!ShatteringGlass effect
 	}
+	for (pObj = CueEvents.GetFirstPrivateData(CID_CrateDestroyed);
+		pObj != NULL; pObj = CueEvents.GetNextPrivateData())
+	{
+		const CMoveCoord* pCoord = DYN_CAST(const CMoveCoord*, const CAttachableObject*, pObj);
+
+		this->fPos[0] = static_cast<float>(pCoord->wX);
+		this->fPos[1] = static_cast<float>(pCoord->wY);
+		g_pTheSound->PlaySoundEffect(SEID_BREAKWALL, this->fPos);
+
+		this->pRoomWidget->AddTLayerEffect(
+			new CDebrisEffect(this->pRoomWidget, *pCoord, 12,
+				GetEffectDuration(7), GetParticleSpeed(4)));
+	}
 	if (CueEvents.HasOccurred(CID_BombExploded))
 	{
 		UINT wRandMod = CueEvents.GetOccurrenceCount(CID_BombExploded);

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4212,7 +4212,8 @@ bool CCharacter::CheckForDamage(CCueEvents& CueEvents)
 	if (!IsFlying()) //airborne monsters are not damaged by oremites
 	{
 		//Damage to metal monster on oremites is the same as on hot tiles.
-		if (IsMetal() && this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY) == T_GOO)
+		if (IsMetal() && this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY) == T_GOO &&
+			this->pCurrentGame->pRoom->GetTSquare(this->wX, this->wY) != T_CRATE)
 		{
 			if (IsDamageableAt(this->wX, this->wY))
 			{

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -695,6 +695,11 @@ enum CUEEVENT_ID
 	//Private data: CMoveCoord *pSquare
 	CID_CrateDestroyed,
 
+	//Fire trap hits a player or monster
+	//
+	//Private data: CCoord *pSquare
+	CID_FiretrapHit,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -690,6 +690,11 @@ enum CUEEVENT_ID
 	//Private data: CCoord *pSquare (one or more)
 	CID_FiretrapActivated,
 
+	//A crate was destroyed
+	//
+	//Private data: CMoveCoord *pSquare
+	CID_CrateDestroyed,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3451,7 +3451,9 @@ bool CCurrentGame::DoesTileDisableMetal(const UINT wX, const UINT wY) const
 {
 	//Oremites on tile disable metal
 	const UINT wOTile = this->pRoom->GetOSquare(wX,wY);
-	return wOTile == T_GOO;
+	//But standing on a crate negates the effect
+	const UINT wTTile = this->pRoom->GetTSquare(wX, wY);
+	return wOTile == T_GOO && wTTile != T_CRATE;
 }
 
 //*****************************************************************************
@@ -5915,10 +5917,11 @@ MakeMove:
 	pRoom->ExplodeStabbedPowderKegs(CueEvents);
 
 	const UINT wNewOSquare = pRoom->GetOSquare(p.wX, p.wY);
+	const UINT wNewTSquare = pRoom->GetTSquare(p.wX, p.wY);
 
 	//These exclude the wait move executed on entering a room.
 	const bool bWasOnSameScroll = (wTTileNo==T_SCROLL) && !bMoved && this->wTurnNo;
-	const bool bStayedOnHotFloor = (wNewOSquare == T_HOT) && this->wTurnNo
+	const bool bStayedOnHotFloor = (wNewOSquare == T_HOT && wNewTSquare != T_CRATE) && this->wTurnNo
 			//flying player types don't get burned by hot tiles
 			&& !p.IsFlying();
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -819,6 +819,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_FiretrapActivated: strText = "Fire trap activated"; break;
 		case MID_PowderKeg: strText = "Powder Keg"; break;
 		case MID_ExplosiveSafe: strText = "Explosive safe"; break;
+		case MID_CrateDestroyed: strText = "Crate destroyed"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -820,6 +820,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_PowderKeg: strText = "Powder Keg"; break;
 		case MID_ExplosiveSafe: strText = "Explosive safe"; break;
 		case MID_CrateDestroyed: strText = "Crate destroyed"; break;
+		case MID_FiretrapHit: strText = "Firetrap hit"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -6008,7 +6008,7 @@ void CDbRoom::ActivateFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEven
 		break;
 		case T_POWDER_KEG:
 			ExplodePowderKeg(CueEvents, wX, wY);
-			break;
+		break;
 		case T_FUSE:
 			//Light the fuse.
 			if (!this->NewFuses.has(wX, wY) && !this->LitFuses.has(wX, wY))
@@ -6019,6 +6019,10 @@ void CDbRoom::ActivateFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEven
 		break;
 		case T_TAR: case T_MUD: case T_GEL:
 			StabTar(wX, wY, CueEvents, true);
+		break;
+		case T_CRATE:
+			Plot(wX, wY, T_EMPTY);
+			CueEvents.Add(CID_CrateDestroyed, new CMoveCoord(wX, wY, NO_ORIENTATION), true);
 		break;
 	}
 

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -6041,6 +6041,7 @@ void CDbRoom::ActivateFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEven
 		//Burn player
 		UINT delta = player.CalcDamage(damageVal);
 		player.DecHealth(CueEvents, delta, CID_ExplosionKilledPlayer);
+		CueEvents.Add(CID_FiretrapHit, new CCoord(wX, wY));
 	}
 
 	CMonster* pMonster = this->GetMonsterAtSquare(wX, wY);
@@ -6057,6 +6058,7 @@ void CDbRoom::ActivateFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEven
 		}
 
 		DamageMonster(pMonster, damageVal, CueEvents);
+		CueEvents.Add(CID_FiretrapHit, new CCoord(wX, wY));
 	}
 }
 

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -317,7 +317,9 @@ bool CMonster::CheckForDamage(CCueEvents& CueEvents)
 		return false;
 
 	//Touching a hot tile causes fractional damage.
-	if (this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY) == T_HOT)
+	//But standing on crate negates the effect.
+	if (this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY) == T_HOT &&
+		this->pCurrentGame->pRoom->GetTSquare(this->wX, this->wY) != T_CRATE)
 	{
 		if (DamagedByHotTiles() && IsDamageableAt(this->wX, this->wY))
 		{

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1553,6 +1553,7 @@ enum MID_CONSTANT {
   MID_MistDestroyed = 1886,
   MID_FiretrapBurning = 1891,
   MID_FiretrapActivated = 1892,
+  MID_CrateDestroyed = 1895,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1554,6 +1554,7 @@ enum MID_CONSTANT {
   MID_FiretrapBurning = 1891,
   MID_FiretrapActivated = 1892,
   MID_CrateDestroyed = 1895,
+  MID_FiretrapHit = 1896,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1399,3 +1399,7 @@ Fire trap burning
 [MID_FiretrapActivated]
 [eng]
 Fire trap activated
+
+[MID_CrateDestroyed]
+[eng]
+Crate destroyed

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1403,3 +1403,7 @@ Fire trap activated
 [MID_CrateDestroyed]
 [eng]
 Crate destroyed
+
+[MID_FiretrapHit]
+[eng]
+Fire trap hit


### PR DESCRIPTION
Makes crates do a few extra things:

- Standing on a crate will prevent the effect of oremites and hot tiles
- Crates will be destroyed by fire traps