### PR TITLE
More script queries

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -192,6 +192,7 @@ const UINT TAG_ARRAYVAR_REMOVE = 866;
 const UINT TAG_ARRAYVAR_TEXTLABEL = 865;
 const UINT TAG_ITEM_GROUP_LISTBOX = 864;
 const UINT TAG_ENTITY_LISTBOX = 863;
+const UINT TAG_PLAYER_STATE_LISTBOX = 862;
 
 const UINT MAX_TEXT_LABEL_SIZE = 100;
 
@@ -439,6 +440,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	, pArrayVarListBox(NULL), pArrayVarOpListBox(NULL)
 	, pWaitFlagsListBox(NULL), pImperativeListBox(NULL), pBuildItemsListBox(NULL)
 	, pBuildMarkerListBox(NULL), pWaitForItemsListBox(NULL), pItemGroupListBox(NULL)
+	, pPlayerStateListBox(NULL)
 	, pCharNameText(NULL), pCharListBox(NULL)
 	, pDisplayFilterListBox(NULL)
 	, pWorldMapIconFlagListBox(NULL)
@@ -1965,6 +1967,15 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pEntityListBox->SortAlphabetically(true);
 	this->pAddCommandDialog->AddWidget(this->pEntityListBox);
 
+	this->pPlayerStateListBox = new CListBoxWidget(TAG_PLAYER_STATE_LISTBOX,
+		X_GRAPHICLISTBOX2, Y_GRAPHICLISTBOX2, CX_ONOFFLISTBOX, CY_DISPLAYFILTER_LISTBOX);
+	this->pPlayerStateListBox->AddItem(ScriptFlag::PS_Invisible, g_pTheDB->GetMessageText(MID_Invisible));
+	this->pPlayerStateListBox->AddItem(ScriptFlag::PS_Hasted, g_pTheDB->GetMessageText(MID_Hasted));
+	this->pPlayerStateListBox->AddItem(ScriptFlag::PS_Powered, g_pTheDB->GetMessageText(MID_Powered));
+	this->pPlayerStateListBox->AddItem(ScriptFlag::PS_Hiding, g_pTheDB->GetMessageText(MID_Hiding));
+	this->pAddCommandDialog->AddWidget(this->pPlayerStateListBox);
+	this->pPlayerStateListBox->SelectLine(0);
+
 	this->pGlobalScriptListBox = new CListBoxWidget(TAG_GLOBALSCRIPTLISTBOX,
 			X_GLOBALSCRIPTLISTBOX, Y_GLOBALSCRIPTLISTBOX, CX_GLOBALSCRIPTLISTBOX, CY_GLOBALSCRIPTLISTBOX, true);
 	this->pAddCommandDialog->AddWidget(this->pGlobalScriptListBox);
@@ -2123,11 +2134,11 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pPlayerBehaviorStateListBox = new CListBoxWidget(TAG_PLAYERBEHAVESTATE_LIST,
 		PLAYERBEHAVELISTBOX_X, PLAYERBEHAVESTATELISTBOX_Y, PLAYERBEHAVELISTBOX_CX, PLAYERBEHAVESTATELISTBOX_CY);
 	this->pAddCommandDialog->AddWidget(this->pPlayerBehaviorStateListBox);
-	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Default, L"Default");
-	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_On, L"On");
-	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Off, L"Off");
-	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Powered, L"Powered");
-	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Unpowered, L"Unpowered");
+	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Default, g_pTheDB->GetMessageText(MID_Default));
+	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_On, g_pTheDB->GetMessageText(MID_On));
+	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Off, g_pTheDB->GetMessageText(MID_Off));
+	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Powered, g_pTheDB->GetMessageText(MID_Powered));
+	this->pPlayerBehaviorStateListBox->AddItem(PlayerBehaviorState::PBS_Unpowered, g_pTheDB->GetMessageText(MID_Unpowered));
 
 	//OK/cancel buttons.
 	CButtonWidget *pOKButton = new CButtonWidget(
@@ -3783,6 +3794,12 @@ const
 		}
 		break;
 
+		case CCharacterCommand::CC_WaitForPlayerState:
+			wstr += this->pPlayerStateListBox->GetTextForKey(command.y);
+			wstr += wszSpace;
+			wstr += this->pOnOffListBox2->GetTextForKey(command.x);
+		break;
+
 		case CCharacterCommand::CC_BuildMarker:
 		case CCharacterCommand::CC_WaitForBuildType:
 		case CCharacterCommand::CC_WaitForNotBuildType:
@@ -4982,6 +4999,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForPlayerToMove, g_pTheDB->GetMessageText(MID_WaitForPlayerToMove));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForPlayerToTouchMe, g_pTheDB->GetMessageText(MID_WaitForPlayerToTouchMe));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForSomeoneToPushMe, g_pTheDB->GetMessageText(MID_WaitForSomeoneToPushMe));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForPlayerState, g_pTheDB->GetMessageText(MID_WaitForPlayerState));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForTurn, g_pTheDB->GetMessageText(MID_WaitForTurn));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForVar, g_pTheDB->GetMessageText(MID_WaitForVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForExpression, g_pTheDB->GetMessageText(MID_WaitForExpression));
@@ -5822,7 +5840,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 {
 	//Code is structured in this way to facilitate quick addition of
 	//additional action parameters.
-	static const UINT NUM_WIDGETS = 65;
+	static const UINT NUM_WIDGETS = 66;
 	static const UINT widgetTag[NUM_WIDGETS] = {
 		TAG_WAIT, TAG_EVENTLISTBOX, TAG_DELAY, TAG_SPEECHTEXT,
 		TAG_SPEAKERLISTBOX, TAG_MOODLISTBOX, TAG_ADDSOUND, TAG_TESTSOUND, TAG_DIRECTIONLISTBOX,
@@ -5843,7 +5861,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_MOVETYPELISTBOX, TAG_IGNOREFLAGSLISTBOX, TAG_COLOR_LISTBOX, TAG_WEAPON_LISTBOX2,
 		TAG_VARCOMPLIST2, TAG_ORBAGENTLIST, TAG_PLAYERBEHAVE_LIST, TAG_PLAYERBEHAVESTATE_LIST,
 		TAG_ARRAYVARLIST, TAG_ARRAYVAROPLIST, TAG_ARRAYVAR_REMOVE, TAG_ITEM_GROUP_LISTBOX,
-		TAG_ENTITY_LISTBOX
+		TAG_ENTITY_LISTBOX, TAG_PLAYER_STATE_LISTBOX
 	};
 
 	static const UINT NO_WIDGETS[] =    {0};
@@ -5900,6 +5918,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT ARRAYVARSET[] = { TAG_VARNAMETEXTINPUT, TAG_VARADD, TAG_ARRAYVAR_REMOVE, TAG_ARRAYVARLIST, TAG_ARRAYVAROPLIST, TAG_VARVALUE, 0 };
 	static const UINT CLEARARRAYVAR[] = { TAG_ARRAYVARLIST, 0};
 	static const UINT WAITFORITEMGROUP[] = { TAG_ITEM_GROUP_LISTBOX, 0 };
+	static const UINT WAITFORPLAYERSTATE[] = { TAG_PLAYER_STATE_LISTBOX, TAG_ONOFFLISTBOX2, 0 };
 
 	static const UINT* activeWidgets[CCharacterCommand::CC_Count] = {
 		NO_WIDGETS,         //CC_Appear
@@ -6014,7 +6033,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		ARRAYVARSET,        //CC_ArrayVarSetAt
 		CLEARARRAYVAR,      //CC_ClearArrayVar
 		WAITFORITEMGROUP,   //CC_WaitForItemGroup
-		WAITFORITEMGROUP    //CC_WaitForNotItemGroup
+		WAITFORITEMGROUP,   //CC_WaitForNotItemGroup
+		WAITFORPLAYERSTATE  //CC_WaitForPlayerState
 	};
 
 	static const UINT NUM_LABELS = 34;
@@ -6175,6 +6195,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_ClearArrayVar
 		NO_LABELS,          //CC_WaitForItemGroup
 		NO_LABELS,          //CC_WaitForNotItemGroup
+		NO_LABELS,          //CC_WaitForPlayerState
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -6623,6 +6644,12 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 
 			QueryXY();
 		}
+		break;
+
+		case CCharacterCommand::CC_WaitForPlayerState:
+			this->pCommand->y = this->pPlayerStateListBox->GetSelectedItem();
+			this->pCommand->x = this->pOnOffListBox2->GetSelectedItem();
+			AddCommand();
 		break;
 
 		case CCharacterCommand::CC_BuildMarker:
@@ -7635,6 +7662,11 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 			this->pOnOffListBox3->SelectItem(this->pCommand->h);
 		break;
 
+		case CCharacterCommand::CC_WaitForPlayerState:
+			this->pPlayerStateListBox->SelectItem(this->pCommand->y);
+			this->pOnOffListBox2->SelectItem(this->pCommand->x);
+		break;
+
 		case CCharacterCommand::CC_VarSet:
 		case CCharacterCommand::CC_VarSetAt:
 		case CCharacterCommand::CC_WaitForVar:
@@ -8352,6 +8384,11 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 		parseNumber(pCommand->w); skipComma;
 		parseNumber(pCommand->h);
 	}
