### PR TITLE
RPG: Fix characters restoring from wrong room when undoing

### DIFF
--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -2772,6 +2772,22 @@ CCharacter* CDbRoom::GetCharacterWithScriptID(const UINT scriptID)
 }
 
 //*****************************************************************************
+CCharacter* CDbRoom::GetCharacterFromExploredRoomWithScriptID(ExploredRoom* pExpRoom, const UINT scriptID)
+//Returns: character monster with indicated (unique) scriptID, or NULL if not found
+{
+	for (CMonster* pMonster = pExpRoom->pMonsterList; pMonster != NULL;
+		pMonster = pMonster->pNext)
+		if (pMonster->wType == M_CHARACTER)
+		{
+			CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
+			if (pCharacter->dwScriptID == scriptID)
+				return pCharacter; //found it
+		}
+
+	return NULL; //not found
+}
+
+//*****************************************************************************
 bool CDbRoom::HasClosedDoors() const
 //Returns: whether there are any closed doors in the room
 {
@@ -9523,7 +9539,7 @@ void CDbRoom::SetMonstersFromExploredRoomData(
 			{
 				//Find original NPC containing the script for this saved character.
 				CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
-				CCharacter *pOrigNPC = GetCharacterWithScriptID(pCharacter->dwScriptID);
+				CCharacter *pOrigNPC = GetCharacterFromExploredRoomWithScriptID(pExpRoom, pCharacter->dwScriptID);
 				if (pOrigNPC)
 				{
 					//Add the script data to the NPC's state, saved in the explored room data.

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -242,6 +242,7 @@ public:
 	void           GetAllDoorSquares(const UINT wX, const UINT wY, CCoordSet& squares,
 			const UINT tile, const CCoordSet* pIgnoreSquares=NULL) const;
 	CCharacter*    GetCharacterWithScriptID(const UINT scriptID);
+	CCharacter*    GetCharacterFromExploredRoomWithScriptID(ExploredRoom* pExpRoom, const UINT scriptID);
 	void           GetConnectedRegionsAround(const UINT wX, const UINT wY,
 			const CTileMask &tileMask, vector<CCoordSet>& regions,
 			const CCoordSet* pIgnoreSquares=NULL, const CCoordSet* pRegionMask=NULL) const;


### PR DESCRIPTION
Second attempt at fixing https://forum.caravelgames.com/viewtopic.php?TopicID=40625

When you undo a room and reload it, the monster list wasn't populating from the explored room, but rather the freshly reloaded room. This caused an issue if a monster had previously used the Set Appearance command, as they have different script commands compared to their logical identity, and so their script commands are only in the explored room monster list.

This creates a variant of the GetCharacterFromScriptId method to pull from the provided explored room.