### PR TITLE
Add script vars to access player weapon and inputs

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5534,6 +5534,9 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_RETURN_X, g_pTheDB->GetMessageText(MID_VarReturnX));
 	this->pVarListBox->AddItem(ScriptVars::P_RETURN_Y, g_pTheDB->GetMessageText(MID_VarReturnY));
 
+	this->pVarListBox->AddItem(ScriptVars::P_INPUT, g_pTheDB->GetMessageText(MID_VarInput));
+	this->pVarListBox->AddItem(ScriptVars::P_INPUT_DIRECTION, g_pTheDB->GetMessageText(MID_VarInputDirection));
+
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_WEATHER, g_pTheDB->GetMessageText(MID_RoomWeather));
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_DARKNESS, g_pTheDB->GetMessageText(MID_RoomDarkness));
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_FOG, g_pTheDB->GetMessageText(MID_RoomFog));

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5512,6 +5512,9 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_Y, g_pTheDB->GetMessageText(MID_VarY));
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_O, g_pTheDB->GetMessageText(MID_VarO));
 
+	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_WEAPON, g_pTheDB->GetMessageText(MID_VarPlayerWeapon));
+	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_LOCAL_WEAPON, g_pTheDB->GetMessageText(MID_VarPlayerLocalWeapon));
+
 	this->pVarListBox->AddItem(ScriptVars::P_ROOMIMAGE_X, g_pTheDB->GetMessageText(MID_VarRoomImageX));
 	this->pVarListBox->AddItem(ScriptVars::P_ROOMIMAGE_Y, g_pTheDB->GetMessageText(MID_VarRoomImageY));
 	this->pVarListBox->AddItem(ScriptVars::P_OVERHEADIMAGE_X, g_pTheDB->GetMessageText(MID_VarOverheadImageX));

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -470,6 +470,8 @@ UINT CCharacter::getPredefinedVarInt(const UINT varIndex) const
 		case (UINT)ScriptVars::P_ROOM_RAIN:
 		case (UINT)ScriptVars::P_SPAWNCYCLE:
 		case (UINT)ScriptVars::P_SPAWNCYCLE_FAST:
+		case (UINT)ScriptVars::P_PLAYER_WEAPON:
+		case (UINT)ScriptVars::P_PLAYER_LOCAL_WEAPON:
 			return this->pCurrentGame->getVar(varIndex);
 
 		default: ASSERT(!"GetVar val not supported"); return 0;