+	break;
+
+	case CCharacterCommand::CC_WaitForPlayerState:
+		parseNumber(pCommand->y); skipComma;
+		parseNumber(pCommand->x); skipComma;
 	break;
 
 	case CCharacterCommand::CC_GetNaturalTarget:
@@ -9245,6 +9282,11 @@ WSTRING CCharacterDialogWidget::toText(
 		concatNumWithComma(c.w);
 		concatNum(c.h);
 	}
+	break;
+
+	case CCharacterCommand::CC_WaitForPlayerState:
+		concatNumWithComma(c.y);
+		concatNumWithComma(c.x);
 	break;
 
 	case CCharacterCommand::CC_AmbientSoundAt:

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5630,6 +5630,8 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_SPAWNCYCLE, g_pTheDB->GetMessageText(MID_SpawnCycle));
 	this->pVarListBox->AddItem(ScriptVars::P_SPAWNCYCLE, g_pTheDB->GetMessageText(MID_SpawnCycleFast));
 
+	this->pVarListBox->AddItem(ScriptVars::P_COMBO, g_pTheDB->GetMessageText(MID_VarCombo));
+
 	this->pVarListBox->AddItem(ScriptVars::P_THREATCLOCK, g_pTheDB->GetMessageText(MID_VarThreatClock));
 	this->pVarListBox->AddItem(ScriptVars::P_LEVELNAME, g_pTheDB->GetMessageText(MID_VarLevelName));
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_X, g_pTheDB->GetMessageText(MID_VarRoomX));

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -1162,7 +1162,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const int X_WAITFLAGSLISTBOX = X_MUSICLISTBOX;
 	static const int Y_WAITFLAGSLISTBOX = Y_ONOFFLISTBOX + CY_ONOFFLISTBOX + CY_SPACE;
 	static const UINT CX_WAITFLAGSLISTBOX = 100;
-	static const UINT CY_WAITFLAGSLISTBOX = 9*LIST_LINE_HEIGHT+4;
+	static const UINT CY_WAITFLAGSLISTBOX = 10*LIST_LINE_HEIGHT+4;
 
 	//Widgets and for variable handling commands.
 	static const int X_VARTEXTLABEL = X_WAITLABEL;
@@ -1303,7 +1303,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const UINT IGNOREFLAGSLISTBOX_X = MOVETYPELISTBOX_X + MOVETYPELISTBOX_CX + CX_SPACE;
 	static const UINT IGNOREFLAGSLISTBOX_Y = MOVETYPELISTBOX_Y;
 	static const UINT IGNOREFLAGSLISTBOX_CX = CX_WAITFLAGSLISTBOX;
-	static const UINT IGNOREFLAGSLISTBOX_CY = CY_WAITFLAGSLISTBOX;
+	static const UINT IGNOREFLAGSLISTBOX_CY = 9 * LIST_LINE_HEIGHT + 4;
 
 	static const UINT IGNOREWEAPONSLABEL_X = MOVETYPELISTBOX_X;
 	static const UINT IGNOREWEAPONSLABEL_Y = MOVETYPELISTBOX_Y + MOVETYPELISTBOX_CY + CY_SPACE;
@@ -1673,6 +1673,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pWaitFlagsListBox->AddItem(ScriptFlag::SLAYER, g_pTheDB->GetMessageText(MID_Slayer2));
 	this->pWaitFlagsListBox->AddItem(ScriptFlag::BEETHRO, g_pTheDB->GetMessageText(MID_Beethro));
 	this->pWaitFlagsListBox->AddItem(ScriptFlag::STALWART, g_pTheDB->GetMessageText(MID_Stalwart));
+	this->pWaitFlagsListBox->AddItem(ScriptFlag::REQUIRED, g_pTheDB->GetMessageText(MID_RequiredMonster));
 	this->pWaitFlagsListBox->SelectLine(0);
 
 	this->pIgnoreFlagsListBox = new CListBoxWidget(TAG_IGNOREFLAGSLISTBOX,

--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -204,7 +204,7 @@ private:
 	CListBoxWidget *pVarListBox, *pVarOpListBox, *pVarCompListBox, *pWaitFlagsListBox,
 		*pImperativeListBox, *pBuildItemsListBox, *pBuildMarkerListBox, *pWaitForItemsListBox,
 		*pNaturalTargetTypesListBox, *pBehaviorListBox, *pRemainsListBox, *pVarCompListBox2,
-		*pArrayVarListBox, *pArrayVarOpListBox, *pItemGroupListBox;
+		*pArrayVarListBox, *pArrayVarOpListBox, *pItemGroupListBox, *pPlayerStateListBox;
 	CTextBoxWidget *pCharNameText;
 	CListBoxWidget *pCharListBox;
 	CListBoxWidget *pDisplayFilterListBox;

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4477,6 +4477,11 @@ bool CCharacter::IsEntityAt(
 			px + pw, py + ph, M_STALWART2, true))
 			return true;
 	}
