### PR TITLE
RPG: Fix mist blocking character movement and egg spawns

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4956,6 +4956,7 @@ const
 		wTileNo == T_FUSE ||
 		wTileNo == T_TOKEN ||
 		wTileNo == T_KEY ||
+		wTileNo == T_MIST ||
 		bIsPowerUp(wTileNo) ||
 		bIsMap(wTileNo) ||
 		bIsShovel(wTileNo) ||

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1048,7 +1048,7 @@ void CMonster::SpawnEgg(CCueEvents& CueEvents)
 				// Not monster or player double or sword
 				!pMonster && !DoesSquareContainObstacle(ex, ey) &&
 				//And t-square is not occupied with a blocking item.
-				(wTSquare == T_EMPTY || wTSquare == T_FUSE) &&
+				(wTSquare == T_EMPTY || wTSquare == T_FUSE || wTSquare == T_MIST) &&
 				!bIsArrow(room.GetFSquare(ex, ey)) &&
 				//And o-square is floor or open door.
 				((bIsPlainFloor(wOSquare) || wOSquare == T_PRESSPLATE) ||


### PR DESCRIPTION
Mist was incorrectly blocking moving characters and egg spawns. This fixes both of these.