### PR TITLE
Update demo description strings

### DIFF
--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -753,6 +753,11 @@ const WCHAR* CDbBase::GetMessageText(
 	string strText;
 	switch (eMessageID)
 	{
+	case MID_DemoDescKilled1: strText = "The player gets themselves killed pretty quickly."; break;
+	case MID_DemoDescKilled4: strText = "The player goes screaming to their death and takes some monsters with them."; break;
+	case MID_DemoDescLeaves1: strText = "Then the player leaves."; break;
+	case MID_DemoDescLoiters1: strText = "The player didn't do much."; break;
+	case MID_DemoDescExits1: strText = "The player exits the level."; break;
 	case MID_SetMusic: strText = "Set music"; break;
 	case MID_IfElseIf: strText = "Else If"; break;
 	case MID_VarInequal: strText = "!="; break;

--- a/Texts/DemosMessages.uni
+++ b/Texts/DemosMessages.uni
@@ -88,7 +88,7 @@ Cette démo est corrompue ou provient d'une autre version de DROD comportant des
 
 [MID_DemoDescKilled1]
 [eng]
-The player gets himself killed pretty quickly.
+The player gets themselves killed pretty quickly.
 [fra]
 Le joueur se fait rapidement tuer.
 [rus]
@@ -112,7 +112,7 @@ Le joueur meurt horriblement, mais pas sans avoir tué un monstre auparavant.
 
 [MID_DemoDescKilled4]
 [eng]
-The player goes screaming to his death and takes some monsters with him.
+The player goes screaming to their death and takes some monsters with them.
 [fra]
 Le joueur meurt en hurlant mais emporte quelques monstres avec lui.
 [rus]


### PR DESCRIPTION
It's not certain that the player who records a demo is "he". In this situation, singular "they" can be used instead. Messages updated in both text files and `DbBase`.