### PR TITLE
New noises for egg spawns and Construct splat

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1440,6 +1440,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pVisualEffectsListBox->AddItem(VET_EQUIP, g_pTheDB->GetMessageText(MID_EquipEffect));
 	this->pVisualEffectsListBox->AddItem(VET_ICEMELT, g_pTheDB->GetMessageText(MID_IceMeltEffect));
 	this->pVisualEffectsListBox->AddItem(VET_PUFFEXPLOSION, g_pTheDB->GetMessageText(MID_PuffExplosionEffect));
+	this->pVisualEffectsListBox->AddItem(VET_CONSTRUCTSPLAT, g_pTheDB->GetMessageText(MID_ConstructSplatterEffect));
 	this->pVisualEffectsListBox->SelectLine(0);
 	this->pVisualEffectsListBox->SetAllowFiltering(true);
 
@@ -4007,6 +4008,7 @@ void CCharacterDialogWidget::PopulateEventListBox()
 	this->pEventListBox->AddItem(CID_CutBriar, g_pTheDB->GetMessageText(MID_CutBriar));
 	this->pEventListBox->AddItem(CID_DrankPotion, g_pTheDB->GetMessageText(MID_DrankPotion));
 	this->pEventListBox->AddItem(CID_EvilEyeWoke, g_pTheDB->GetMessageText(MID_EvilEyeWoke));
+	this->pEventListBox->AddItem(CID_EggSpawned, g_pTheDB->GetMessageText(MID_EggSpawned));
 	this->pEventListBox->AddItem(CID_Firetrap, g_pTheDB->GetMessageText(MID_FiretrapBurning));
 	this->pEventListBox->AddItem(CID_FiretrapActivated, g_pTheDB->GetMessageText(MID_FiretrapActivated));
 	this->pEventListBox->AddItem(CID_FiretrapHit, g_pTheDB->GetMessageText(MID_FiretrapHit));

--- a/drodrpg/DROD/DrodEffect.h
+++ b/drodrpg/DROD/DrodEffect.h
@@ -98,6 +98,7 @@ enum VisualEffectType
 	VET_ICEMELT=20,
 	VET_FIRETRAP=21,
 	VET_PUFFEXPLOSION=22,
+	VET_CONSTRUCTSPLAT=23,
 };
 
 #endif //...#ifndef DRODEFFECT_H

--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -186,6 +186,7 @@ void CDrodScreen::AddDamageEffect(CRoomWidget* pRoomWidget, CCurrentGame* pGame,
 		break;
 		case M_ROCKGOLEM:
 		case M_ROCKGIANT:
+		case M_CONSTRUCT:
 			pRoomWidget->AddTLayerEffect(
 				new CGolemDebrisEffect(pRoomWidget, coord, 10,
 						GetEffectDuration(pGame, 7), GetParticleSpeed(pGame, 4)));

--- a/drodrpg/DROD/DrodSound.cpp
+++ b/drodrpg/DROD/DrodSound.cpp
@@ -132,6 +132,7 @@ const
 		case SEID_BRIAR_BREAK: strKeyName="BriarBreak"; break;
 		case SEID_BUTTON:    strKeyName="Button"; break;
 		case SEID_CHECKPOINT:   strKeyName="Checkpoint"; break;
+		case SEID_CONSTRUCT_SMASH:  strKeyName = "ConstructSmash"; break;
 		case SEID_DOOROPEN:     strKeyName="DoorOpen"; break;
 		case SEID_EVILEYEWOKE:  strKeyName="EvilEyeWoke"; break;
 		case SEID_FALLING:  strKeyName="Falling"; break;
@@ -165,6 +166,7 @@ const
 		case SEID_PUFF_EXPLOSION:       strKeyName="PuffExplosion"; break;
 		case SEID_PUNCH:        strKeyName="Punch"; break;
 		case SEID_READ:         strKeyName="Read"; break;
+		case SEID_ROACH_EGG_SPAWNED: strKeyName = "RoachEggSpawned"; break;
 		case SEID_SECRET:    strKeyName="Secret"; break;
 		case SEID_SHATTER:     strKeyName="Shatter"; break;
 		case SEID_SHIELDED:     strKeyName="Shielded"; break;
@@ -379,6 +381,7 @@ bool CDrodSound::LoadSoundEffects()
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_BRIAR_BREAK );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_BUTTON );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_CHECKPOINT );
+	SHARED_CHANNEL_SOUNDEFFECT( SEID_CONSTRUCT_SMASH );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_DOOROPEN );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_EVILEYEWOKE );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_FALLING );
@@ -402,6 +405,7 @@ bool CDrodSound::LoadSoundEffects()
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_PUFF_EXPLOSION );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_PUNCH );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_READ );
+	SHARED_CHANNEL_SOUNDEFFECT( SEID_ROACH_EGG_SPAWNED );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_SECRET );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_SHATTER );
 	SHARED_CHANNEL_SOUNDEFFECT( SEID_SHIELDED );

