### PR TITLE
Improvements for array script variables

### DIFF
--- a/DROD/VarMonitorEffect.cpp
+++ b/DROD/VarMonitorEffect.cpp
@@ -53,8 +53,10 @@ CVarMonitorEffect::CVarMonitorEffect(CWidget *pSetWidget)
 
 	//Get current var state.
 	CCurrentGame *pGame = (CCurrentGame*)pRoomWidget->GetCurrentGame();
-	if (pGame)
+	if (pGame) {
 		pGame->GetVarValues(this->lastVars);
+		pGame->GetArrayVarValues(this->lastArrayVars);
+	}
 }
 
 CVarMonitorEffect::~CVarMonitorEffect()
@@ -72,19 +74,23 @@ void CVarMonitorEffect::SetTextForNewTurn()
 
 	//Check vars for updated state.
 	CCurrentGame *pGame = (CCurrentGame*)pRoomWidget->GetCurrentGame();
+	if (!pGame) {
+		this->lastTurn = turn;
+		return;
+	}
+
 	VARMAP curVars;
 	set<VarNameType> diff, diff2;
-	if (pGame)
-	{
-		pGame->GetVarValues(curVars);
-		pGame->DiffVarValues(this->lastVars,curVars,diff);
-		pGame->DiffVarValues(curVars,this->lastVars,diff2);
-		diff.insert(diff2.begin(), diff2.end());
-	}
+	WSTRING newText;
+
+	pGame->GetVarValues(curVars);
+	pGame->DiffVarValues(this->lastVars,curVars,diff);
+	pGame->DiffVarValues(curVars,this->lastVars,diff2);
+	diff.insert(diff2.begin(), diff2.end());
+
 	if (!diff.empty())
 	{
 		//Vars have changed.  Update display.
-		WSTRING newText;
 		for (set<VarNameType>::const_iterator var = diff.begin(); var != diff.end(); ++var)
 		{
 			//Print changed var names and values.
@@ -109,10 +115,45 @@ void CVarMonitorEffect::SetTextForNewTurn()
 			newText += wszCRLF;
 		}
 		this->lastVars = curVars;
-
-		SetText(newText.c_str());
 	}
 
+	//Now do array vars. Containers are cleared by functions so we can reuse them
+	pGame->GetArrayVarValues(curVars);
+	pGame->DiffVarValues(this->lastArrayVars, curVars, diff);
+	pGame->DiffVarValues(curVars, this->lastArrayVars, diff2);
+	diff.insert(diff2.begin(), diff2.end());
+
+	if (!diff.empty())
+	{
+		//Vars have changed. Update display.
+		for (set<VarNameType>::const_iterator var = diff.begin(); var != diff.end(); ++var)
+		{
+			WSTRING temp;
+			const char* pVarName = var->c_str();
+			UTF8ToUnicode(pVarName, temp);
+			vector<WSTRING> parts = WCSExplode(temp, L'/');
+			int value = curVars[pVarName].val;
+
+			ASSERT(parts.size() == 2);
+			newText += parts[0];
+			newText += wszLeftBracket;
+			newText += parts[1];
+			newText += wszRightBracket;
+
+			newText += wszSpace;
+			newText += wszEqual;
+			newText += wszSpace;
+			newText += to_wstring(value);
+
+			newText += wszCRLF;
+		}
+
+		this->lastArrayVars = curVars;
+	}
+
+	if (!newText.empty()) {
+		SetText(newText.c_str());
+	}
 	this->lastTurn = turn;
 }
 

--- a/DROD/VarMonitorEffect.h
+++ b/DROD/VarMonitorEffect.h
@@ -52,6 +52,7 @@ private:
 	UINT lastTurn;      //last turn var query was made
 
 	VARMAP lastVars;   //latest displayed var state
