### PR TITLE
RPG: Add support for array script variables

### DIFF
--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -205,8 +205,8 @@ UINT CListBoxWidget::AddItem_Insert(
 	}
 
 	//Recalc areas of widget since they may have changed.
-	CalcAreas();
 	this->UpdateFilter(this->wstrActiveFilter);
+	CalcAreas();
 	return wIndex;
 }
 

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -3966,6 +3966,15 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 				wstr += wszQuestionMark; //questionable logic condition
 		}
 		break;
+		case CCharacterCommand::CC_WaitForExpression:
+		{
+			CEditRoomScreen* pEditRoomScreen = DYN_CAST(CEditRoomScreen*, CScreen*,
+				g_pTheSM->GetScreen(SCR_EditRoom));
+			UINT index = 0;
+			if (!CCharacter::IsValidExpression(pCommand->label.c_str(), index, pEditRoomScreen->pHold))
+				wstr += wszAsterisk; //expression is not valid
+		}
+		break;
 
 		//Deprecated commands.
 		case CCharacterCommand::CC_GotoIf:

--- a/drodrpg/DROD/CharacterDialogWidget.h
+++ b/drodrpg/DROD/CharacterDialogWidget.h
@@ -76,7 +76,7 @@ public:
 	virtual void   OnBetweenEvents();
 
 	bool RenameCharacter();
-	bool RenameVar();
+	bool RenameVar(const bool bIsArrayVar = false);
 
 	UINT queryX, queryY, queryW, queryH; //for querying the user for coord info
 
@@ -97,7 +97,7 @@ private:
 	void  ClearPasteBuffer();
 	void  DeleteCommands(CListBoxWidget *pActiveCommandList, COMMANDPTR_VECTOR& commands);
 	void  DeleteCustomCharacter();
-	void  DeleteVar();
+	void  DeleteVar(const bool bIsArrayVar = false);
 	void  EditCustomCharacters();
 	void  FinishEditingDefaultScript();
 	UINT  FilterUnsupportedCommands();
@@ -137,6 +137,7 @@ private:
 	void  PopulateMainGraphicList();
 	void  PopulateSpeakerList(CListBoxWidget *pListBox);
 	void  PopulateVarList();
+	void  UpdateVarDeleteButton(UINT widgetTag, CListBoxWidget* varListBox);
 
 	void  prepareForwardReferences(const COMMANDPTR_VECTOR& newCommands);
 
@@ -187,7 +188,8 @@ private:
 	CListBoxWidget *pGotoLabelListBox;
 	CListBoxWidget *pMusicListBox;
 	CListBoxWidget *pVarListBox, *pVarOpListBox, *pVarCompListBox, *pWaitFlagsListBox,
-			*pImperativeListBox, *pBuildItemsListBox, *pBehaviorListBox, *pVarCompListBox2;
+			*pImperativeListBox, *pBuildItemsListBox, *pBehaviorListBox, *pVarCompListBox2,
+			*pArrayVarListBox, *pArrayVarOpListBox;
 	CListBoxWidget *pEquipmentTypesListBox, *pCustomNPCListBox, *pEquipTransListBox;
 	CTextBoxWidget *pCharNameText;
 	CListBoxWidget *pCharListBox;

--- a/drodrpg/DROD/VarMonitorEffect.cpp
+++ b/drodrpg/DROD/VarMonitorEffect.cpp
@@ -53,8 +53,10 @@ CVarMonitorEffect::CVarMonitorEffect(CWidget *pSetWidget)
 
 	//Get current var state.
 	CCurrentGame *pGame = (CCurrentGame*)pRoomWidget->GetCurrentGame();
-	if (pGame)
+	if (pGame) {
 		pGame->GetVarValues(this->lastVars);
+		pGame->GetArrayVarValues(this->lastArrayVars);
+	}
 }
 
 CVarMonitorEffect::~CVarMonitorEffect()
@@ -72,19 +74,23 @@ void CVarMonitorEffect::SetTextForNewTurn()
 
 	//Check vars for updated state.
 	CCurrentGame *pGame = (CCurrentGame*)pRoomWidget->GetCurrentGame();
+	if (!pGame) {
+		this->lastTurn = turn;
+		return;
+	}
+
 	VARMAP curVars;
 	set<VarNameType> diff, diff2;