@@ -594,6 +596,8 @@ void CCharacter::setPredefinedVarInt(
 		case (UINT)ScriptVars::P_ROOM_FOG:
 		case (UINT)ScriptVars::P_ROOM_SNOW:
 		case (UINT)ScriptVars::P_ROOM_RAIN:
+		case (UINT)ScriptVars::P_PLAYER_WEAPON:
+		case (UINT)ScriptVars::P_PLAYER_LOCAL_WEAPON:
 		default:
 			pGame->ProcessCommandSetVar(varIndex, val);
 		break;

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -472,6 +472,8 @@ UINT CCharacter::getPredefinedVarInt(const UINT varIndex) const
 		case (UINT)ScriptVars::P_SPAWNCYCLE_FAST:
 		case (UINT)ScriptVars::P_PLAYER_WEAPON:
 		case (UINT)ScriptVars::P_PLAYER_LOCAL_WEAPON:
+		case (UINT)ScriptVars::P_INPUT:
+		case (UINT)ScriptVars::P_INPUT_DIRECTION:
 			return this->pCurrentGame->getVar(varIndex);
 
 		default: ASSERT(!"GetVar val not supported"); return 0;

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -392,6 +392,7 @@ void CCurrentGame::Clear(
 
 	this->bRoomExitLocked = false;
 	this->conquerTokenTurn = NO_CONQUER_TOKEN_TURN;
+	this->lastProcessedCommand = CMD_WAIT;
 
 	this->bSwordsmanOutsideRoom = false;
 	this->dwAutoSaveOptions = ASO_DEFAULT;
@@ -1087,6 +1088,24 @@ UINT CCurrentGame::getVar(const UINT varIndex) const
 			return this->swordsman.weaponType;
 		case (UINT)ScriptVars::P_PLAYER_LOCAL_WEAPON:
 			return this->swordsman.localRoomWeaponType;
+		case (UINT)ScriptVars::P_INPUT:
+		{
+			return this->lastProcessedCommand;
+		}
+		case (UINT)ScriptVars::P_INPUT_DIRECTION:
+		{
+			switch(this->lastProcessedCommand) {
+				case CMD_N: return N;
+				case CMD_NE: return NE;
+				case CMD_W: return W;
+				case CMD_E: return E;
+				case CMD_SW: return SW;
+				case CMD_S: return S;
+				case CMD_SE: return SE;
+				case CMD_NW: return NW;
+				default: return NO_ORIENTATION;
+			}
+		}
 		default:
 			return 0;
 	}
@@ -2271,6 +2290,7 @@ void CCurrentGame::ProcessCommand(
 	ASSERT(this->bIsGameActive);
 
 	const UINT dwStart = GetTicks();
+	this->lastProcessedCommand = nCommand;
 
 	//Reset relative movement for the current turn.
 	UpdatePrevCoords();
@@ -7008,6 +7028,7 @@ void CCurrentGame::SetMembers(const CCurrentGame &Src)
 	this->scriptArraysAtRoomStart = Src.scriptArraysAtRoomStart;
 	this->ambientSounds = Src.ambientSounds;
 	this->conquerTokenTurn = Src.conquerTokenTurn;
+	this->lastProcessedCommand = Src.lastProcessedCommand;
 	this->bWasRoomConqueredAtTurnStart = Src.bWasRoomConqueredAtTurnStart;
 	this->bIsLeavingLevel = Src.bIsLeavingLevel;
 

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -1083,6 +1083,10 @@ UINT CCurrentGame::getVar(const UINT varIndex) const
 			cycleTurn *= 2;
 			return this->bHalfTurn ? cycleTurn + 1 : cycleTurn;
 		}
+		case (UINT)ScriptVars::P_PLAYER_WEAPON:
+			return this->swordsman.weaponType;
+		case (UINT)ScriptVars::P_PLAYER_LOCAL_WEAPON:
+			return this->swordsman.localRoomWeaponType;
 		default:
 			return 0;
 	}
@@ -1193,6 +1197,22 @@ void CCurrentGame::ProcessCommandSetVar(
 			UINT wRain = max(0, min(newVal, MAX_ROOM_RAIN));
 			this->pRoom->weather.rain = wRain;
 		}
+		break;
+		case (UINT)ScriptVars::P_PLAYER_WEAPON:
+			if (bIsRealWeapon(newVal) || newVal == WT_On || newVal == WT_Off) {
+				this->swordsman.EquipWeapon(newVal);
+			}
+		break;
+		case (UINT)ScriptVars::P_PLAYER_LOCAL_WEAPON:
+			if (bIsRealWeapon(newVal)) {
+				this->swordsman.SetWeaponType(newVal, false);
+			} else if (newVal == WT_On) {
+				this->swordsman.bNoWeapon = false;
+				this->pRoom->ChangeTiles(WeaponDisarm);
+			} else if (newVal == WT_Off) {
+				this->swordsman.bNoWeapon = true;
+				this->pRoom->ChangeTiles(WeaponDisarm);
+			}
 		break;
 		default:
 		break;

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -361,6 +361,7 @@ public:
 	vector<SpeechLog> roomSpeech; //speech played up to this moment in the current room
 	bool     bRoomExitLocked; //safety to prevent player from exiting room when set
 	UINT     conquerTokenTurn; //turn player touched a Conquer token
+	UINT     lastProcessedCommand; //most recently processed comand, for read-only script var access
 
 	UINT     wMonsterKills; //total monsters killed in current room
 	UINT     wMonsterKillCombo; //total monsters killed without interruption

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -982,6 +982,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_CantChangeVarType: strText = "Var type can't be changed between array and non-array"; break;
 	case MID_VarPlayerWeapon: strText = "_PlayerWeapon"; break;
 	case MID_VarPlayerLocalWeapon: strText = "_PlayerLocalWeapon"; break;
+	case MID_VarInput: strText = "_Input"; break;
+	case MID_VarInputDirection: strText = "_InputDirection"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -980,6 +980,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_ArrayVarNameExpression: strText = "Variable Name/Expression"; break;
 	case MID_ArrayIndexLabel: strText = "Index"; break;
 	case MID_CantChangeVarType: strText = "Var type can't be changed between array and non-array"; break;