+	VARMAP lastArrayVars;   //latest displayed array var state
 
 	CRoomWidget *pRoomWidget;
 

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -383,6 +383,10 @@ int CCharacter::getArrayValue(
 //Returns: the value at the given index in the specified script array.
 //If the value has not been set, a default value of 0 is returned.
 {
+	if (!ScriptVars::IsIndexInArrayRange(arrayIndex)) {
+		return 0; //Out of range value is always 0
+	}
+
 	ScriptArrayMap::const_iterator array = scriptArrays.find(varId);
 
 	if (array == scriptArrays.end()) {
@@ -5272,6 +5276,11 @@ void CCharacter::SetArrayVariable(
 	vector<WSTRING> expressions = WCSExplode(command.label, *wszSemicolon);
 	for (vector<WSTRING>::const_iterator expression = expressions.begin();
 		expression != expressions.end(); ++expression) {
+		if (!ScriptVars::IsIndexInArrayRange(arrayIndex)) {
+			++arrayIndex;
+			continue; //Don't set value outside of allowed range. continue instead of break as negative values can end up in range
+		}
+
 		UINT index = 0;
 		int x = getArrayValue(scriptArrays, varIndex, arrayIndex);
 		//Note: [] operator will initialize missing values. This gives a default of 0.

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -1269,6 +1269,30 @@ void CCurrentGame::GetVarValues(VARMAP& vars)
 }
 
 //*****************************************************************************
+void CCurrentGame::GetArrayVarValues(VARMAP& vars)
+//Outputs a mapping of combined array name and index to value info for all array vars
+{
+	vars.clear();
+
+	for (ScriptArrayMap::const_iterator iter = this->scriptArrays.begin();
+		iter != this->scriptArrays.end(); ++iter) {
+		//Get var name.
+		const UINT wVarID = iter->first;
+		const string varName = UnicodeToUTF8(this->pHold->GetVarName(wVarID));
+		const map<int, int> array = iter->second;
+
+		for (map<int, int>::const_iterator arrayIter = array.begin(); arrayIter != array.end(); ++arrayIter) {
+			//Create a key for each entry in the format v[id]/[index]
+			const string key = varName + "/" + to_string(arrayIter->first);
+			VarMapInfo info;
+			info.bInteger = true;
+			info.val = arrayIter->second;
+			vars[key] = info;
+		}
+	}
+}
+
+//*****************************************************************************
 void CCurrentGame::GotoLevelEntrance(
 //Leaves the level and goes to the level with the indicated entrance.
 //

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -226,6 +226,7 @@ public:
 			{ return UnansweredQuestions.empty() ? NULL : &UnansweredQuestions.front(); }
 	UINT     getVar(const UINT varIndex) const;
 	void     GetVarValues(VARMAP& vars);
+	void     GetArrayVarValues(VARMAP& vars);
 	WSTRING  getStringVar(const UINT varIndex) const;
 	void     GotoLevelEntrance(CCueEvents& CueEvents, const UINT wEntrance, const bool bSkipEntranceDisplay=false);
 	bool     IsCurrentLevelComplete() const;

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -201,6 +201,12 @@ bool ScriptVars::IsCharacterArrayVar(const WCHAR* wstr)
 }
 
 //*****************************************************************************
+bool ScriptVars::IsIndexInArrayRange(const int index)
+{
+	return abs(index) <= 50000;
+}
+
+//*****************************************************************************
 void Challenges::deserialize(CDbPackedVars& vars)
 {
 	challenges.clear();

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -131,6 +131,8 @@ namespace ScriptVars
 	bool IsCharacterArrayVar(const WSTRING& wstr);
 	bool IsCharacterArrayVar(const WCHAR* wstr);
 
+	bool IsIndexInArrayRange(const int index);
+
 	//All predefined vars.
 	extern const UINT predefinedVarMIDs[PredefinedVarCount];
 	extern string midTexts[PredefinedVarCount];

--- a/Data/Help/1/scriptarray.html
+++ b/Data/Help/1/scriptarray.html
@@ -17,6 +17,7 @@
     <p>Additionally, multiple array values can be set by providing multiple values or expressions, separated by a semi-colon (;). The first value will be assigned at the specified index, 
     and each subsequent value will be assigned to the next index. For example, if the specified index is 3, the first value is assigned to the at position 3, the second value to position 4, and so on.</p>
     <p>The <b>Set array var at</b> command works in the same way, but allows for remote variable assignment, as with <a href="script.html#setvarat">Set var at</a>.</p>
+    <p>Values cannot be set for an index that is less than -50,000 or above 50,000.</p>
 
     <p><u>Querying array values</u></p>
     <p>Like any other script variable, an array value can be used anywhere an integer value is expected. 


### PR DESCRIPTION
Some changes to improve array vars:

1. Limited array indexes to be between -50,000 and 50,000 inclusive. Mainly an improvement for avoiding issues with supermassive arrays.
2. Added tracking of array vars to the var monitor effect. It does a bit of trickery to allow existing infrastructure to be reused, but it works well enough.