-	if (pGame)
-	{
-		pGame->GetVarValues(curVars);
-		pGame->DiffVarValues(this->lastVars,curVars,diff);
-		pGame->DiffVarValues(curVars,this->lastVars,diff2);
-		diff.insert(diff2.begin(), diff2.end());
-	}
+	WSTRING newText;
+
+	pGame->GetVarValues(curVars);
+	pGame->DiffVarValues(this->lastVars,curVars,diff);
+	pGame->DiffVarValues(curVars,this->lastVars,diff2);
+	diff.insert(diff2.begin(), diff2.end());
+
 	if (!diff.empty())
 	{
 		//Vars have changed.  Update display.
-		WSTRING newText;
 		for (set<VarNameType>::const_iterator var = diff.begin(); var != diff.end(); ++var)
 		{
 			//Print changed var names and values.
@@ -109,10 +115,45 @@ void CVarMonitorEffect::SetTextForNewTurn()
 			newText += wszCRLF;
 		}
 		this->lastVars = curVars;
-
-		SetText(newText.c_str());
 	}
 
+	//Now do array vars. Containers are cleared by functions so we can reuse them
+	pGame->GetArrayVarValues(curVars);
+	pGame->DiffVarValues(this->lastArrayVars, curVars, diff);
+	pGame->DiffVarValues(curVars, this->lastArrayVars, diff2);
+	diff.insert(diff2.begin(), diff2.end());
+
+	if (!diff.empty())
+	{
+		//Vars have changed. Update display.
+		for (set<VarNameType>::const_iterator var = diff.begin(); var != diff.end(); ++var)
+		{
+			WSTRING temp;
+			const char* pVarName = var->c_str();
+			UTF8ToUnicode(pVarName, temp);
+			vector<WSTRING> parts = WCSExplode(temp, L'/');
+			int value = curVars[pVarName].val;
+
+			ASSERT(parts.size() == 2);
+			newText += parts[0];
+			newText += wszLeftBracket;
+			newText += parts[1];
+			newText += wszRightBracket;
+
+			newText += wszSpace;
+			newText += wszEqual;
+			newText += wszSpace;
+			newText += to_wstring(value);
+
+			newText += wszCRLF;
+		}
+
+		this->lastArrayVars = curVars;
+	}
+
+	if (!newText.empty()) {
+		SetText(newText.c_str());
+	}
 	this->lastTurn = turn;
 }
 

--- a/drodrpg/DROD/VarMonitorEffect.h
+++ b/drodrpg/DROD/VarMonitorEffect.h
@@ -52,6 +52,7 @@ private:
 	UINT lastTurn;      //last turn var query was made
 
 	VARMAP lastVars;   //latest displayed var state