+	case MID_VarPlayerWeapon: strText = "_PlayerWeapon"; break;
+	case MID_VarPlayerLocalWeapon: strText = "_PlayerLocalWeapon"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -22,7 +22,8 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarRoomX, MID_VarRoomY,
 	MID_RoomWeather, MID_RoomDarkness, MID_RoomFog, MID_RoomSnow, MID_RoomRain,
 	MID_SpawnCycle, MID_SpawnCycleFast,
-	MID_VarPlayerWeapon, MID_VarPlayerLocalWeapon
+	MID_VarPlayerWeapon, MID_VarPlayerLocalWeapon,
+	MID_VarInput, MID_VarInputDirection
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -21,7 +21,8 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarMonsterName, 
 	MID_VarRoomX, MID_VarRoomY,
 	MID_RoomWeather, MID_RoomDarkness, MID_RoomFog, MID_RoomSnow, MID_RoomRain,
-	MID_SpawnCycle, MID_SpawnCycleFast
+	MID_SpawnCycle, MID_SpawnCycleFast,
+	MID_VarPlayerWeapon, MID_VarPlayerLocalWeapon
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -77,7 +77,9 @@ namespace ScriptVars
 		P_ROOM_RAIN = -34,
 		P_SPAWNCYCLE = -35,
 		P_SPAWNCYCLE_FAST = -36,
-		FirstPredefinedVar = P_SPAWNCYCLE_FAST, //set this to the last var in the enumeration
+		P_PLAYER_WEAPON = -37,
+		P_PLAYER_LOCAL_WEAPON = -38,
+		FirstPredefinedVar = P_PLAYER_LOCAL_WEAPON, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -79,7 +79,9 @@ namespace ScriptVars
 		P_SPAWNCYCLE_FAST = -36,
 		P_PLAYER_WEAPON = -37,
 		P_PLAYER_LOCAL_WEAPON = -38,
-		FirstPredefinedVar = P_PLAYER_LOCAL_WEAPON, //set this to the last var in the enumeration
+		P_INPUT = -39,
+		P_INPUT_DIRECTION = -40,
+		FirstPredefinedVar = P_INPUT_DIRECTION, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -709,6 +709,8 @@ You may select these in variable commands to examine or set certain game states.
 	<li><b>_MyScript*</b> - Variables used to inject dynamic values into other scripting commands. <a href="myscript.html">See this section</a> for explanation on how to use them.</li>
 	<li><b>_X</b> and <b>_Y</b> - X and Y position of the Player. Can cause the same potential problems as <b>_MyX</b> and <b>_MyY</b>, so use 'Teleport player to' wheen you need to teleport along two axes.</li>
 	<li><b>_O</b> - Player's current <a href="#valuesorientation">orientation</a>.</li>
+    <li><b>_PlayerWeapon</b> - Can be used to check the player's base weapon, or to indefinitely change their weapon in the same manner as the <a href="#setplayerweapon">Set player weapon</a> command. This value can also be set to -2 to disable the player's weapon, and to -1 to enable it.</li>
+    <li><b>_PlayerLocalWeapon</b> - Can be used to check the weapon currently be used by the player, or to set their current weapon for the duration of the room. This value can also be set to -2 to disarm the player, and to -1 to rearm them, as if touching a Disarm token.</li>
 	<li><b>_RoomImageX</b> and <b>_RoomImageY</b> - Offset of the custom room image in tiles.</li>
 	<li><b>_OverheadImageX</b> and <b>_OverheadImageY</b> - Offset of the custom overhead image in tiles.</li>
 	<li><b>_ThreatClock</b> - <a href="#threatclockdisplay">See this section</a>.</li>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -716,6 +716,7 @@ You may select these in variable commands to examine or set certain game states.
 	<li><b>_ThreatClock</b> - <a href="#threatclockdisplay">See this section</a>.</li>
 	<li><b>_LevelName</b> - <u>Read only!</u> Gets the name of the level.</li>
 	<li><b>_RoomX</b> and <b>_RoomY</b> - <u>Read only!</u> Gets the position of the current room in the level.</li>