+	if ((pflags & ScriptFlag::REQUIRED) != 0)
+	{
+		if (room.IsRequiredMonsterInRect(px, py, px + pw, py + ph))
+			return true;
+	}
 
 	return false;
 }

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3642,6 +3642,15 @@ void CCharacter::Process(
 			}
 			break;
 
+			case CCharacterCommand::CC_WaitForPlayerState:
+			{
+				if (!IsPlayerState(command, player))
+					STOP_COMMAND;
+
+				bProcessNextCommand = true;
+			}
+			break;
+
 			case CCharacterCommand::CC_LogicalWaitAnd:
 			{
 				//Wait until all conditions are true.
@@ -4976,6 +4985,26 @@ bool CCharacter::IsPlayerFacing(
 }
 
 //*****************************************************************************
+bool CCharacter::IsPlayerState(const CCharacterCommand& command, const CSwordsman& player) const
+{
+	UINT px;
+	getCommandX(command, px);
+	ScriptFlag::PlayerState state = (ScriptFlag::PlayerState)command.y;
+	bool active;
+
+	switch (state)
+	{
+		case ScriptFlag::PS_Invisible: active = player.bIsInvisible; break;
+		case ScriptFlag::PS_Hasted: active = player.bIsHasted; break;
+		case ScriptFlag::PS_Powered: active = player.bCanGetItems; break;
+		case ScriptFlag::PS_Hiding: active = player.bIsHiding; break;
+		default: active = false; break;
+	}
+
+	return (active == px);
+}
+
+//*****************************************************************************
 // Returns: did the player input the specified command (x)
 bool CCharacter::DidPlayerInput(
 	const CCharacterCommand& command,
@@ -5675,6 +5704,10 @@ bool CCharacter::EvaluateConditionalCommand(
 		case CCharacterCommand::CC_WaitForNotItemGroup:
 		{
 			return !IsTileGroupAt(command);
+		}
+		case CCharacterCommand::CC_WaitForPlayerState:
+		{
+			return IsPlayerState(command, pGame->swordsman);
 		}
 		default:
 		{

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -478,6 +478,7 @@ UINT CCharacter::getPredefinedVarInt(const UINT varIndex) const
 		case (UINT)ScriptVars::P_PLAYER_LOCAL_WEAPON:
 		case (UINT)ScriptVars::P_INPUT:
 		case (UINT)ScriptVars::P_INPUT_DIRECTION:
+		case (UINT)ScriptVars::P_COMBO:
 			return this->pCurrentGame->getVar(varIndex);
 
 		default: ASSERT(!"GetVar val not supported"); return 0;

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4075,7 +4075,6 @@ void CCharacter::LinkOrb(const CCharacterCommand& command, CDbRoom& room)
 	COrbAgentData* orbAgent = orb->GetAgentAt(linkX, linkY);
 	if (!orbAgent && bIsYellowDoor(linkO)) {
 		CCoordSet doorCoords;
-		UINT wDoorX, wDoorY;
 		room.GetAllYellowDoorSquares(linkX, linkY, doorCoords);
 		for (COrbAgentData* agent : orb->agents) {
 			if (doorCoords.has(agent->wX, agent->wY)) {

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -193,6 +193,7 @@ public:
 	bool           IsOpenTileAt(const CCharacterCommand& command, const CCurrentGame* pGame);
 	virtual bool   IsPlayerAllyTarget() const;
 	bool           IsPlayerFacing(const CCharacterCommand& command, const CSwordsman& player) const;
+	bool           IsPlayerState(const CCharacterCommand& command, const CSwordsman& player) const;
 	virtual bool   IsPushableByBody() const;
 	virtual bool   IsPushableByWeaponAttack() const;
 	bool           IsRequiredToConquer() const {return GetImperative() == ScriptFlag::RequiredToConquer;}

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -93,6 +93,7 @@ namespace ScriptFlag
 	static const UINT BEETHRO = 0x00000080;
 	static const UINT STALWART= 0x00000100;
 	static const UINT PUFFBABY= 0x00000200;
+	static const UINT REQUIRED= 0x00000400;
 
 	//How killing NPC affects the game
 	enum Imperative

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -268,6 +268,14 @@ namespace ScriptFlag
 		ItemGroupCount //Total number of defined groups
 	};
 
+	enum PlayerState
+	{
+		PS_Invisible = 0, //Taken invisibility potion
+		PS_Hasted = 1, //Taken speed potion
+		PS_Powered = 2, //Activated power token
+		PS_Hiding = 3, //Invisible or in shallow water
+	};
+
 	//World map icons
 	static const UINT WMI_OFF        = 0x00000000; //remove icon when no flags are set
 	static const UINT WMI_ON         = 0x00000001; //basic display
@@ -426,6 +434,7 @@ public:
 		CC_ClearArrayVar,       //Reset array var X
 		CC_WaitForItemGroup,    //Wait for game element in group (flags) to exist in rect (x,y,w,h).
 		CC_WaitForNotItemGroup, //Wait until no game element in group (flags) exists in rect (x,y,w,h).
+		CC_WaitForPlayerState,  //Wait until player state (Y) is on or off (x).
 
 		CC_Count
 	};

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -1141,6 +1141,8 @@ UINT CCurrentGame::getVar(const UINT varIndex) const
 				default: return NO_ORIENTATION;
 			}
 		}
+		case (UINT)ScriptVars::P_COMBO:
+			return this->wMonsterKillCombo;
 		default:
 			return 0;
 	}

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -675,6 +675,28 @@ int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vect
 			const SQUARE& square = this->pRoom->pPathMap[movement]->GetSquare(x, y);
 			return square.dwTargetDist;
 		}
+		case ScriptVars::P_CleanRooms:
+		{
+			int flags = params[0];
+			CIDSet rooms = CDb::getRoomsInLevel(this->pLevel->dwLevelID);
+			CIDSet cleanRooms;
+
+			for (CIDSet::const_iterator iter = rooms.begin(); iter != rooms.end(); ++iter) {
+				UINT roomId = *iter;
+				if (!this->ConqueredRooms.has(roomId)) {
+					continue;
+				}
+
+				if ((flags & 1 && CDbRoom::IsRequired(roomId)) ||
+						(flags & 2 && CDbRoom::IsSecret(roomId)) ||
+						(flags & 4 && !CDbRoom::IsRequired(roomId)))
+				{
+					cleanRooms += roomId;
+				}
+			}
+
+			return cleanRooms.size();
+		}
 	}
 
 	return 0;

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -647,6 +647,19 @@ int CCurrentGame::EvalPrimitive(ScriptVars::PrimitiveType ePrimitive, const vect
 
 			return pArmedMonster->weaponType;
 		}
