### PR TITLE
RPG: Port fixes for Turn Into Monster orientation

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -285,9 +285,10 @@ CMonster* CCurrentGame::AddNewEntity(
 	if (IsValidMonsterType(identity))
 	{
 		CMonster *pMonster = this->pRoom->AddNewMonster(identity, wX, wY);
-		if (pMonster->HasOrientation()) {
-			pMonster->wO = (wO != NO_ORIENTATION) ? wO : NW ; //NW = default
-		} //otherwise: leave as constructed default
+		const bool bHasOrientation = pMonster->HasOrientation();
+		pMonster->wO = bHasOrientation ? wO : NO_ORIENTATION;
+		if (bHasOrientation && pMonster->wO == NO_ORIENTATION)
+			pMonster->wO = NW; //default
 		pMonster->bIsFirstTurn = true;
 
 		//Affect tile being placed on.

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -271,7 +271,7 @@ void CMonster::SetOrientation(
 	ASSERT(abs((int)dyFirst) <= 1);
 	const UINT wNewO = nGetO(dxFirst, dyFirst);
 	ASSERT(IsValidOrientation(wNewO));
-	if (wNewO != NO_ORIENTATION || !HasOrientation()) //TOFIX logic is not quite right for all cases; not sure if we want to modify at this point
+	if (IsValidOrientation(wNewO) && wNewO != NO_ORIENTATION || !HasOrientation())
 		this->wO = wNewO;
 }
 


### PR DESCRIPTION
When using Turn Into Monster command on a character, if the base monster class had no orientation, it would set the orientation to NW, which would then spam errors when trying to draw this orientation.

This PR ports over a fix for this that's in classic DROD.