+    <li><b>_Input</b> and <b>_InputDirection</b> - <u>Read only!</u> Gets the command value of the player's last input and the move direction of that input respectively. For inputs that do not move the player, such as rotations, a value of 4 is returned for the input direction.</li>
 	<li><b>_PlayerLight</b> - <a href="#playerlightvars">See this section</a></li>
 	<li><b>_PlayerLightType</b> - <a href="#playerlightvars">See this section</a></li>
 	<li><b>_ReturnX</b> and <b>_ReturnY</b> - Used by other commands to return values for later use, eg. Get Natural Target. Otherwise can be used for temporary storing information.</li>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -710,7 +710,7 @@ You may select these in variable commands to examine or set certain game states.
 	<li><b>_X</b> and <b>_Y</b> - X and Y position of the Player. Can cause the same potential problems as <b>_MyX</b> and <b>_MyY</b>, so use 'Teleport player to' wheen you need to teleport along two axes.</li>
 	<li><b>_O</b> - Player's current <a href="#valuesorientation">orientation</a>.</li>
     <li><b>_PlayerWeapon</b> - Can be used to check the player's base weapon, or to indefinitely change their weapon in the same manner as the <a href="#setplayerweapon">Set player weapon</a> command. This value can also be set to -2 to disable the player's weapon, and to -1 to enable it.</li>
-    <li><b>_PlayerLocalWeapon</b> - Can be used to check the weapon currently be used by the player, or to set their current weapon for the duration of the room. This value can also be set to -2 to disarm the player, and to -1 to rearm them, as if touching a Disarm token.</li>
+    <li><b>_PlayerLocalWeapon</b> - Can be used to check the weapon currently being used by the player, or to set their current weapon for the duration of the room. This value can also be set to -2 to disarm the player, and to -1 to rearm them, as if touching a Disarm token.</li>
 	<li><b>_RoomImageX</b> and <b>_RoomImageY</b> - Offset of the custom room image in tiles.</li>
 	<li><b>_OverheadImageX</b> and <b>_OverheadImageY</b> - Offset of the custom overhead image in tiles.</li>
 	<li><b>_ThreatClock</b> - <a href="#threatclockdisplay">See this section</a>.</li>

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1904,6 +1904,8 @@ enum MID_CONSTANT {
   MID_RoomRain = 2051,
   MID_SpawnCycle = 2055,
   MID_SpawnCycleFast = 2056,
+  MID_VarPlayerWeapon = 2095,
+  MID_VarPlayerLocalWeapon = 2096,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1898,

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1906,6 +1906,8 @@ enum MID_CONSTANT {
   MID_SpawnCycleFast = 2056,
   MID_VarPlayerWeapon = 2095,
   MID_VarPlayerLocalWeapon = 2096,
+  MID_VarInput = 2097,
+  MID_VarInputDirection = 2098,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1898,

--- a/Texts/Stats.uni
+++ b/Texts/Stats.uni
@@ -142,3 +142,11 @@ _PlayerWeapon
 [MID_VarPlayerLocalWeapon]
 [eng]
 _PlayerLocalWeapon
+
+[MID_VarInput]
+[eng]
+_Input
+
+[MID_VarInputDirection]
+[eng]
+_InputDirection

--- a/Texts/Stats.uni
+++ b/Texts/Stats.uni
@@ -134,3 +134,11 @@ _SpawnCycle
 [MID_SpawnCycleFast]
 [eng]
 _SpawnCycleFast
+
+[MID_VarPlayerWeapon]
+[eng]
+_PlayerWeapon
+
+[MID_VarPlayerLocalWeapon]
+[eng]
+_PlayerLocalWeapon


### PR DESCRIPTION
New script vars to access some more bits of information:

- `_PlayerWeapon` gives access to the player's base weapon, allowing to be checked separately from the currently wielded weapon, and provides another way to change it, include enabling and disabling the weapon.
- `PlayerLocalWeapon` gives access to the weapon the player is currently wielding, allowing scripted changes of the local weapon without effecting the global weapon, including arming and disarming.
- `_Input` give read-only access to the most recent command the player input.
- `_InputDirection` gives read-only access to the movement direction of the most recent player input, or 4 if a non-movement command was input.

The two input commands required a new member variable in `CCurrentGame`, which is set by `ProcessCommand`. It should not need to be serialized, as its only purpose to allow the access during script processing, which can only happen as part of command processing.

Thread 1: https://forum.caravelgames.com/viewtopic.php?TopicID=46100
Thread 2: https://forum.caravelgames.com/viewtopic.php?TopicID=46142