+		case ScriptVars::P_MonsterSize:
+		{
+			CMonster* pMonster = this->pRoom->GetMonsterAtSquare(params[0], params[1]);
+			if (!pMonster) {
+				return 0;
+			}
+
+			if (pMonster->IsPiece()) {
+				pMonster = pMonster->GetOwningMonster();
+			}
+
+			return pMonster->Pieces.size() + 1;
+		}
 		case ScriptVars::P_BrainScore:
 		{
 			int x = params[0];

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1000,6 +1000,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_TarFluffGroup: strText = "Tar, mud, gel or fluff"; break;
 	case MID_Briars: strText = "Any briar"; break;
 	case MID_PotionOrHorn: strText = "Any potion or horn"; break;
+	case MID_RequiredMonster: strText = "Required"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1007,6 +1007,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_Hasted: strText = "Hasted"; break;
 	case MID_Hiding: strText = "Hiding"; break;
 	case MID_WaitForPlayerState: strText = "Wait for player state"; break;
+	case MID_VarCombo: strText = "_Combo"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1001,6 +1001,12 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_Briars: strText = "Any briar"; break;
 	case MID_PotionOrHorn: strText = "Any potion or horn"; break;
 	case MID_RequiredMonster: strText = "Required"; break;
+	case MID_Powered: strText = "Powered"; break;
+	case MID_Unpowered: strText = "Unpowered"; break;
+	case MID_Invisible: strText = "Invisible"; break;
+	case MID_Hasted: strText = "Hasted"; break;
+	case MID_Hiding: strText = "Hiding"; break;
+	case MID_WaitForPlayerState: strText = "Wait for player state"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -3960,6 +3960,44 @@ const
 }
 
 //*****************************************************************************