+	VARMAP lastArrayVars; //latest displayed array var state
 
 	CRoomWidget *pRoomWidget;
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5250,35 +5250,14 @@ void CCharacter::SaveCommands(CDbPackedVars& ExtraVars, const COMMANDPTR_VECTOR&
 UINT CCharacter::readBpUINT(const BYTE* buffer, UINT& index)
 //Deserialize 1..5 bytes --> UINT
 {
-	const BYTE *buffer2 = buffer + (index++);
-	ASSERT(*buffer2); // should not be zero (indicating a negative number)
-	UINT n = 0;
-	for (;;index++)
-	{
-		n = (n << 7) + *buffer2;
-		if (*buffer2++ & 0x80)
-			break;
-	}
-
-	return n - 0x80;
+	return CDbSavedGame::readBpUINT(buffer, index);
 }
 
 //*****************************************************************************
 void CCharacter::writeBpUINT(string& buffer, UINT n)
 //Serialize UINT --> 1..5 bytes
 {
-	int s = 7;
-	while ((n >> s) && s < 32)
-		s += 7;
-
-	while (s)
-	{
-		s -= 7;
-		BYTE b = BYTE((n >> s) & 0x7f);
-		if (!s)
-			b |= 0x80;
-		buffer.append(1, b);
-	}
+	CDbSavedGame::writeBpUINT(buffer, n);
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -63,6 +63,7 @@ using std::vector;
 class CSwordsman;
 struct HoldCharacter;
 class CDbHold;
+typedef map<UINT, map<int, int>> ScriptArrayMap;
 class CCharacter : public CPlayerDouble
 {
 public:
@@ -136,6 +137,8 @@ public:
 	WSTRING getPredefinedVar(const UINT varIndex) const;
 	UINT getPredefinedVarInt(const UINT varIndex) const;
 	WSTRING getPredefinedVarString(const UINT varIndex) const;
+
+	static int getArrayValue(const ScriptArrayMap& scriptArrays, const UINT& varId, const int arrayIndex);
 
 	virtual bool   IsAlive() const {return this->bAlive && !this->bReplaced;}
 	virtual bool   IsAggressive() const {return false;}
@@ -253,6 +256,7 @@ private:
 	bool setPredefinedVarInt(UINT varIndex, const UINT val, CCueEvents& CueEvents);
 	void setPredefinedVarString(UINT varIndex, const WSTRING val, CCueEvents& CueEvents);
 	void SetVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
+	void SetArrayVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 
 	void SyncCustomCharacterData(const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);
 	static void SyncCustomCharacterData(UINT& wLogicalIdentity, const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);

--- a/drodrpg/DRODLib/CharacterCommand.cpp
+++ b/drodrpg/DRODLib/CharacterCommand.cpp
@@ -113,6 +113,40 @@ bool CCharacterCommand::IsLogicalWaitCondition() const {
 	}
 }
 
+UINT CCharacterCommand::getVarID() const
+{
+	switch (command) {
+		case CC_VarSet:
+		case CC_WaitForVar:
+		case CC_ClearArrayVar:
+			return x;
+		case CC_VarSetAt:
+		case CC_ArrayVarSet:
+		case CC_ArrayVarSetAt:
+			return w;
+		default:
+			return 0;
+	}
+}
+
+void CCharacterCommand::setVarID(const UINT varID)
+{
+	switch (command) {
+		case CC_VarSet:
+		case CC_WaitForVar:
+		case CC_ClearArrayVar:
+			x = varID;
+			break;
+		case CC_VarSetAt:
+		case CC_ArrayVarSet:
+		case CC_ArrayVarSetAt:
+			w = varID;
+			break;
+		default:
+			break;
+	}
+}
+
 //*****************************************************************************
 bool addWithClamp(int& val, const int operand)
 //Multiplies two integers, ensuring the product doesn't overflow.

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -281,6 +281,9 @@ public:
 		CC_LogicalWaitXOR,      //Begins a logical wait block. Waits until exactly one condition is true.
 		CC_LogicalWaitEnd,      //Ends a logical wait block.
 		CC_ImageOverlay,        //Display image (w) with display strategy (text).
+		CC_ArrayVarSet,         //Set array var W with operation H using expressions, starting at index f
+		CC_ArrayVarSetAt,       //Remotely invoke ArrayVarSet with NPC at (x,y)
+		CC_ClearArrayVar,       //Reset array var X
 		CC_Count
 	};
 
@@ -310,6 +313,13 @@ public:
 		return command == CC_LogicalWaitEnd ||
 			IsLogicalWaitCommand() || IsLogicalWaitCondition();
 	}
+
+	// If the command has a variable reference, return it. Otherwise returns zero.
+	UINT getVarID() const;
+
+	// Set the variable reference for a command.
+	// Has no effect on commands that don't reference a variable.
+	void setVarID(const UINT varID);
 };
 
 class CDbMessageText;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1449,6 +1449,30 @@ void CCurrentGame::GetVarValues(VARMAP& vars)
 }
 
 //*****************************************************************************
