### PR TITLE
RPG: Port fix for desync when changing monster appearance

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -390,6 +390,10 @@ void CCharacter::ChangeHoldForCommands(
 				case CCharacterCommand::CC_SetMusic:
 					CDbData::CopyObject(info, c.w, pNewHold->dwHoldID);
 				break;
+				case CCharacterCommand::CC_SetNPCAppearance:
+				case CCharacterCommand::CC_SetPlayerAppearance:
+					SyncCustomCharacterData(c.x, pOldHold, pNewHold, info);
+					break;
 				case CCharacterCommand::CC_GenerateEntity:
 					SyncCustomCharacterData(c.h, pOldHold, pNewHold, info);
 					break;


### PR DESCRIPTION
https://forum.caravelgames.com/viewtopic.php?TopicID=40625

Game could desync when changing an NPC appearance, this ports over a fix from classic DROD. Looking at the fix, this bug may have been present for changing player roles too.