+bool CDbRoom::IsRequiredMonsterInRect(
+//Determines if a required monster is in a rectangular area of the room.
+//Params:
+	const UINT wLeft, const UINT wTop, //(in)   Rect to find monsters in.
+	const UINT wRight, const UINT wBottom//     Boundaries are inclusive.
+) const
+{
+	ASSERT(wLeft <= wRight && wTop <= wBottom);
+
+	for (UINT y = wTop; y <= wBottom; ++y)
+	{
+		CMonster** pMonsters = &(this->pMonsterSquares[ARRAYINDEX(wLeft, y)]);
+		for (UINT x = wLeft; x <= wRight; ++x)
+		{
+			CMonster* pMonster = *pMonsters;
+			if (pMonster && pMonster->IsAlive() && pMonster->IsConquerable())
+			{
+				return true;
+			}
+			if (pMonster && pMonster->wType == M_CHARACTER)
+			{
+				CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
+				if (pCharacter && pCharacter->IsAlive() &&
+					pCharacter->IsVisible() && pCharacter->IsRequiredToConquer())
+				{
+					return true;
+				}
+			}
+
+			++pMonsters;
+		}
+	}
+
+	//No required monster in rect.
+	return false;
+}
+
+//*****************************************************************************
 bool CDbRoom::IsMonsterRemainsInRectOfType(
 //Determines if any dead monster of specified type is in a rectangular area of the room.
 //

--- a/DRODLib/DbRooms.h
+++ b/DRODLib/DbRooms.h
@@ -364,6 +364,8 @@ public:
 	bool           IsPathmapNeeded() const;
 	bool           IsTimerNeeded() const;
 	static bool    IsRequired(const UINT dwRoomID);
+	bool           IsRequiredMonsterInRect(const UINT wLeft, const UINT wTop,
+		const UINT wRight, const UINT wBottom) const;
 	bool           IsRoomLightingChanged() const { return room_lighting_changed; }
 	static bool    IsSecret(const UINT dwRoomID);
 	bool           IsSwordAt(const UINT wX, const UINT wY) const;

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -51,7 +51,8 @@ const char ScriptVars::primitiveNames[PrimitiveCount][15] =
 	"_CharacterType",
 	"_EntityWeapon",
 	"_MonsterSize",
-	"_BrainScore"
+	"_BrainScore",
+	"_CleanRooms"
 };
 
 //*****************************************************************************
@@ -105,6 +106,7 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_OrientY:
 		case P_RotateCW:
 		case P_RotateCCW:
+		case P_CleanRooms:
 			return 1;
 		case P_Min:
 		case P_Max:

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -23,7 +23,8 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_RoomWeather, MID_RoomDarkness, MID_RoomFog, MID_RoomSnow, MID_RoomRain,
 	MID_SpawnCycle, MID_SpawnCycleFast,
 	MID_VarPlayerWeapon, MID_VarPlayerLocalWeapon,
-	MID_VarInput, MID_VarInputDirection
+	MID_VarInput, MID_VarInputDirection,
+	MID_VarCombo
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/DRODLib/PlayerStats.cpp
+++ b/DRODLib/PlayerStats.cpp
@@ -50,6 +50,7 @@ const char ScriptVars::primitiveNames[PrimitiveCount][15] =
 	"_MonsterType",
 	"_CharacterType",
 	"_EntityWeapon",
+	"_MonsterSize",
 	"_BrainScore"
 };
 
@@ -114,6 +115,7 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_MonsterType:
 		case P_CharacterType:
 		case P_EntityWeapon:
+		case P_MonsterSize:
 			return 2;
 		case P_RoomTile:
 		case P_BrainScore:

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -111,6 +111,7 @@ namespace ScriptVars
 		P_MonsterType,//(x,y) --> type of monster at (x,y), or -1 if no monster is there
 		P_CharacterType,//(x,y) --> appearance of character at (x,y) or -1 if no character is there
 		P_EntityWeapon,//(x,y) --> weapon type of monster/player at (x,y), or -1 if no weapon holder is there
+		P_MonsterSize,//(x,y) --> number of tiles monster at (x,y) occupies, or 0 if no monster is there
 		P_BrainScore,//(x,y,t) --> pathmap score of tile at (x,y) for movement type t
 		PrimitiveCount
 	};

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -113,6 +113,7 @@ namespace ScriptVars
 		P_EntityWeapon,//(x,y) --> weapon type of monster/player at (x,y), or -1 if no weapon holder is there
 		P_MonsterSize,//(x,y) --> number of tiles monster at (x,y) occupies, or 0 if no monster is there
 		P_BrainScore,//(x,y,t) --> pathmap score of tile at (x,y) for movement type t
+		P_CleanRooms,//(f) -> number of cleared rooms in level matching bitmap flags (1 required, 2 secret, 4 unrequired)
 		PrimitiveCount
 	};
 

--- a/DRODLib/PlayerStats.h
+++ b/DRODLib/PlayerStats.h
@@ -81,7 +81,8 @@ namespace ScriptVars
 		P_PLAYER_LOCAL_WEAPON = -38,
 		P_INPUT = -39,
 		P_INPUT_DIRECTION = -40,