+void CCurrentGame::GetArrayVarValues(VARMAP& vars)
+//Outputs a mapping of combined array name and index to value info for all array vars
+{
+	vars.clear();
+
+	for (ScriptArrayMap::const_iterator iter = this->scriptArrays.begin();
+		iter != this->scriptArrays.end(); ++iter) {
+		//Get var name.
+		const UINT wVarID = iter->first;
+		const string varName = UnicodeToUTF8(this->pHold->GetVarName(wVarID));
+		const map<int, int> array = iter->second;
+
+		for (map<int, int>::const_iterator arrayIter = array.begin(); arrayIter != array.end(); ++arrayIter) {
+			//Create a key for each entry in the format v[id]/[index]
+			const string key = varName + "/" + to_string(arrayIter->first);
+			VarMapInfo info;
+			info.bInteger = true;
+			info.val = arrayIter->second;
+			vars[key] = info;
+		}
+	}
+}
+
+//*****************************************************************************
 void CCurrentGame::GotoLevelEntrance(
 //Leaves the level and goes to the level with the indicated entrance.
 //

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -264,6 +264,7 @@ public:
 	WSTRING  getTextForInputCommandKey(InputCommands::DCMD id) const;
 	UINT     getVar(const UINT varIndex) const;
 	void     GetVarValues(VARMAP& vars);
+	void     GetArrayVarValues(VARMAP& vars);
 	int      getItemAmount(const UINT item) const;
 	int      getPlayerATK() const;
 	int      getPlayerDEF() const;

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -235,6 +235,7 @@ public:
 	bool     changingInventory(CCueEvents& CueEvents, const UINT type, const UINT newEquipment);
 	void     Clear(const bool bNewGame=true);
 	bool     CustomNPCExists(const UINT characterID) const;
+	void     DeserializeScriptArrays();
 	void     DestroyInventory(CCueEvents& CueEvents, const UINT type, const bool bShowStatChanges=true);
 	static void DiffVarValues(const VARMAP& vars1, const VARMAP& vars2, set<VarNameType>& diff);
 	bool     DoesPlayerAttackFirst() const;
@@ -400,6 +401,7 @@ public:
 	bool     bContinueCutScene;
 //	bool     bWaitedOnHotFloorLastTurn;
 	CDbPackedVars statsAtRoomStart; //stats when room was begun
+	map<UINT, map<int, int>> scriptArraysAtRoomStart;
 	CIDSet   roomsExploredAtRoomStart, roomsMappedAtRoomStart;
 	vector<CMoveCoordEx> ambientSounds;  //ambient sounds playing now
 	vector<SpeechLog> roomSpeech; //speech played up to this moment in the current room

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -851,6 +851,12 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_PuffExplosionEffect: strText = "Puff destroyed"; break;
 		case MID_EggSpawned: strText = "Roach egg spawned"; break;
 		case MID_ConstructSplatterEffect: strText = "Construct splatter"; break;
+		case MID_ArrayVarSet: strText = "Set array var"; break;
+		case MID_ArrayVarSetAt: strText = "Set array var at"; break;
+		case MID_ClearArrayVar: strText = "Clear array var"; break;
+		case MID_ArrayVarNameExpression: strText = "Variable Name/Expression"; break;
+		case MID_ArrayIndexLabel: strText = "Index"; break;
+		case MID_CantChangeVarType: strText = "Var type can't be changed between array and non-array"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbHolds.cpp
+++ b/drodrpg/DRODLib/DbHolds.cpp
@@ -1330,20 +1330,25 @@ void CDbHolds::CheckForVarRefs(
 			AddScriptVarRef(varMap, c.label.c_str(), pRoom, pCharacter, characterName);
 		break;
 	case CCharacterCommand::CC_VarSet:
+	case CCharacterCommand::CC_VarSetAt:
 	case CCharacterCommand::CC_WaitForVar:
+	case CCharacterCommand::CC_ArrayVarSet:
+	case CCharacterCommand::CC_ArrayVarSetAt:
+	case CCharacterCommand::CC_ClearArrayVar:
 	{
 		if (bScorepoints)
 			break;
 
+		UINT refVarID = c.getVarID();
 		const WCHAR* pVarName;
 		WSTRING wstr;
-		if (c.x >= (UINT)ScriptVars::FirstPredefinedVar)
+		if (refVarID >= (UINT)ScriptVars::FirstPredefinedVar)
 		{
-			wstr = ScriptVars::getVarNameW(ScriptVars::Predefined(c.x));
+			wstr = ScriptVars::getVarNameW(ScriptVars::Predefined(refVarID));
 			pVarName = wstr.c_str();
 		}
 		else {
-			pVarName = pHold->GetVarName(c.x);
+			pVarName = pHold->GetVarName(refVarID);
 		}
 
 		AddScriptVarRef(varMap, pVarName, pRoom, pCharacter, characterName);
@@ -1373,7 +1378,7 @@ void CDbHolds::CheckForVarRefs(
 			default: break;
 			}
 		}
-		else {
+		else if (c.command == CCharacterCommand::CC_WaitForVar) {
 			switch (c.y)
 			{
 			case ScriptVars::Equals:
@@ -1398,6 +1403,20 @@ void CDbHolds::CheckForVarRefs(
 		}
 	}
 	break;
+	case CCharacterCommand::CC_WaitForExpression:
+	{
+		//Search for a variable name in the expression.
+		if (!c.label.empty())
+		{
+			//parse expression
+			ScriptVars::Predefined varID = ScriptVars::parsePredefinedVar(c.label);
+			if (varID != ScriptVars::P_NoVar || pHold->GetVarID(c.label.c_str()))
+			{
+				//Mark reference to variable.
+				AddScriptVarRef(varMap, c.label.c_str(), pRoom, pCharacter, characterName);
+			}
+		}
+	}
 	default: break;
 	}
 }

--- a/drodrpg/DRODLib/DbHolds.h
+++ b/drodrpg/DRODLib/DbHolds.h
@@ -94,6 +94,7 @@ public:
 	UINT        GetVarID(const WCHAR* pwszName) const;
 	const WCHAR* GetVarName(const UINT dwVarID) const;
 	void        InsertLevel(CDbLevel *pLevel);
+	bool        IsArrayVar(UINT varID) const { return this->arrayScriptVars.count(varID); }
 	static bool IsVarNameGoodSyntax(const WCHAR* pName);
 	bool        Load(const UINT dwHoldID, const bool bQuick=false);
 	CDbHold*    MakeCopy();
@@ -174,6 +175,8 @@ private:
 	vector<UINT> deletedTextIDs;   //message text IDs to be deleted on Update
 	vector<UINT> deletedSpeechIDs; //speech IDs to be deleted on Update
 	vector<UINT> deletedDataIDs;   //data IDs to be deleted on Update
+
+	map<UINT, WSTRING> arrayScriptVars;
 };
 
 //******************************************************************************************

--- a/drodrpg/DRODLib/DbSavedGames.cpp
+++ b/drodrpg/DRODLib/DbSavedGames.cpp
@@ -1225,6 +1225,41 @@ void CDbSavedGame::ClearDeadMonsters()
 	this->DeadMonsters.clear();
 }
 
