### PR TITLE
RPG: Fix Set Appearance for the third time

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5429,7 +5429,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 
 	this->wIdentity = this->wLogicalIdentity; //by default, these are the same
 
-	this->wInitialIdentity = vars.GetVar(initialIdStr, this->wLogicalIdentity); // Won't exist in earlier versions of the engine, so assume current identity
+	this->wInitialIdentity = vars.GetVar(initialIdStr, this->wLogicalIdentity); // Note the default is wLogicalIdentity
 
 	this->bVisible = vars.GetVar(visibleStr, this->bVisible);
 	if (!this->bVisible)

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -219,6 +219,7 @@ public:
 	CIDSet answerOptions;   //optional answers supplied to a Question command
 	UINT  dwScriptID;       //charater script ref
 	UINT  wIdentity;        //monster type
+	UINT  wInitialIdentity; //initial identity in case it changes e.g. Set Appearance command
 	UINT  wLogicalIdentity; //logical ID (might be a hold custom character type)
 	bool  bVisible;         //on screen in room, or not
 	bool  bInvisibleInspectable; //appears in tooltip when invisible

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -2771,21 +2771,6 @@ CCharacter* CDbRoom::GetCharacterWithScriptID(const UINT scriptID)
 	return NULL; //not found
 }
 
-//*****************************************************************************
-CCharacter* CDbRoom::GetCharacterFromExploredRoomWithScriptID(ExploredRoom* pExpRoom, const UINT scriptID)
-//Returns: character monster with indicated (unique) scriptID, or NULL if not found
-{
-	for (CMonster* pMonster = pExpRoom->pMonsterList; pMonster != NULL;
-		pMonster = pMonster->pNext)
-		if (pMonster->wType == M_CHARACTER)
-		{
-			CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
-			if (pCharacter->dwScriptID == scriptID)
-				return pCharacter; //found it
-		}
-
-	return NULL; //not found
-}
 
 //*****************************************************************************
 bool CDbRoom::HasClosedDoors() const
@@ -9539,7 +9524,7 @@ void CDbRoom::SetMonstersFromExploredRoomData(
 			{
 				//Find original NPC containing the script for this saved character.
 				CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
-				CCharacter *pOrigNPC = GetCharacterFromExploredRoomWithScriptID(pExpRoom, pCharacter->dwScriptID);
+				CCharacter *pOrigNPC = GetCharacterWithScriptID(pCharacter->dwScriptID);
 				if (pOrigNPC)
 				{
 					//Add the script data to the NPC's state, saved in the explored room data.

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -242,7 +242,6 @@ public:
 	void           GetAllDoorSquares(const UINT wX, const UINT wY, CCoordSet& squares,
 			const UINT tile, const CCoordSet* pIgnoreSquares=NULL) const;
 	CCharacter*    GetCharacterWithScriptID(const UINT scriptID);
-	CCharacter*    GetCharacterFromExploredRoomWithScriptID(ExploredRoom* pExpRoom, const UINT scriptID);
 	void           GetConnectedRegionsAround(const UINT wX, const UINT wY,
 			const CTileMask &tileMask, vector<CCoordSet>& regions,
 			const CCoordSet* pIgnoreSquares=NULL, const CCoordSet* pRegionMask=NULL) const;


### PR DESCRIPTION
Third attempt at fixing https://forum.caravelgames.com/viewtopic.php?TopicID=40625

Undoes PR #616 , which was working around the real issue and broke all saved games. Characters now store their initial identity, which stays the same even after using Set Appearance. When recovering default character scripts, the initial identity is used. If the initial identity does not exist (because you're loading an old saved game, etc.) then the current identity is assumed.