### PR TITLE
RPG: Make wall movement characters transparent

### DIFF
--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -409,7 +409,7 @@ protected:
 	void           DrawInvisibilityRange(const int nX, const int nY,
 			SDL_Surface *pDestSurface, CCoordIndex *pCoordIndex=NULL, const int nRange=DEFAULT_SMELL_RANGE);
 	virtual void   DrawCharacter(CCharacter *pCharacter, const float fRaised,
-			SDL_Surface *pDestSurface, const bool bMoveInProgress);
+			SDL_Surface *pDestSurface, const bool bMoveInProgress, const bool bActionIsFrozen);
 	virtual bool   DrawingSwordFor(const CMonster* /*pMonster*/) const { return true; }
 	void           DrawDouble(const CPlayerDouble *pDouble, const float  fRaised,
 			SDL_Surface *pDestSurface, const bool bMoveInProgress, const Uint8 nOpacity=255);


### PR DESCRIPTION
The default Seep monster fades in and out. This change makes all characters with wall movement type also fade in and out. I wanted my custom seep enemies to exhibit this behavior, which was not possible to set before.

This isn't fully backwards compatible as characters with a Seep identity by default have wall movement, so any custom seep characters in published holds will now fade in and out where they didn't before. This can be disabled by giving those characters any other movement type (this being customizable is new 1.3 functionality), so if necessary holds can be updated to bring the visuals back to how they were before.

The alternative is to stop making characters with a seep identity have wall movement by default and require the player to set it themselves. No published hold had any moving seep as far as I am aware, but I feel uncomfortable potentially messing with the underlying properties of existing characters.