### PR TITLE
RPG: Add new monsters to editor + puff effects

### DIFF
--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -201,6 +201,11 @@ void CDrodScreen::AddDamageEffect(CRoomWidget* pRoomWidget, CCurrentGame* pGame,
 				new CBloodEffect(pRoomWidget, coord, 30,
 						GetEffectDuration(pGame, 7), GetParticleSpeed(pGame, 4)));
 		break;
+		case M_FLUFFBABY:
+			pRoomWidget->AddTLayerEffect(
+				new CFluffStabEffect(pRoomWidget, coord,
+					GetEffectDuration(pGame, 7), GetParticleSpeed(pGame, 4)));
+		break;
 		default:
 			pRoomWidget->AddTLayerEffect(
 				new CBloodEffect(pRoomWidget, coord, 16,
@@ -472,7 +477,7 @@ void CDrodScreen::AddVisualCues(CCueEvents& CueEvents, CRoomWidget* pRoomWidget,
 			else
 				pRoomWidget->AddTLayerEffect(
 					new CFluffStabEffect(pRoomWidget, *pCoord,
-						GetEffectDuration(pGame, 6), GetParticleSpeed(pGame, 2)));
+						GetEffectDuration(pGame, 6), GetParticleSpeed(pGame, 4)));
 			break;
 		}
 	}

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -258,14 +258,14 @@ const UINT MenuDisplayTiles[TOTAL_EDIT_TILE_COUNT][4] =
 	{TI_HALPH_S},
 	{TI_WW_S},
 	{TI_EYE_S},
-	{TI_SNKT_W,/*TI_SNK_EW,*/TI_SNK_E},
+	{TI_SNK_E},
 	{TI_TAREYE_WO,TI_TAREYE_EO},
 	{TI_TARBABY_S},
 	{TI_BRAIN},
 	{TI_MIMIC_S},
 	{TI_SPIDER_S},
-	{TI_SNKT_G_W,/*TI_SNK_G_EW,*/TI_SNK_G_E},
-	{TI_SNKT_B_W,/*TI_SNK_B_EW,*/TI_SNK_B_E},
+	{TI_SNK_G_E},
+	{TI_SNK_B_E},
 	{TI_ROCK_S},
 	{TI_WATERSKIPPER_S},
 	{TI_SKIPPERNEST},
@@ -289,6 +289,8 @@ const UINT MenuDisplayTiles[TOTAL_EDIT_TILE_COUNT][4] =
 	{TI_ROCKGIANT_S,TI_ROCKGIANT_S1,TI_ROCKGIANT_S2,TI_ROCKGIANT_S3},
 	{TI_EYE_WS},
 	{TI_GOBLINKING_S},
+	{TI_CONSTRUCT_S},
+	{TI_FLUFFBABY},
 
 	//pseudo tiles
 	{TI_STALWART_E, TI_SWORD_YE},
@@ -459,6 +461,8 @@ const bool SinglePlacement[TOTAL_EDIT_TILE_COUNT] =
 	0, //T_ROCKGIANT     +35
 	0, //T_MADEYE        +36
 	0, //T_GOBLINKING    +37
+	0, //T_CONSTRUCT     +38
+	0, //T_FLUFFBABY     +39
 
 	1, //T_SWORDSMAN     TOTAL+0
 	0, //T_NOMONSTER     TOTAL+1
@@ -488,8 +492,8 @@ const UINT wItemX[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, //mist, vent
 	1, 1, //firetraps
 	1, //powder keg
-	1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
-	1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1, 1, //M+13
+	1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
+	1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1, 1, 1, 1,//M+15
 	2, 1, 1 //psuedo tiles
 };
 
@@ -517,7 +521,7 @@ const UINT wItemY[TOTAL_EDIT_TILE_COUNT] = {
 	1, 1, //firetraps
 	1, //powder keg
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+25
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, //M+13
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,//M+15
 	1, 1, 1 //pseudo tiles
 };
 
@@ -619,16 +623,15 @@ const UINT tLayerEntries[numTLayerEntries] = {
 	T_TAR, T_OBSTACLE, T_MIST, T_LIGHT
 };
 
