### PR TITLE
RPG: Add script vars to access total player ATK and DEF

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4490,6 +4490,7 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_ITEM_DEF_MULT, g_pTheDB->GetMessageText(MID_VarItemDEFMult));
 	this->pVarListBox->AddItem(ScriptVars::P_ITEM_GR_MULT, g_pTheDB->GetMessageText(MID_VarItemGRMult));
 	this->pVarListBox->AddItem(ScriptVars::P_ITEM_SHOVEL_MULT, g_pTheDB->GetMessageText(MID_VarItemShovelMult));
+	this->pVarListBox->AddItem(ScriptVars::P_LEVEL_MULT, g_pTheDB->GetMessageText(MID_VarLevelMultiplier));
 
 	this->pVarListBox->AddItem(ScriptVars::P_SCRIPT_MONSTER_HP_MULT, g_pTheDB->GetMessageText(MID_VarMyMonsterHPMult));
 	this->pVarListBox->AddItem(ScriptVars::P_SCRIPT_MONSTER_ATK_MULT, g_pTheDB->GetMessageText(MID_VarMyMonsterATKMult));
@@ -4525,6 +4526,8 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_X, g_pTheDB->GetMessageText(MID_VarX));
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_Y, g_pTheDB->GetMessageText(MID_VarY));
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_O, g_pTheDB->GetMessageText(MID_VarO));
+	this->pVarListBox->AddItem(ScriptVars::P_ROOM_X, g_pTheDB->GetMessageText(MID_VarRoomX));
+	this->pVarListBox->AddItem(ScriptVars::P_ROOM_Y, g_pTheDB->GetMessageText(MID_VarRoomY));
 
 	this->pVarListBox->AddItem(ScriptVars::P_TOTALMOVES, g_pTheDB->GetMessageText(MID_TotalMoves));
 //	this->pVarListBox->AddItem(ScriptVars::P_TOTALTIME, g_pTheDB->GetMessageText(MID_TotalTime)); //hidden from script use -- not correctly supported for deterministic move replay

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4545,6 +4545,9 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_ACCESSORY_DEF, g_pTheDB->GetMessageText(MID_VarAccessoryDEF));
 	this->pVarListBox->AddItem(ScriptVars::P_ACCESSORY_GR, g_pTheDB->GetMessageText(MID_VarAccessoryGR));
 
+	this->pVarListBox->AddItem(ScriptVars::P_TOTAL_ATK, g_pTheDB->GetMessageText(MID_VarTotalAtk));
+	this->pVarListBox->AddItem(ScriptVars::P_TOTAL_DEF, g_pTheDB->GetMessageText(MID_VarTotalDef));
+
 	this->pVarListBox->AddItem(ScriptVars::P_MUD_SPAWN, g_pTheDB->GetMessageText(MID_VarMudSpawn));
 	this->pVarListBox->AddItem(ScriptVars::P_TAR_SPAWN, g_pTheDB->GetMessageText(MID_VarTarSpawn));
 	this->pVarListBox->AddItem(ScriptVars::P_GEL_SPAWN, g_pTheDB->GetMessageText(MID_VarGelSpawn));

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -855,6 +855,8 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 					case (UINT)ScriptVars::P_LEVEL_MULT:
 					case (UINT)ScriptVars::P_ROOM_X:
 					case (UINT)ScriptVars::P_ROOM_Y:
+					case (UINT)ScriptVars::P_TOTAL_ATK:
+					case (UINT)ScriptVars::P_TOTAL_DEF:
 						//cannot alter
 					break;
 

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1405,6 +1405,12 @@ UINT CCurrentGame::getVar(const UINT varIndex) const
 			return varIndex == (UINT)ScriptVars::P_ROOM_X ? dX : dY;
 		}
 
+		//Derived stat values
+		case (UINT)ScriptVars::P_TOTAL_ATK:
+			return this->getPlayerATK();
+		case (UINT)ScriptVars::P_TOTAL_DEF:
+			return this->getPlayerDEF();
+
 		default:
 			return player.st.getVar(ScriptVars::Predefined(varIndex));
 	}
@@ -2407,6 +2413,8 @@ void CCurrentGame::ProcessCommandSetVar(
 		case (UINT)ScriptVars::P_LEVEL_MULT:
 		case (UINT)ScriptVars::P_ROOM_X:
 		case (UINT)ScriptVars::P_ROOM_Y:
+		case (UINT)ScriptVars::P_TOTAL_ATK:
+		case (UINT)ScriptVars::P_TOTAL_DEF:
 			//cannot alter
 			return;
 	}

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -821,6 +821,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ExplosiveSafe: strText = "Explosive safe"; break;
 		case MID_CrateDestroyed: strText = "Crate destroyed"; break;
 		case MID_FiretrapHit: strText = "Firetrap hit"; break;
+		case MID_VarTotalAtk: strText = "_TotalATK"; break;
+		case MID_VarTotalDef: strText = "_TotalDEF"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -46,7 +46,8 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][16] =
 	"", "", "",
 	"",
 	"_Shovels", "_ScoreShovels", "_ItemShovelMult", "",
-	"_Beam", "_Firetrap"
+	"_Beam", "_Firetrap",
+	"", ""
 };
 
 //Message texts corresponding to the above short var texts.
@@ -80,6 +81,7 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarMyDescription,
 	MID_VarShovels, MID_VarScoreShovels, MID_VarItemShovelMult, MID_VarMyItemShovelMult,
 	MID_VarBeam, MID_VarFiretrap,
+	MID_VarTotalAtk, MID_VarTotalDef,
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -154,7 +154,9 @@ namespace ScriptVars
 		P_SCRIPT_ITEM_SHOVEL_MULT = -97,
 		P_BEAM = -98,
 		P_FIRETRAP = -99,
-		FirstPredefinedVar = P_FIRETRAP, //set this to the last var in the enumeration
+		P_TOTAL_ATK = -100,
+		P_TOTAL_DEF = -101,
+		FirstPredefinedVar = P_TOTAL_DEF, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -890,6 +890,9 @@ The variable names are case-insensitive.
   When predefined equipment is carried, its values may be queried but not
   altered.
 </p>
+<p><a name="totalstats"><b>*_TotalATK, _TotalDEF</b></a> - These vars are equal to the player's total ATK and DEF stats 
+    after applying the effects of equipment and room elements. These are read-only values.
+</p>
 <p><a name="scorevars"><b>*_ScoreHP, _ScoreATK, _ScoreDEF, _ScoreYellowKeys,
   _ScoreGreenKeys, _ScoreBlueKeys, _ScoreSkeletonKeys, _ScoreGR, _ScoreREP</b></a> - 
   These vars determine how much each of the player's resources is worth for scoring

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1651,6 +1651,8 @@ enum MID_CONSTANT {
   MID_VarMyItemShovelMult = 1865,
   MID_VarBeam = 1866,
   MID_VarFiretrap = 1890,
+  MID_VarTotalAtk = 1897,
+  MID_VarTotalDef = 1898,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -373,3 +373,11 @@ _Beam
 [MID_VarFiretrap]
 [eng]
 _Firetrap
+
+[MID_VarTotalAtk]
+[eng]
+_TotalATK
+
+[MID_VarTotalDef]
+[eng]
+_TotalDEF


### PR DESCRIPTION
Adds script vars `_TotalATK` and `_TotalDEF`, which allow access to the values calculated in `CCurrentGame::getPlayerATK` and `CCurrentGame::getPlayerDEF`.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46091