-		FirstPredefinedVar = P_INPUT_DIRECTION, //set this to the last var in the enumeration
+		P_COMBO = -41,
+		FirstPredefinedVar = P_COMBO, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/DRODLibTests/src/tests/Monsters/Guard/GuardPuffObstacle.cpp
+++ b/DRODLibTests/src/tests/Monsters/Guard/GuardPuffObstacle.cpp
@@ -3,7 +3,6 @@
 
 TEST_CASE("Guard interaction with puffs", "[game][guard][puff]") {
 	RoomBuilder::ClearRoom();
-	CDbRoom* pRoom;
 
 	SECTION("Guard paths around puff") {
 		RoomBuilder::AddMonster(M_GUARD, 10, 10, S);

--- a/Data/Help/1/myscript.html
+++ b/Data/Help/1/myscript.html
@@ -67,6 +67,7 @@
 <tr><td><b>W. open move</b></td>         <td>Orientation</td>  <td></td>              <td></td>             <td></td>             <td></td></tr>
 <tr><td></td><td></td><td></td><td></td><td></td><td></td></tr>
 <tr><td><b>W. player to face</b></td>    <td>Orientation</td>  <td></td>              <td></td>             <td></td>             <td></td></tr>
+<tr><td><b>W. player state</b></td>    <td>On or off</td>  <td></td>              <td></td>             <td></td>             <td></td></tr>
 <tr><td><b>W. player to input</b></td>   <td>Command</td>      <td></td>              <td></td>             <td></td>             <td></td></tr>
 <tr><td><b>W. player to move</b></td>    <td>Orientation</td>  <td></td>              <td></td>             <td></td>             <td></td></tr>
 <tr><td><b>W. remains</b></td>     <td>Rect X</td>       <td>Rect Y</td>        <td>Rect Width</td>   <td>Rect Height</td>  <td>Remains</td></tr>

--- a/Data/Help/1/myscript.html
+++ b/Data/Help/1/myscript.html
@@ -93,6 +93,8 @@ This is a bit map value, meaning it can contain multiple values created by just 
 <b>64 (0x040)</b> - Slayer<br/>
 <b>128 (0x080)</b> - Beethro<br/>
 <b>256 (0x100)</b> - Stalwart<br/>
+<b>512 (0x200)</b> - Fluff Baby (Wait for open tile only)<br/>
+<b>1024 (0x400)</b> - Required Monster<br/>
 <br/>
 
 <b>Attack type</b>:<br />

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -729,6 +729,7 @@ You may select these in variable commands to examine or set certain game states.
 	<li><b>_ReturnX</b> and <b>_ReturnY</b> - Used by other commands to return values for later use, eg. Get Natural Target. Otherwise can be used for temporary storing information.</li>
 	<li><b>_SpawnCycle</b> - <u>Read only!</u> Gets the current turn in the spawn cycle, between 0 and 29.</li>
 	<li><b>_SpawnCycleFast</b> - <u>Read only!</u> Gets the current turn in the spawn cycle, between 0 and 59. Even values correspond to normal turns, while odd values correspond 'half turns' where the player is moving with a speed potion.</li>
+	<li><b>_Combo</b> - <u>Read only!</u> Gets the current "combo value", the number of monsters the player has killed in a continuous run of turns.</li>
 	<li><b>_RoomWeather</b> - <a href="#roomweathervars">See this section</a></li>
 	<li><b>_RoomDarkness</b> - Controls the <a href="weather.html">lighting level</a> of a room. Can be set between 0 (no darkness) to 6 (the highest level of darkness) inclusive. If the <a href="weather.html">Skip light crossfading</a> setting is not enabled, the room will perform a fade from the old light level to the new light level.</li>
 	<li><b>_RoomFog</b> - Controls the <a href="weather.html">fog height</a> in the room. Can be set between 0 and 3 inclusive.</li>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -643,6 +643,7 @@ Hint: This can be used to compare the monsters in different tiles, or for provid
 <p><a name="charactertype">* <b>_CharacterType(x,y)</b></a> - Returns the logical type of the scripted character at (x,y). If no character is present on the tile, -1 is returned.<br/>
   Hint: This can be used to provide a value for _MyScript injection.
 </p>
+<p><a name="monstersize">* <b>_MonsterSize(x,y)</b></a> - Returns the number of tiles occupied by the monster at (x,y). If no monster is present on the tile, 0 is returned.</p>
 <p><a name="entityweapon">* <b>_EntityWeapon(x,y)</b></a> - Returns the numeric weapon type of the monster or player at (x,y). The weapon type will be returned even if the entity is currently disarmed. If no weapon-using entity is present, -1 is returned.</p>
 <p><a name="brainscore">* <b>_BrainScore(x,y,t)</b></a> - Returns the distance the given tile is from the player, along a brained path, for the given <a href="#movement-types">movement type</a>. Tiles that cannot access the player return a value of -1.</p>
 

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -357,6 +357,7 @@ the state of the room and wait indefinitely until certain events occur.</p>
   <li><a name="wait-for-remains"><b>Wait for monster remains</b></a> - Wait for the remains of a specific entity type to be present in a specified room region.</li>
   <li><a name="wait-for-open-move"><b>Wait for open move</b></a> - Wait until it becomes possible for the NPC to move in the specified direction.</li>
   <li><a name="wait-for-open-tile"><b>Wait for open tile</b></a> - Wait until the tile at the specified location is open, according to the specified movement type. Additionally, this command can be configured to ignore tile-blocking weapons and entities. Hold &lt;Ctrl&gt; while clicking to select and unselect multiple selections for ignorable entities.</li>
+  <li><a name="waitplayerstate"><b>Wait for player state</b></a> - Waits until the player has a specific state (or doesn't have it if set to Off).</li>
   <li><a name="waitplayerface"><b>Wait for player to face</b></a> - Waits until
       the player turns in the specified direction.</li>
   <li><a name="waitplayerinput"><b>Wait for player to input</b></a> - Waits until the player inputs the specified command.</li>

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -646,6 +646,7 @@ Hint: This can be used to compare the monsters in different tiles, or for provid
 <p><a name="monstersize">* <b>_MonsterSize(x,y)</b></a> - Returns the number of tiles occupied by the monster at (x,y). If no monster is present on the tile, 0 is returned.</p>
 <p><a name="entityweapon">* <b>_EntityWeapon(x,y)</b></a> - Returns the numeric weapon type of the monster or player at (x,y). The weapon type will be returned even if the entity is currently disarmed. If no weapon-using entity is present, -1 is returned.</p>
 <p><a name="brainscore">* <b>_BrainScore(x,y,t)</b></a> - Returns the distance the given tile is from the player, along a brained path, for the given <a href="#movement-types">movement type</a>. Tiles that cannot access the player return a value of -1.</p>
+<p><a name="cleanrooms">*<b>_CleanRooms(f)</b></a> - Returns how many rooms the player has cleared on the current level. It takes a bit map flag as an argument. A value of 1 counts required rooms, 2 counts secret rooms, and 4 counts unrequired rooms. These values can be combined to count multiple categories.</p>
 
 <p><a name="branchingexamples"><b>Examples of branching code structures:</b></a></p>
 <ol>

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1884,6 +1884,7 @@ enum MID_CONSTANT {
   MID_TarFluffGroup = 2112,
   MID_Briars = 2113,
   MID_PotionOrHorn = 2114,
+  MID_RequiredMonster = 2115,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1885,6 +1885,12 @@ enum MID_CONSTANT {
   MID_Briars = 2113,
   MID_PotionOrHorn = 2114,
   MID_RequiredMonster = 2115,
+  MID_Powered = 2116,
+  MID_Unpowered = 2117,
+  MID_Invisible = 2118,
+  MID_Hasted = 2119,
+  MID_Hiding = 2120,
+  MID_WaitForPlayerState = 2121,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1931,6 +1931,7 @@ enum MID_CONSTANT {
   MID_VarPlayerLocalWeapon = 2096,
   MID_VarInput = 2097,
   MID_VarInputDirection = 2098,
+  MID_VarCombo = 2122,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1898,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3449,3 +3449,31 @@ Any brair
 [MID_PotionOrHorn]
 [eng]
 Any potion or horn
+
+[MID_RequiredMonster]
+[eng]
+Required
+
+[MID_Powered]
+[eng]
+Powered
+
+[MID_Unpowered]
+[eng]
+Unpowered
+
+[MID_Invisible]
+[eng]
+Invisible
+
+[MID_Hasted]
+[eng]
+Hasted
+
+[MID_Hiding]
+[eng]
+Hiding
+
+[MID_WaitForPlayerState]
+[eng]
+Wait for player state

--- a/Texts/Stats.uni
+++ b/Texts/Stats.uni
@@ -150,3 +150,7 @@ _Input
 [MID_VarInputDirection]
 [eng]
 _InputDirection
+
+[MID_VarCombo]
+[eng]
+_Combo


### PR DESCRIPTION
A loesely related group of additions to allow more stuff to be queried in scripts.

- `_MonsterSize` script primitive, to check how large a monster at a specific tile is. Works on both heads and pieces.
- `_CleanRooms` script primitive, which can be used to know how many rooms in the level are clean. Parameter can be used to filter the types of rooms checked for (Required/secret/unrequired).
- Added a "Required" option to `Wait for entity`. This looks for required monsters. ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=38994))
- `Wait for player state`, which allows checking for invisibility, haste and poweredness.
- `_Combo` predefined var, which accesses the combo number.

(A few unused variable declarations were also trimmed)