-const UINT numMLayerEntries = 31;  //35
+const UINT numMLayerEntries = 33;
 const UINT mLayerEntries[numMLayerEntries] = {
 	T_BRAIN, T_ROACH, T_WWING, T_EYE, T_QROACH,
 	T_SPIDER, T_MUDBABY, T_SKIPPERNEST, T_MUDMOTHER,
-	T_CITIZEN, T_MADEYE, T_NEATHER, T_ROCKGOLEM, T_GOBLIN,
-	T_TARBABY, T_DECOY, T_MIMIC, T_CLONE, T_GUARD,
-	T_GELBABY, T_FEGUNDO, T_WATERSKIPPER, T_SEEP, T_PIRATE,
-	T_AUMTLICH, T_WUBBA, T_GOBLINKING, T_SLAYER,
-	//T_TARMOTHER, T_GELMOTHER, T_SERPENT, T_SERPENTG,
-	T_ROCKGIANT, T_SERPENTB, T_CHARACTER
+	T_CITIZEN, T_FLUFFBABY, T_MADEYE, T_NEATHER, T_ROCKGOLEM,
+	T_GOBLIN, T_TARBABY, T_DECOY, T_MIMIC, T_CLONE,
+	T_GUARD, T_GELBABY, T_FEGUNDO, T_WATERSKIPPER, T_SEEP,
+	T_PIRATE, T_CONSTRUCT, T_AUMTLICH, T_WUBBA, T_GOBLINKING,
+	T_SLAYER, T_ROCKGIANT, T_SERPENTB, T_CHARACTER
 };
 
 //Ordering of obstacle types on pop-up menu.
@@ -5413,6 +5416,7 @@ void CEditRoomScreen::PlotObjects()
 					g_pTheSound->PlaySoundEffect(SEID_STABTAR);  break;
 				case T_MIST:
 				case T_MISTVENT:
+				case T_FLUFFBABY:
 					g_pTheSound->PlaySoundEffect(SEID_PUFF_EXPLOSION); break;
 				case T_ROCKGOLEM:
 				case T_ROCKGIANT:
@@ -5618,6 +5622,7 @@ bool CEditRoomScreen::PlotObjectAt(
 		{
 		case M_BRAIN:
 		case M_SKIPPERNEST:
+		case M_FLUFFBABY:
 			pMonster->wO = NO_ORIENTATION;
 			break;
 		case M_TARMOTHER:

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -1008,6 +1008,7 @@ const
 		case T_CITIZEN:
 		case T_SKIPPERNEST:
 		case T_HALPH: case T_SLAYER:
+		case T_CONSTRUCT:
 			//Ground movement types
 			if (bSwordsmanAt) return false;
 			return (bIsFloor(wTileNo[0]) || bIsDoor(wTileNo[0]) || bIsOpenDoor(wTileNo[0]) ||
@@ -1040,6 +1041,7 @@ const
 					(wTileNo[1] == T_GEL || wTileNo[1] == T_EMPTY);
 		case T_WWING:
 		case T_FEGUNDO:
+		case T_FLUFFBABY:
 			//Air movement types
 			if (bSwordsmanAt) return false;
 			return (bIsFloor(wTileNo[0]) || bIsDoor(wTileNo[0]) || bIsOpenDoor(wTileNo[0]) || bIsPlatform(wTileNo[0]) ||

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -371,7 +371,7 @@ UINT CGameScreen::GetMonsterDisplayTile(CMonster *pMonster, const UINT x, const 
 					TI_HALPH_S, TI_SLAYER_S, TI_FEGUNDO_S, TI_UNSPECIFIED,
 					TI_GUARD_S, TI_UNSPECIFIED, TI_MUDEYE_WO, TI_MUDBABY_S,
 					TI_GELEYE_WO, TI_GELBABY_S, TI_CITIZEN_S, TI_ROCKGIANT_S,
-					TI_EYE_WS, TI_GOBLINKING_S
+					TI_EYE_WS, TI_GOBLINKING_S, TI_CONSTRUCT_S, TI_FLUFFBABY
 				};
 				val = tile[pMonster->wType];
 				//NPC special appearance.
@@ -3984,6 +3984,16 @@ void CGameScreen::AddDamageEffect(
 						GetEffectDuration(7), GetParticleSpeed(3)));
 		}
 		break;
+		case M_FLUFFBABY:
+		{
+			UINT particles = UINT(20 * fDamagePercent);
+			if (!particles)
+				particles = 1;
+			pRoomWidget->AddTLayerEffect(
+				new CFluffStabEffect(pRoomWidget, coord,
+					GetEffectDuration(7), GetParticleSpeed(4), particles));
+		}
+		break;
 		default:
 		{
 			UINT particles = UINT(16 * fDamagePercent);
@@ -4019,6 +4029,10 @@ void CGameScreen::AddKillEffect(const UINT wMonsterType, const CMoveCoord& coord
 	{
 		case M_SLAYER: soundID = SEID_SLAYERDIE; break;
 		case M_ROCKGOLEM: case M_ROCKGIANT: soundID = SEID_BREAKWALL; break;
+		case M_FLUFFBABY:
+			pRoomWidget->AddTLayerEffect(new CPuffExplosionEffect(pRoomWidget, coord));
+			soundID = SEID_PUFF_EXPLOSION;
+			break;
 		default: soundID = SEID_SPLAT; break;
 	}
 	g_pTheSound->PlaySoundEffect(soundID, this->fPos);

--- a/drodrpg/DROD/ParticleExplosionEffect.h
+++ b/drodrpg/DROD/ParticleExplosionEffect.h
@@ -39,6 +39,7 @@
 #include <vector>
 
 #define PARTICLES_PER_EXPLOSION (25)
+#define FLUFF_PARTICLES (15)
 
 struct PARTICLE
 {

--- a/drodrpg/DROD/TarStabEffect.cpp
+++ b/drodrpg/DROD/TarStabEffect.cpp
@@ -30,8 +30,6 @@
 #include "../DRODLib/GameConstants.h"
 #include <BackEndLib/Assert.h>
 
-const UINT FLUFF_PARTICLES = 15;
-
 //********************************************************************************
 CTarStabEffect::CTarStabEffect(
 //Constructor.
@@ -109,8 +107,9 @@ CFluffStabEffect::CFluffStabEffect(
 	CWidget* pSetWidget,       //(in)   Should be a room widget.
 	const CMoveCoord& MoveCoord,  //(in)   Location of debris and direction of its movement.
 	const UINT wParticleMinDuration,
-	const UINT baseSpeed)
-	: CParticleExplosionEffect(pSetWidget, MoveCoord, 8, 8, 2, FLUFF_PARTICLES,
+	const UINT baseSpeed,
+	const UINT particles)  //[default=FLUFF_PARTICLES]
+	: CParticleExplosionEffect(pSetWidget, MoveCoord, 8, 8, 2, particles,
 		wParticleMinDuration, baseSpeed)
 {
 	this->bRotatingParticles = false;

--- a/drodrpg/DROD/TarStabEffect.h
+++ b/drodrpg/DROD/TarStabEffect.h
@@ -58,7 +58,8 @@ class CFluffStabEffect : public CParticleExplosionEffect
 {
 public:
 	CFluffStabEffect(CWidget* pSetWidget, const CMoveCoord& MoveCoord,
-		const UINT wParticleMinDuration, const UINT baseSpeed);
+		const UINT wParticleMinDuration, const UINT baseSpeed,
+		const UINT particles=FLUFF_PARTICLES);
 };
 
 class CFluffInWallEffect : public CParticleExplosionEffect

--- a/drodrpg/DRODLib/MonsterFactory.cpp
+++ b/drodrpg/DRODLib/MonsterFactory.cpp
@@ -202,10 +202,10 @@ CMonster * CMonsterFactory::GetNewMonster(
 		return new CZombie(this->pCurrentGame);
 
 		case M_CONSTRUCT:
-		return new CConstruct();
+		return new CConstruct(this->pCurrentGame);
 
 		case M_FLUFFBABY:
-		return new CFluffBaby();
+		return new CFluffBaby(this->pCurrentGame);
 
 		default:
 			ASSERT(!"Unexpected monster type.");


### PR DESCRIPTION
Adds the two new monsters to the monster editor tab. In order to fit them I had to shrink the serpents from 2 tiles wide to one. It was either those or the rock giant, but reducing the serpents to only the head looked better.

Also adds effects to combat with the puff, wiring up its death effect and replacing blood with fluff particles. The construct still bleeds, that's a change for another day.