### PR TITLE
RPG: Character emits Evil Eye Woke

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3336,7 +3336,9 @@ Finish:
 		if (this->bAttackInFront && !this->bAttacked)
 		{
 			this->bAttacked = true;
-			this->bAttacked = AttackPlayerWhenInFront(CueEvents);
+			if (this->bAttacked = AttackPlayerWhenInFront(CueEvents) && (this->pCustomChar->wType == M_EYE || this->pCustomChar->wType == M_MADEYE))
+				CueEvents.Add(CID_EvilEyeWoke);
+				
 		}
 		if (this->bAttackInFrontWhenBackIsTurned && !this->bAttacked)
 		{


### PR DESCRIPTION
When you have a character with Evil Eye or Mad Eye as its base and it is attacking via Attacks in Front, it will now emit the Evil Eye Woke event to trigger the HMMM sound effect.

This also means you can now use this event in script logic in this case. This has the potential to mess up scripts in previously released holds, but I am not aware of any that have rooms that fulfill all three of these criteria at the same time:
- contains default eye monster
- contains character eye
- waited for this event

I believe this should be safe.