### PR TITLE
Allow exception catching in _DEBUG builds

### DIFF
--- a/DROD/Main.cpp
+++ b/DROD/Main.cpp
@@ -373,7 +373,7 @@ int main(int argc, char *argv[])
 		if (ret != static_cast<MESSAGE_ID>(-1))
 			DisplayInitErrorMessage(ret);
 	} else {
-#ifndef _DEBUG
+#ifndef NO_EXCEPTIONS
 		try
 		{
 #endif
@@ -540,7 +540,7 @@ int main(int argc, char *argv[])
 				delete pCurrentPlayer;
 			}
 
-#ifndef _DEBUG
+#ifndef NO_EXCEPTIONS
 		}
 		catch (CException& e)
 		{


### PR DESCRIPTION
Currently, some preprocessor blocks are set up so that exception catching and logging is mutually exclusive with functionality provided by the `_DEBUG` flag, such as assert logging. This makes it more difficult to assess certain crashes, as they do not trip any asserts before breaking everything. By allowing exceptions to also be caught and logged, more information might be collected to help with such problems.