### PR TITLE
Check script completion after question answer processing

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -2400,8 +2400,12 @@ void CCurrentGame::ProcessCommand(
 			CMonster *pMonster = this->pRoom->pFirstMonster;
 			while (pMonster)
 			{
-				if (pMonster->wType == M_CHARACTER)
+				if (pMonster->wType == M_CHARACTER) {
 					pMonster->Process(CMD_WAIT, CueEvents);
+					CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
+					if (pCharacter && pCharacter->bScriptDone)
+						ScriptCompleted(pCharacter);
+				}
 				pMonster = pMonster->pNext;
 			}
 			this->bExecuteNoMoveCommands = false;


### PR DESCRIPTION
If a non-visible character runs an `End` command after the player answers a question, the script does not correctly end. This is because post-question processing does not check if the script has been ended. Previously this would get picked up by the next monster processing pass, but changes to how characters are managed means this doesn't happen.

To fix this, a script end check has been added to answer processing.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46140