### PR TITLE
RPG: Fix regression with non-visible characters in editor

### DIFF
--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -1314,7 +1314,8 @@ void CEditRoomWidget::DrawCharacter(
 	CCharacter *pCharacter,    //(in)   Pointer to CCharacter monster.
 	const float fRaised,    //(in)   Draw Character raised above floor?
 	SDL_Surface *pDestSurface, //(in)   Surface to draw to.
-	const bool /*bMoveInProgress*/)
+	const bool /*bMoveInProgress*/,
+	const bool /*bActionIsFrozen*/)  //(in) Whether action is currently stopped.
 {
 	const bool bAlt = (SDL_GetModState() & KMOD_ALT) != 0;
 	const bool preview = (bAlt != characterPreview);

--- a/drodrpg/DROD/EditRoomWidget.h
+++ b/drodrpg/DROD/EditRoomWidget.h
@@ -128,7 +128,7 @@ protected:
 	virtual  ~CEditRoomWidget();
 
 	virtual void   DrawCharacter(CCharacter *pCharacter, const float fRaised,
-			SDL_Surface *pDestSurface, const bool bMoveInProgress);
+			SDL_Surface *pDestSurface, const bool bMoveInProgress, const bool bActionIsFrozen);
 	virtual bool   DrawingSwordFor(const CMonster *pMonster) const;
 
 	virtual void   HandleAnimate() {if (this->pRoom) Paint(false);}   //parent must handle calling UpdateRect()


### PR DESCRIPTION
In #613  I changed the interface of DrawCharacter. As EditRoomWidget inherits from RoomWidget, Draw Character was no longer being called in the editor for non-visible characters. This updates the interface to match.