--- a/drodrpg/DROD/DrodSound.h
+++ b/drodrpg/DROD/DrodSound.h
@@ -163,6 +163,8 @@ enum SEID
 	SEID_PUFF_EXPLOSION,
 	SEID_FIRETRAP,
 	SEID_FIRETRAP_START,
+	SEID_CONSTRUCT_SMASH,
+	SEID_ROACH_EGG_SPAWNED,
 
 	//Grouped sound effects -- may only play one at a time -- designated private channels.
 	//Channel n+1--Tendry's voice.

--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -5389,7 +5389,6 @@ void CEditRoomScreen::PlotObjects()
 				break;
 
 				case T_ROACH:
-				case T_QROACH:
 				case T_GOBLIN: case T_GOBLINKING:
 				case T_WWING:
 				case T_SPIDER:
@@ -5402,6 +5401,8 @@ void CEditRoomScreen::PlotObjects()
 				case T_NOMONSTER:
 				case T_NEATHER:
 					g_pTheSound->PlaySoundEffect(SEID_SPLAT); break;
+				case T_QROACH:
+					g_pTheSound->PlaySoundEffect(SEID_ROACH_EGG_SPAWNED); break;
 				case T_EYE:
 				case T_MADEYE:
 					g_pTheSound->PlaySoundEffect(SEID_EVILEYEWOKE); break;
@@ -5432,6 +5433,8 @@ void CEditRoomScreen::PlotObjects()
 //					g_pTheSound->PlaySoundEffect(SEID_SLAYERENTERFAR);
 //					UniquePlacement(this->pRoomWidget->wEndX, this->pRoomWidget->wEndY, M_SLAYER);
 					break;
+				case T_CONSTRUCT:
+					g_pTheSound->PlaySoundEffect(SEID_CONSTRUCT_SMASH); break;
 				case T_CHARACTER:
 				case T_CITIZEN:
 					break;

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1483,6 +1483,7 @@ void CGameScreen::AddVisualEffect(const VisualEffectInfo* pEffect)
 			case VET_ICEMELT: soundID = SEID_ICEMELT; break;
 			case VET_FIRETRAP: soundID = SEID_FIRETRAP_START; break;
 			case VET_PUFFEXPLOSION: soundID = SEID_PUFF_EXPLOSION; break;
+			case VET_CONSTRUCTSPLAT: soundID = SEID_CONSTRUCT_SMASH; break;
 			default: break;
 		}
 
@@ -1517,6 +1518,7 @@ void CGameScreen::AddVisualEffect(const VisualEffectInfo* pEffect)
 				new CBloodInWallEffect(this->pRoomWidget, coord, particles));
 		break;
 		case VET_GOLEMSPLAT:
+		case VET_CONSTRUCTSPLAT:
 			this->pRoomWidget->AddTLayerEffect(
 				new CGolemDebrisEffect(this->pRoomWidget, coord, particles,
 						GetEffectDuration(7), GetParticleSpeed(3)));
