### PR TITLE
Don't clear spark effects when in process of leaving room

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -4415,17 +4415,19 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		}
 	}
 
-	//Remove old sparks before drawing the current ones.
-	if (//Leave sparks burning while double is being placed.
-		(!player.wPlacingDoubleType ||
-				CueEvents.HasOccurred(CID_DrankPotion)) &&
-				!CueEvents.HasOccurred(CID_DoublePlaced))
-		this->pRoomWidget->RemoveTLayerEffectsOfType(ESPARK);
-
-	//Spark rendering must come both before and after room is drawn so it will
-	//show up correctly both on room entrance and  in double-placing freeze frame.
 	if (!bPlayerLeftRoom)
+	{
+		//Remove old sparks before drawing the current ones.
+		if (//Leave sparks burning while double is being placed.
+			(!player.wPlacingDoubleType ||
+				CueEvents.HasOccurred(CID_DrankPotion)) &&
+			!CueEvents.HasOccurred(CID_DoublePlaced))
+			this->pRoomWidget->RemoveTLayerEffectsOfType(ESPARK);
+
+		//Spark rendering must come both before and after room is drawn so it will
+		//show up correctly both on room entrance and  in double-placing freeze frame.
 		ProcessFuseBurningEvents(CueEvents);
+	}
 
 	//3rd. Monster actions.
 	for (pObj = CueEvents.GetFirstPrivateData(CID_SnakeDiedFromTruncation);


### PR DESCRIPTION
Removing spark effects in `CGameScreen::ProcessCueEventsBeforeRoomDraw` after `CCurrentGame` has loaded a new room can lead to crashes. To fix this, the spark clearing is skipped if the player has left the room.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=46021