+//*****************************************************************************
+UINT CDbSavedGame::readBpUINT(const BYTE* buffer, UINT& index)
+//Deserialize 1..5 bytes --> UINT
+{
+	const BYTE* buffer2 = buffer + (index++);
+	ASSERT(*buffer2); // should not be zero (indicating a negative number)
+	UINT n = 0;
+	for (;; index++)
+	{
+		n = (n << 7) + *buffer2;
+		if (*buffer2++ & 0x80)
+			break;
+	}
+
+	return n - 0x80;
+}
+
+//*****************************************************************************
+void CDbSavedGame::writeBpUINT(string& buffer, UINT n)
+//Serialize UINT --> 1..5 bytes
+{
+	int s = 7;
+	while (s < 32 && (n >> s))
+		s += 7;
+
+	while (s)
+	{
+		s -= 7;
+		BYTE b = BYTE((n >> s) & 0x7f);
+		if (!s)
+			b |= 0x80;
+		buffer.append(1, b);
+	}
+}
+
 //
 //CDbSavedGame private methods.
 //

--- a/drodrpg/DRODLib/DbSavedGames.cpp
+++ b/drodrpg/DRODLib/DbSavedGames.cpp
@@ -1187,6 +1187,7 @@ void CDbSavedGame::Clear(
 	this->wStartRoomX=this->wStartRoomY=this->wStartRoomO=0;
 	this->wStartRoomAppearance = defaultPlayerType(); //use default value
 	this->bStartRoomSwordOff = false;
+	this->scriptArrays.clear();
 	this->eType = ST_Unknown;
 
 	this->dwPlayerID = 0L;
@@ -1403,6 +1404,41 @@ const
 }
 
 //*****************************************************************************