@@ -3953,6 +3955,7 @@ void CGameScreen::AddDamageEffect(
 		break;
 		case M_ROCKGOLEM:
 		case M_ROCKGIANT:
+		case M_CONSTRUCT:
 		{
 			UINT particles = UINT(10 * fDamagePercent);
 			if (!particles)
@@ -4029,6 +4032,7 @@ void CGameScreen::AddKillEffect(const UINT wMonsterType, const CMoveCoord& coord
 	{
 		case M_SLAYER: soundID = SEID_SLAYERDIE; break;
 		case M_ROCKGOLEM: case M_ROCKGIANT: soundID = SEID_BREAKWALL; break;
+		case M_CONSTRUCT: soundID = SEID_CONSTRUCT_SMASH; break;
 		case M_FLUFFBABY:
 			pRoomWidget->AddTLayerEffect(new CPuffExplosionEffect(pRoomWidget, coord));
 			soundID = SEID_PUFF_EXPLOSION;
@@ -5696,6 +5700,8 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 	}
 	if (CueEvents.HasOccurred(CID_Tunnel))
 		g_pTheSound->PlaySoundEffect(SEID_TUNNEL);
+	if (CueEvents.HasOccurred(CID_EggSpawned))
+		PlaySoundEffect(SEID_ROACH_EGG_SPAWNED);
 
 	//2nd. Important room events.
 	if (CueEvents.HasOccurred(CID_RedGatesToggled) ||

--- a/drodrpg/DROD/Main.cpp
+++ b/drodrpg/DROD/Main.cpp
@@ -1964,6 +1964,7 @@ void RepairMissingINIKeys(const bool bFullVersion)
 	AddIfMissing(INISection::Waves, "Button", "buttonClick.ogg");
 	AddIfMissing(INISection::Waves, "BriarBreak", "briar-break1.ogg;briar-break2.ogg");
 	AddIfMissing(INISection::Waves, "Checkpoint", "blooomp.ogg");
+	AddIfMissing(INISection::Waves, "ConstructSmash", "ConstructSmash1.ogg;ConstructSmash2.ogg");
 	AddIfMissing(INISection::Waves, "DoorOpen", "hugedoor.ogg");
 	AddIfMissing(INISection::Waves, "EvilEyeWoke", "hmm.ogg");
 	AddIfMissing(INISection::Waves, "Falling", "whoosh.ogg");
@@ -1988,6 +1989,7 @@ void RepairMissingINIKeys(const bool bFullVersion)
 	AddIfMissing(INISection::Waves, "PuffExplosion", "puff-explosion.ogg");
 	AddIfMissing(INISection::Waves, "Punch", "punch.ogg");
 	AddIfMissing(INISection::Waves, "Read", "read.ogg");
+	AddIfMissing(INISection::Waves, "RoachEggSpawned", "QueenSpawn_01.ogg;QueenSpawn_02.ogg;QueenSpawn_03.ogg");
 	AddIfMissing(INISection::Waves, "Secret", "SecretArea.ogg");
 	AddIfMissing(INISection::Waves, "Shatter", "shatter.ogg");
 	AddIfMissing(INISection::Waves, "Shielded", "shielded.ogg");

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -700,6 +700,11 @@ enum CUEEVENT_ID
 	//Private data: CCoord *pSquare
 	CID_FiretrapHit,
 
+	//A roach queen spawned a roach egg.
+	//
+	//Private data: CMonster *pMonster (one or more)
+	CID_EggSpawned,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -849,6 +849,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_Construct: strText = "Construct"; break;
 		case MID_FluffBaby: strText = "Puff"; break;
 		case MID_PuffExplosionEffect: strText = "Puff destroyed"; break;
+		case MID_EggSpawned: strText = "Roach egg spawned"; break;
+		case MID_ConstructSplatterEffect: strText = "Construct splatter"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1081,6 +1081,7 @@ void CMonster::SpawnEgg(CCueEvents& CueEvents)
 		if (wType != M_REGG && !bMonsterHasDirection(wType)) {
 			m->wO = NO_ORIENTATION;
 		}
+		CueEvents.Add(CID_EggSpawned);
 	}
 }
 

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1581,6 +1581,8 @@ enum MID_CONSTANT {
   MID_CrateDestroyed = 1895,
   MID_FiretrapHit = 1896,
   MID_PuffExplosionEffect = 1934,
+  MID_EggSpawned = 1935,
+  MID_ConstructSplatterEffect = 1936,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1491,3 +1491,11 @@ Ambient - Roaches
 [MID_PuffExplosionEffect]
 [eng]
 Puff destroyed
+
+[MID_EggSpawned]
+[eng]
+Roach egg spawned
+
+[MID_ConstructSplatterEffect]
+[eng]
+Construct splatter


### PR DESCRIPTION
Add event for queen spawns which you can now wait for etc.

New egg spawn event plays egg spawning sound.

Add construct death sounds.

Add golem debris effect instead of blood when fighting construct (I thought it had its own effect in classic DROD, but turns out it doesn't)

Has an accompanying PR in the data repo.