+void CDbSavedGame::SerializeScriptArrays()
+//Converts script arrays into byte buffers that can be stored in CDbPackedVars
+//Note: deserialization is done in CCurrentGame, as it requires hold information
+{
+	if (this->scriptArrays.empty()) {
+		return;
+	}
+
+	for (ScriptArrayMap::const_iterator it = this->scriptArrays.cbegin();
+		it != this->scriptArrays.cend(); ++it) {
+		const map<int, int> arrayMap = it->second;
+		string buffer;
+
+		UINT size = 0;
+		for (map<int, int>::const_iterator arrayIt = arrayMap.cbegin();
+			arrayIt != arrayMap.cend(); ++arrayIt) {
+			if (arrayIt->second == 0) {
+				continue; //save space by skipping zero-value entries
+			}
+
+			writeBpUINT(buffer, (UINT)arrayIt->first);
+			writeBpUINT(buffer, (UINT)arrayIt->second);
+			++size;
+		}
+
+		string sizeBuffer;
+		writeBpUINT(sizeBuffer, size);
+
+		string varName("v");
+		varName += std::to_string(it->first);
+		this->stats.SetVar(varName.c_str(), (sizeBuffer + buffer).c_str());
+	}
+}
+
+//*****************************************************************************
 bool CDbSavedGame::UpdateNew()
 //Add new SavedGames record to database.
 {
@@ -1514,6 +1550,8 @@ bool CDbSavedGame::UpdateExisting()
 	c4_View MonstersView;
 	SaveMonsters(MonstersView, this->pMonsterListAtRoomStart);
 
+	SerializeScriptArrays();
+
 	//Get stats into a buffer that can be written to db.
 	UINT dwStatsSize;
 	BYTE *pbytStatsBytes = this->stats.GetPackedBuffer(dwStatsSize);
@@ -1600,6 +1638,7 @@ bool CDbSavedGame::SetMembers(
 	this->moves = Src.moves;
 
 	this->stats = Src.stats;
+	this->scriptArrays = Src.scriptArrays;
 	this->wVersionNo = Src.wVersionNo;
 	this->checksumStr = Src.checksumStr;
 

--- a/drodrpg/DRODLib/DbSavedGames.h
+++ b/drodrpg/DRODLib/DbSavedGames.h
@@ -125,6 +125,10 @@ public:
 			char* const str, CImportInfo &info);
 	virtual bool   Update();
 
+	//Read/write UINT and UINT shaped types to/from buffer
+	static UINT  readBpUINT(const BYTE* buffer, UINT& index);
+	static void  writeBpUINT(string& buffer, UINT n);
+
 	UINT     dwSavedGameID;
 	UINT     dwRoomID;
 	UINT     dwPlayerID;

--- a/drodrpg/DRODLib/DbSavedGames.h
+++ b/drodrpg/DRODLib/DbSavedGames.h
@@ -167,6 +167,9 @@ public:
 	CMonster *pMonsterList, *pMonsterListAtRoomStart; //global scripts and custom equipment
 	vector<CMonster*> DeadMonsters; //deactivated global scripts and custom equipment
 
+	typedef map<UINT, map<int, int>> ScriptArrayMap;
+	ScriptArrayMap scriptArrays; //unpacked hold array var values
+
 	//Version info.
 	UINT     wVersionNo;
 	string   checksumStr;
@@ -183,6 +186,7 @@ private:
 	void     SaveEntrancesExplored(c4_View &EntrancesExploredView) const;
 	void     SaveExploredRooms(c4_View &ExploredRoomsView) const;
 	void     SaveMonsters(c4_View &MonstersView, CMonster *pMonsterList) const;
+	void     SerializeScriptArrays();
 	bool     SetMembers(const CDbSavedGame &Src);
 	bool     UpdateExisting();
 	bool     UpdateNew();

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -390,6 +390,23 @@ Predefined ScriptVars::parsePredefinedVar(const string& str)
 }
 
 //*****************************************************************************
+bool ScriptVars::IsCharacterArrayVar(const WSTRING& wstr)
+{
+	return IsCharacterArrayVar(wstr.c_str());
+}
+
+bool ScriptVars::IsCharacterArrayVar(const WCHAR* wstr)
+{
+	return wstr && wstr[0] == '#';
+}
+
+//*****************************************************************************
+bool ScriptVars::IsIndexInArrayRange(const int index)
+{
+	return abs(index) <= 50000;
+}
+
+//*****************************************************************************
 PrimitiveType ScriptVars::parsePrimitive(const WSTRING& wstr)
 {
 	const string str = UnicodeToUTF8(wstr);

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -195,6 +195,11 @@ namespace ScriptVars
 	UINT getPrimitiveRequiredParameters(PrimitiveType eType);
 	PrimitiveType parsePrimitive(const WSTRING& wstr);
 
+	bool IsCharacterArrayVar(const WSTRING& wstr);
+	bool IsCharacterArrayVar(const WCHAR* wstr);
+
+	bool IsIndexInArrayRange(const int index);
+
 	//All predefined vars.
 	extern const char predefinedVarTexts[PredefinedVarCount][16];
 	extern const UINT predefinedVarMIDs[PredefinedVarCount];

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -216,23 +216,25 @@ interacts with its environment.</p>
       will continue execution if the user selects this choice.
       Up to nine answer options are supported for a given Question.  Any
       additional options are ignored.</li>
-  <li><a name="setvar"><b>Set var</b></a> - In addition to
+  <li>
+      <a name="setvar"><b>Set var</b></a> - In addition to
       <a href="#predefinedvars">predefined variables</a>,
-	  each hold you create contains a set
+      each hold you create contains a set
       of zero or more variables, named by you.  Use these variables to track
       persistent game state information across rooms during play. To add a variable
-      to a hold, type its name into the uppermost text box and click "Add".
-	  Variable names must begin with a letter and not contain any punctuation
-	  except underscore ('_').  
+      to a hold, type its name into the uppermost text box and click "Add".<br />
+      <u>Syntax</u>: Variable names must begin with a letter or hash (#) and not contain any punctuation
+      except underscore ('_').<br />
+      <u>Arrays</u>: Starting a variable name with a hash (#) configures it as an array variable. See <a href="scriptarray.html">Script arrays</a> for more information.<br />
       To permanently remove a hold variable, select it from the list box on the
       left and click "Remove".  Note that this removes the variable completely
       from the hold and all NPC scripts that use it, not just from this
       particular script.<br />
-      <a name="varops">Select</a> a hold variable from the list, choose an
+      <u>Modifying variables</u>: <a name="varops">Select</a> a hold variable from the list, choose an
       operation and a value. Variables may either store an integer or text. If
       the operation you specify is "Assign text" or "Add text", the variable you
       select will be set to store the text you provide. You may also reference
-	  other variables to insert into the given text.  For operations dealing
+      other variables to insert into the given text.  For operations dealing
       with numbers, if you provide the name of another variable, its value will
       be used (invalid names will be considered a value of 0). Otherwise, the
       number you provide is used. Use the text box on top to specify the text
@@ -241,11 +243,11 @@ interacts with its environment.</p>
       will store a number.<br />
       <a name="varsintext"><u>Using vars in text</u></a>:
       In variable text assignments,
-	  <a href="#autosave">Autosave</a>, <a href="#speech">Speech</a>, <a href="#question">Questions</a>
+      <a href="#autosave">Autosave</a>, <a href="#speech">Speech</a>, <a href="#question">Questions</a>
       (see below), level entrance texts, and scroll text,
       type "$&lt;var name&gt;$" to insert the
       current value of the variable you name at this point in the text.
-	  Type "$\n$" to skip to the next line of text.<br />
+      Type "$\n$" to skip to the next line of text.<br />
       <a name="varref"><u>Comprehensive variable reference list</u></a>:
       In the <a href="editroom.html">Room Editor Screen</a>, press F2 to output
       a comprehensive list of hold variables to the clipboard (use the paste
@@ -257,7 +259,8 @@ interacts with its environment.</p>
       Press Ctrl-F7 while playing to turn on and off the variable monitor.
       Whenever a script changes a hold variable, you will be notified onscreen.
       This only works while playtesting, playing a hold you authored, or playing
-      a CaravelNet hold in beta.</li>
+      a CaravelNet hold in beta.
+  </li>
   <li><a name="setvarat"><b>Set var at</b></a> - Allows the <a href="#setvar">Set var</a> command to be invoked with an NPC on another tile. All assignment and parsing will occur as if the target NPC called the Set var command. Thus, its local variables will be used, allowing them to be written or read remotely. This command can also be used an <a href="#if">If</a> condition. The condition is satisfied if the command successfully invokes a variable assignment on an NPC in the target square. Hint: Use this for scripts that rely on the result of a remote variable assignment.
   </li>
   <li><a name="setmonstervar"><b>Set monster var</b></a> - Modify a
@@ -1112,6 +1115,7 @@ Certain commands with time duration, marked above, may be optionally prefixed wi
 
 <hr />
 <a href="character.html">Character Scripting</a><br />
+<a href="scriptarray.html">Script arrays</a><br/>
 <a href="editroom.html">Room Editor</a><br />
 <a href="editselect.html">Level Editor</a><br />
 <a href="contents.html">Contents</a><br />

--- a/drodrpg/Data/Help/1/scriptarray.html
+++ b/drodrpg/Data/Help/1/scriptarray.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <title>Help for Deadly Rooms of Death</title>
+</head>
+<body bgcolor="#FFFFFF">
+<img src="images/drodlogo.jpg" />
+<hr />
+<h3><u>Using Arrays in Scripts</u></h3>
+    <p> Script variables can be configured as arrays by starting the variable name with a hash symbol (#).
+    Once a variable is created, you cannot change whether it is an array variable. Array variables can only store integer values, not text.</p>
+    <p> An array variable is effectively a set of index-value pairs, where each index has a value (defaulting to 0). Therefore, an arbitary number of values can be stored under a single variable name.
+    In character scripts, all array indexes are integers, however unlike many programming languages, arrays allow negative indexes to be used.</p>
+
+    <p><u>Setting array values</u></p>
+    <p>Values can be set in an array variable using the <b>Set array var</b> command. The value at a specified index can be set either to an integer value, or an expression that will resolve to such a value.</p>
+    <p>Additionally, multiple array values can be set by providing multiple values or expressions, separated by a semi-colon (;). The first value will be assigned at the specified index,
+    and each subsequent value will be assigned to the next index. For example, if the specified index is 3, the first value is assigned to the at position 3, the second value to position 4, and so on.</p>
+    <p>The <b>Set array var at</b> command works in the same way, but allows for remote variable assignment, as with <a href="script.html#setvarat">Set var at</a>.</p>
+    <p>Values cannot be set for an index that is less than -50,000 or above 50,000.</p>
+
+    <p><u>Querying array values</u></p>
+    <p>Like any other script variable, an array value can be used anywhere an integer value is expected. 
+    The one difference is that the variable name must be followed by a pair of square brackets ([]) containing an index value. This can be a numeric value or an expression that resolves to such a value.
+    If an index that has not been set is accessed, a default value of 0 is returned.</p>
+
+    <p><u>Examples of valid array expressions</u></p>
+    <ul>
+        <li>#Array[2]</li>
+        <li>#Array[-1]</li>
+        <li>#Array[_X]</li>
+        <li>#Array[_MyY * 2]</li>
+    </ul>
+
+    <p><u>Clearing arrays</u></p>
+    <p>The <b>Clear array var</b> command can be used to reset all values in an array variable to zero.</p>
+<hr />
+<a href="script.html">Command list</a><br />
+<a href="character.html">Character Scripting</a><br />
+</body>
+</html>

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1583,6 +1583,12 @@ enum MID_CONSTANT {
   MID_PuffExplosionEffect = 1934,
   MID_EggSpawned = 1935,
   MID_ConstructSplatterEffect = 1936,
+  MID_ArrayVarSet = 1937,
+  MID_ArrayVarSetAt = 1938,
+  MID_ClearArrayVar = 1939,
+  MID_ArrayVarNameExpression = 1940,
+  MID_ArrayIndexLabel = 1941,
+  MID_CantChangeVarType = 1942,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,


### PR DESCRIPTION
Adds new functionality to scripts by allowing arrays. A script variable starting with a `#` becomes an array. To avoid weird issues with serialization, once a variable is created, it can't be renamed in a way that changes its "arrayness".

Internally, arrays are technically maps, as they can be non-continuous. Negative indexes are also supported, although this is not unheard of in some languages.

Arrays are serialized back to the packed stats object when saving. The number of active items in the array is saved as the first value, followed by a sequence of key/value pairs. The `readBpUINT` and `writeBpUINT` functions have been moved to `CDbSavedGame` to allow them to reused for this. To save space, values of zero are not packed when serializing (as getting an int value from a map will return zero is no value is assigned to that key).

New script commands have been added to write to arrays. Reading from arrays is handled by expression parsing functions.

(This is #587 for DROD RPG. Since RPG does not have local character variables, support for local arrays has not been added.)