### PR TITLE
Improvements for demo management and save exports

### DIFF
--- a/BackEndLib/Date.cpp
+++ b/BackEndLib/Date.cpp
@@ -205,6 +205,13 @@ const
 				wstrText += wszSpace;
 				wstrText += _itoW(1900 + tmGet->tm_year,dummy,10);
 			break;
+			case YMD:
+				wstrText += _itoW(1900 + tmGet->tm_year, dummy, 10);
+				wstrText += wszSpace;
+				wstrText += this->wstrMonthName[tmGet->tm_mon];
+				wstrText += wszSpace;
+				wstrText += _itoW(tmGet->tm_mday, dummy, 10);
+				break;
 		}
 		bShowDate = true;
 	} else if ((dwFormatFlags & DF_SHORT_DATE) == DF_SHORT_DATE)
@@ -238,6 +245,14 @@ const
 					wstrText += wTmp;
 				}
 				wstrText += _itoW(nYear,dummy,10);
+			break;
+			case YMD:
+				//ISO-8601: YYYY-MM_DD
+				wstrText += std::to_wstring(1900 + tmGet->tm_year);
+				wstrText += wszHyphen;
+				wstrText += std::to_wstring(tmGet->tm_mon + 1);
+				wstrText += wszHyphen;
+				wstrText += std::to_wstring(tmGet->tm_mday);
 			break;
 		}
 		bShowDate = true;

--- a/BackEndLib/Date.h
+++ b/BackEndLib/Date.h
@@ -65,6 +65,7 @@ public:
 	{
 		MDY,
 		DMY,
+		YMD,
 		DateFormatCount
 	};
 

--- a/DROD/DemosScreen.cpp
+++ b/DROD/DemosScreen.cpp
@@ -1094,7 +1094,14 @@ const
 	if (!pSavedGame) {delete pDemo; return false;}
 
 	//Copy date/time to beginning of item.
-	pSavedGame->Created.GetLocalFormattedText(DF_SHORT_DATE | DF_SHORT_TIME, wstrText);
+	CDate date = pSavedGame->Created;
+	CDbPlayer* pCurrentPlayer = g_pTheDB->GetCurrentPlayer();
+	if (pCurrentPlayer)
+	{
+		date.SetDateFormat((CDate::DateFormat)pCurrentPlayer->Settings.GetVar(Settings::DemoDateFormat, CDate::MDY));
+		delete pCurrentPlayer;
+	}
+	date.GetLocalFormattedText(DF_SHORT_DATE | DF_SHORT_TIME, wstrText);
 	dwRoomID = pSavedGame->dwRoomID;
 	delete pSavedGame;
 

--- a/DROD/DemosScreen.cpp
+++ b/DROD/DemosScreen.cpp
@@ -1146,40 +1146,15 @@ WSTRING CDemosScreen::GetSelectedDemosDescription(
 	const CIDSet demoIDs,
 	const CDbDemo* pDemo) const
 {
-	//Get the saved game
-	CDbSavedGame* pSavedGame = g_pTheDB->SavedGames.GetByID(pDemo->dwSavedGameID);
-
-	if (!pSavedGame) {
-		return (WSTRING)pDemo->DescriptionText;
-	}
-
-	//Get the room
-	CDbRoom* pRoom = pSavedGame->GetRoom();
-	delete pSavedGame;
-
-	if (!pRoom) {
-		return (WSTRING)pDemo->DescriptionText;
-	}
-
-	// Get the level
-	CDbLevel* pLevel = pRoom->GetLevel();
-	delete pRoom;
-
-	if (!pLevel) {
-		return (WSTRING)pDemo->DescriptionText;
-	}
-
-	//Get the hold
-	CDbHold* pHold = pLevel->GetHold();
-
-	if (!pHold) {
-		delete pLevel;
-		return (WSTRING)pDemo->DescriptionText;
-	}
+	ASSERT(pDemo);
+	//Get the level and hold IDs
+	UINT roomID = CDbSavedGames::GetRoomIDofSavedGame(pDemo->dwSavedGameID);
+	UINT levelID = CDbRooms::GetLevelIDForRoom(roomID);
+	UINT holdID = CDbRooms::GetHoldIDForRoom(roomID);
 
 	//Hold name.
 	WSTRING descText;
-	WSTRING holdName = static_cast<const WCHAR*>(pHold->NameText);
+	WSTRING holdName = CDbHolds::GetHoldName(holdID);
 	WSTRING abbrevHoldName;
 	static const UINT MAX_HOLD_NAME = 8;
 	if (holdName.size() <= MAX_HOLD_NAME)
@@ -1194,11 +1169,8 @@ WSTRING CDemosScreen::GetSelectedDemosDescription(
 	descText += wszSpace;
 
 	//Level name.
-	descText += pLevel->NameText;
+	descText += CDbLevels::GetLevelName(levelID);
 	descText += wszSpace;
-
-	delete pLevel;
-	delete pHold;
 
 	//Append total number of demos
 	descText += std::to_wstring(demoIDs.size());

--- a/DROD/DemosScreen.h
+++ b/DROD/DemosScreen.h
@@ -83,6 +83,7 @@ private:
 	void     ExportDemos();
 	void		GetCNetDemos(CNetResult* pResult);
 	bool     GetItemTextForDemo(UINT dwDemoID,  WSTRING &wstrText, UINT& dwRoomID) const;
+	WSTRING  GetSelectedDemosDescription(const CIDSet demoIDs, const CDbDemo* pDemo) const;
 	bool     IsDemoAccessible(CDbDemo* pDemo, const UINT dwPlayerID,
 			const bool bPlayerIsHoldAuthor) const;
 	void		ListCNetDemos();

--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -1845,7 +1845,7 @@ void CDrodScreen::ExportSaves(
 	//Quick player export if requested.
 	bool bQuickExport = false;
 	string str;
-	if (CFiles::GetGameProfileString(INISection::Customizing, "QuickPlayerExport", str))
+	if (CFiles::GetGameProfileString(INISection::Customizing, INIKey::QuickPlayerExport, str))
 		bQuickExport = atoi(str.c_str()) != 0;
 	if (bQuickExport && ShowYesNoMessage(MID_ExportPlayerQuickPrompt) == TAG_YES)
 		CDbXML::info.bQuickPlayerExport = true;

--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -1809,6 +1809,93 @@ void CDrodScreen::ExportHoldTexts(CDbHold *pHold)
 }
 
 //*****************************************************************************
+void CDrodScreen::ExportSaves(
+	const UINT& playerID,  //(in) player to export data for
+	const UINT& holdID,    //(in) hold to export for [default = 0]
+	const bool singleHold) //(in) export saves only for a specified hold [default=false]
+{
+	//Compile IDs of this player's saved games.
+	//The export will exclude hidden saved game records (e.g. those attached to demos, room tallies, etc.)
+	//but will include records for conquering secret rooms and ending holds.
+	CDb db;
+	db.SavedGames.FilterByPlayer(playerID);
+	db.SavedGames.FindHiddens(true);
+	if (singleHold)
+	{
+		db.SavedGames.FilterByHold(holdID);
+	}
+
+	CIDSet savedGameIDs, allSavedGameIDs = db.SavedGames.GetIDs();
+	for (CIDSet::const_iterator id = allSavedGameIDs.begin();
+		id != allSavedGameIDs.end(); ++id)
+	{
+		CDbSavedGame* pSavedGame = db.SavedGames.GetByID(*id, true);
+		if (!pSavedGame->bIsHidden ||
+			pSavedGame->eType == ST_SecretConquered ||
+			pSavedGame->eType == ST_EndHold ||
+			pSavedGame->eType == ST_HoldMastered)
+			savedGameIDs += *id;
+		delete pSavedGame;
+	}
+	if (savedGameIDs.empty()) return;
+
+	CDbPlayer* pPlayer = g_pTheDB->Players.GetByID(playerID);
+	if (!pPlayer) return;
+
+	//Quick player export if requested.
+	bool bQuickExport = false;
+	string str;
+	if (CFiles::GetGameProfileString(INISection::Customizing, "QuickPlayerExport", str))
+		bQuickExport = atoi(str.c_str()) != 0;
+	if (bQuickExport && ShowYesNoMessage(MID_ExportPlayerQuickPrompt) == TAG_YES)
+		CDbXML::info.bQuickPlayerExport = true;
+
+	//Default filename is player name.
+	WSTRING wstrExportFile = (WSTRING)pPlayer->NameText;
+	CDrodScreen::callbackContext = wstrExportFile;
+	wstrExportFile += wszSpace;
+
+	//Add hold name if exporting for single hold
+	if (singleHold)
+	{
+		CDbHold* pHold = g_pTheDB->Holds.GetByID(holdID);
+		if (pHold)
+		{
+			WSTRING holdName = pHold->NameText;
+			static const UINT MAX_HOLD_NAME = 16;
+			if (holdName.size() <= MAX_HOLD_NAME)
+			{
+				wstrExportFile += holdName;
+			}
+			else
+			{
+				//Abbreviate by taking only the first letter from each word
+				wstrExportFile += filterFirstLettersAndNumbers(holdName);
+			}
+
+			wstrExportFile += wszSpace;
+			delete pHold;
+		}
+	}
+
+	wstrExportFile += g_pTheDB->GetMessageText(MID_Saves);
+	if (ExportSelectFile(MID_SavePlayerPath, wstrExportFile, EXT_PLAYER))
+	{
+		//Write the player saves file.
+		SetCursor(CUR_Wait);
+		Callback(MID_Exporting);
+		CDbXML::SetCallback(this);
+
+		const bool bResult = CDbXML::ExportXML(V_SavedGames, savedGameIDs,
+			wstrExportFile.c_str());
+		ExportCleanup();
+		ShowOkMessage(bResult ? MID_SavedGamesSaved : MID_PlayerFileNotSaved);
+	}
+	CDrodScreen::callbackContext.resize(0);
+	delete pPlayer;
+}
+
+//*****************************************************************************
 bool CDrodScreen::ExportSelectFile(
 //Select a file to export data to.
 //

--- a/DROD/DrodScreen.h
+++ b/DROD/DrodScreen.h
@@ -102,6 +102,7 @@ friend class CDrodDialogs;
 	void           ExportHold(const UINT dwHoldID);
 	void           ExportHoldScripts(CDbHold *pHold);
 	void           ExportHoldTexts(CDbHold *pHold);
+	void           ExportSaves(const UINT& playerId, const UINT& holdId = 0, const bool singleHold = false);
 	bool           ExportSelectFile(const MESSAGE_ID messageID,
 			WSTRING &wstrExportFile, const UINT extensionTypes);
 	void           ExportStyle(const WSTRING& style);

--- a/DROD/HoldSelectScreen.cpp
+++ b/DROD/HoldSelectScreen.cpp
@@ -992,7 +992,7 @@ void CHoldSelectScreen::OnBetweenEvents()
 		RequestThumbnail(this->pSelCNetHold);
 
 	//Advance play of the featured saved game.
-	if (dwNow - lastGameTurnTick >= gameTurnTick && playDemo)
+	if (dwNow - lastGameTurnTick >= gameTurnTick && this->playDemo)
 	{
 		AdvanceRestoreGameTurn();
 		lastGameTurnTick = dwNow;

--- a/DROD/HoldSelectScreen.cpp
+++ b/DROD/HoldSelectScreen.cpp
@@ -128,6 +128,7 @@ CHoldSelectScreen::CHoldSelectScreen()
 	, pCurrentRestoreGame(NULL)
 	, filter(F_ALL)
 	, pSelCNetHold(NULL)
+	, playDemo(true)
 //Constructor
 {
 	this->imageFilenames.push_back(string("Background"));
@@ -547,6 +548,8 @@ bool CHoldSelectScreen::SetForActivate()
 		this->bDownloadList = true;
 		this->dwLastNotice = updates.back().id;
 	}
+
+	this->playDemo = pCurrentPlayer->Settings.GetVar(Settings::PlayHoldManagementDemo, true);
 
 	pCurrentPlayer->Settings.SetVar(Settings::LastNotice, this->dwLastNotice);
 	pCurrentPlayer->Update();
@@ -989,7 +992,7 @@ void CHoldSelectScreen::OnBetweenEvents()
 		RequestThumbnail(this->pSelCNetHold);
 
 	//Advance play of the featured saved game.
-	if (dwNow - lastGameTurnTick >= gameTurnTick)
+	if (dwNow - lastGameTurnTick >= gameTurnTick && playDemo)
 	{
 		AdvanceRestoreGameTurn();
 		lastGameTurnTick = dwNow;

--- a/DROD/HoldSelectScreen.h
+++ b/DROD/HoldSelectScreen.h
@@ -169,6 +169,7 @@ private:
 	CCurrentGame *pCurrentRestoreGame;
 	HoldTypeFilter filter;
 	CNetMedia *pSelCNetHold; //set if thumbnail image pending
+	bool playDemo;
 };
 
 #endif

--- a/DROD/RestoreScreen.cpp
+++ b/DROD/RestoreScreen.cpp
@@ -75,6 +75,8 @@ const UINT TAG_HELP = 1093;
 const UINT TAG_CHALLENGES = 1094;
 const UINT TAG_CHALLENGES_LIST = 1095;
 
+const UINT TAG_EXPORT_HOLD_SAVES = 1096;
+
 //Reserve 2000 to (2000+room size) for checkpoint tags.
 const UINT TAG_CHECKPOINT = 2000;
 #define IS_CHECKPOINT_TAG(t) ((t) >= 2000 && (t) < (2000+(38*32)))
@@ -123,12 +125,16 @@ CRestoreScreen::CRestoreScreen()
 	static const UINT CY_CANCEL_BUTTON = CY_RESTORE_BUTTON;
 	static const UINT CX_HELP_BUTTON = CX_CANCEL_BUTTON;
 	static const UINT CY_HELP_BUTTON = CY_RESTORE_BUTTON;
+	static const UINT CX_EXPORT_SAVES_BUTTON = 120;
+	static const UINT CY_EXPORT_SAVES_BUTTON = CY_RESTORE_BUTTON;
 	const int X_CANCEL_BUTTON = this->w / 2;
 	const int X_RESTORE_BUTTON = X_CANCEL_BUTTON - CX_RESTORE_BUTTON - CX_SPACE;
 	const int X_HELP_BUTTON = X_CANCEL_BUTTON + CX_CANCEL_BUTTON + CX_SPACE;
+	const int X_EXPORT_SAVES_BUTTON = X_HELP_BUTTON + CX_HELP_BUTTON + CX_SPACE;
 	const int Y_RESTORE_BUTTON = this->h - CY_SPACE - CY_RESTORE_BUTTON;
 	const int Y_CANCEL_BUTTON = Y_RESTORE_BUTTON;
 	const int Y_HELP_BUTTON = Y_RESTORE_BUTTON;
+	const int Y_EXPORT_SAVES_BUTTON = Y_RESTORE_BUTTON;
 
 	//Mini-room widget has strict proportions and its dimensions will define 
 	//placement of most everything else.
@@ -223,6 +229,10 @@ CRestoreScreen::CRestoreScreen()
 				CX_HELP_BUTTON, CY_HELP_BUTTON, g_pTheDB->GetMessageText(MID_Help));
 	AddWidget(pButton);
 	AddHotkey(SDLK_F1,TAG_HELP);
+
+	pButton = new CButtonWidget(TAG_EXPORT_HOLD_SAVES, X_EXPORT_SAVES_BUTTON, Y_EXPORT_SAVES_BUTTON,
+		CX_EXPORT_SAVES_BUTTON, CY_EXPORT_SAVES_BUTTON, g_pTheDB->GetMessageText(MID_ExportSaves));
+	AddWidget(pButton);
 
 	//Level selection area.
 	AddWidget(new CLabelWidget(0L, X_CHOOSE_LEVEL_LABEL, Y_CHOOSE_LEVEL_LABEL, 
@@ -467,6 +477,10 @@ void CRestoreScreen::OnClick(
 		case TAG_CHALLENGES:
 			DisplayChallengesDialog();
 			Paint();
+		break;
+
+		case TAG_EXPORT_HOLD_SAVES:
+			ExportSaves(g_pTheDB->GetPlayerID(), g_pTheDB->GetHoldID(), true);
 		break;
 
 		default:

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -455,7 +455,7 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 
 	pOptionButton = new COptionButtonWidget(TAG_PLAY_HOLDMANAGE_DEMO, X_PLAY_HOLDMANAGE_DEMO,
 		Y_PLAY_HOLDMANAGE_DEMO, CX_PLAY_HOLDMANAGE_DEMO, CY_PLAY_HOLDMANAGE_DEMO,
-		L"Play demo on Hold Management screen", true);
+		g_pTheDB->GetMessageText(MID_PlayHoldManagementDemo), true);
 	pDemoFrame->AddWidget(pOptionButton);
 
 	pDemoFrame->AddWidget(

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -35,6 +35,7 @@
 #include <FrontEndLib/LabelWidget.h>
 #include <FrontEndLib/FrameWidget.h>
 #include <FrontEndLib/ButtonWidget.h>
+#include <FrontEndLib/ListBoxWidget.h>
 #include <FrontEndLib/OptionButtonWidget.h>
 #include <FrontEndLib/SliderWidget.h>
 #include <FrontEndLib/TextBoxWidget.h>
@@ -116,9 +117,12 @@ const UINT TAG_MENU = 1093;
 const UINT TAG_RESIZABLE_SCREEN = 1094;
 
 const UINT TAG_PLAY_HOLDMANAGE_DEMO = 1095;
+const UINT TAG_DEMO_DATE_FORMAT = 1096;
 
 static const UINT CX_SPACE = 10;
 static const UINT CY_SPACE = 10;
+
+const UINT LIST_LINE_HEIGHT = 22;
 
 static const UINT CY_TITLE = CY_LABEL_FONT_TITLE;
 static const int Y_TITLE = Y_TITLE_LABEL_CENTER_DARK_BAR;
@@ -335,7 +339,17 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 	static const UINT CX_PLAY_HOLDMANAGE_DEMO = CX_DEMO_FRAME - X_PLAY_HOLDMANAGE_DEMO;
 	static const UINT CY_PLAY_HOLDMANAGE_DEMO = CY_STANDARD_OPTIONBUTTON;
 
-	static const UINT CY_DEMO_FRAME = Y_PLAY_HOLDMANAGE_DEMO + CY_PLAY_HOLDMANAGE_DEMO + CY_SPACE;
+	static const int X_DEMO_DATE_FORMAT_LABEL = CX_SPACE;
+	static const int Y_DEMO_DATE_FORMAT_LABEL = Y_PLAY_HOLDMANAGE_DEMO + CY_PLAY_HOLDMANAGE_DEMO;
+	static const UINT CX_DEMO_DATE_FORMAT_LABEL = CX_DEMO_FRAME - X_DEMO_DATE_FORMAT_LABEL;
+	static const UINT CY_DEMO_DATE_FORMAT_LABEL = 30;
+	static const int X_DEMO_DATE_FORMAT = CX_SPACE;
+	static const int Y_DEMO_DATE_FORMAT = Y_DEMO_DATE_FORMAT_LABEL + CY_DEMO_DATE_FORMAT_LABEL + CY_SPACE;
+	static const UINT CX_DEMO_DATE_FORMAT = CX_DEMO_FRAME - X_PLAY_HOLDMANAGE_DEMO - CX_SPACE;
+	static const UINT CY_DEMO_DATE_FORMAT = LIST_LINE_HEIGHT * 3 + 4;
+
+	static const UINT CY_DEMO_FRAME = Y_PLAY_HOLDMANAGE_DEMO + CY_DEMO_DATE_FORMAT_LABEL +
+		CY_PLAY_HOLDMANAGE_DEMO + CY_DEMO_DATE_FORMAT + 2 * CY_SPACE;
 
 	COptionButtonWidget* pOptionButton;
 
@@ -443,6 +457,17 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 		Y_PLAY_HOLDMANAGE_DEMO, CX_PLAY_HOLDMANAGE_DEMO, CY_PLAY_HOLDMANAGE_DEMO,
 		L"Play demo on Hold Management screen", true);
 	pDemoFrame->AddWidget(pOptionButton);
+
+	pDemoFrame->AddWidget(
+		new CLabelWidget(0L, X_DEMO_DATE_FORMAT_LABEL, Y_DEMO_DATE_FORMAT_LABEL,
+			CX_DEMO_DATE_FORMAT_LABEL, CY_DEMO_DATE_FORMAT_LABEL, F_FrameCaption, g_pTheDB->GetMessageText(MID_DemoDateFormat)));
+
+	CListBoxWidget* pDemoDateFormat = new CListBoxWidget(TAG_DEMO_DATE_FORMAT, X_DEMO_DATE_FORMAT,
+		Y_DEMO_DATE_FORMAT, CX_DEMO_DATE_FORMAT, CY_DEMO_DATE_FORMAT);
+	pDemoDateFormat->AddItem(CDate::MDY, g_pTheDB->GetMessageText(MID_DateFormatMDY));
+	pDemoDateFormat->AddItem(CDate::DMY, g_pTheDB->GetMessageText(MID_DateFormatDMY));
+	pDemoDateFormat->AddItem(CDate::YMD, g_pTheDB->GetMessageText(MID_DateFormatYMD));
+	pDemoFrame->AddWidget(pDemoDateFormat);
 }
 
 //************************************************************************************
@@ -1621,6 +1646,10 @@ void CSettingsScreen::UpdateWidgetsFromPlayerData(
 		GetWidget(TAG_PLAY_HOLDMANAGE_DEMO));
 	pOptionButton->SetChecked(settings.GetVar(Settings::PlayHoldManagementDemo, true));
 
+	CListBoxWidget* pDemoDateFormat = DYN_CAST(CListBoxWidget*, CWidget*,
+		GetWidget(TAG_DEMO_DATE_FORMAT));
+	pDemoDateFormat->SelectItem(settings.GetVar(Settings::DemoDateFormat, CDate::MDY));
+
 	//Command settings.
 	for (int nCommand = DCMD_NW; nCommand < DCMD_Count; ++nCommand)
 	{
@@ -1771,6 +1800,10 @@ void CSettingsScreen::UpdatePlayerDataFromWidgets(
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 		GetWidget(TAG_PLAY_HOLDMANAGE_DEMO));
 	settings.SetVar(Settings::PlayHoldManagementDemo, pOptionButton->IsChecked());
+
+	CListBoxWidget* pDemoDateFormat = DYN_CAST(CListBoxWidget*, CWidget*,
+		GetWidget(TAG_DEMO_DATE_FORMAT));
+	settings.SetVar(Settings::DemoDateFormat, pDemoDateFormat->GetSelectedItem());
 
 	//Command settings--these were updated in response to previous UI events, 
 	//so nothing to do here.

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -115,6 +115,8 @@ const UINT TAG_MENU = 1093;
 
 const UINT TAG_RESIZABLE_SCREEN = 1094;
 
+const UINT TAG_PLAY_HOLDMANAGE_DEMO = 1095;
+
 static const UINT CX_SPACE = 10;
 static const UINT CY_SPACE = 10;
 
@@ -323,6 +325,18 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 
 	static const UINT CY_SPECIAL_FRAME = Y_AUTOUNDOONDEATH + CY_AUTOUNDOONDEATH + CY_SPACE;
 
+	//Demo frame and children
+	static const UINT X_DEMO_FRAME = X_EDITOR_FRAME;
+	static const UINT Y_DEMO_FRAME = Y_EDITOR_FRAME + CY_EDITOR_FRAME + CY_SPACE;
+	static const UINT CX_DEMO_FRAME = CX_TABBEDMENU - X_DEMO_FRAME - X_PERSONAL_FRAME;
+
+	static const int X_PLAY_HOLDMANAGE_DEMO = CX_SPACE;
+	static const int Y_PLAY_HOLDMANAGE_DEMO = CY_SPACE;
+	static const UINT CX_PLAY_HOLDMANAGE_DEMO = CX_DEMO_FRAME - X_PLAY_HOLDMANAGE_DEMO;
+	static const UINT CY_PLAY_HOLDMANAGE_DEMO = CY_STANDARD_OPTIONBUTTON;
+
+	static const UINT CY_DEMO_FRAME = Y_PLAY_HOLDMANAGE_DEMO + CY_PLAY_HOLDMANAGE_DEMO + CY_SPACE;
+
 	COptionButtonWidget* pOptionButton;
 
 	//Personal frame.
@@ -419,6 +433,16 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 		Y_GEMI, CX_GEMI, CY_GEMI,
 		g_pTheDB->GetMessageText(MID_GroupEditorMenuItems), false);
 	pEditorFrame->AddWidget(pOptionButton);
+
+	//Demo frame
+	CFrameWidget* pDemoFrame = new CFrameWidget(0L, X_DEMO_FRAME, Y_DEMO_FRAME,
+		CX_DEMO_FRAME, CY_DEMO_FRAME, g_pTheDB->GetMessageText(MID_Demos));
+	pTabbedMenu->AddWidgetToTab(pDemoFrame, PERSONAL_TAB);
+
+	pOptionButton = new COptionButtonWidget(TAG_PLAY_HOLDMANAGE_DEMO, X_PLAY_HOLDMANAGE_DEMO,
+		Y_PLAY_HOLDMANAGE_DEMO, CX_PLAY_HOLDMANAGE_DEMO, CY_PLAY_HOLDMANAGE_DEMO,
+		L"Play demo on Hold Management screen", true);
+	pDemoFrame->AddWidget(pOptionButton);
 }
 
 //************************************************************************************
@@ -1591,6 +1615,11 @@ void CSettingsScreen::UpdateWidgetsFromPlayerData(
 			GetWidget(TAG_GROUPEDITORMENUITEMS));
 	pOptionButton->SetChecked(settings.GetVar(Settings::GEMI, false));
 	//Check above line
+	
+	//Demo settings
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_PLAY_HOLDMANAGE_DEMO));
+	pOptionButton->SetChecked(settings.GetVar(Settings::PlayHoldManagementDemo, true));
 
 	//Command settings.
 	for (int nCommand = DCMD_NW; nCommand < DCMD_Count; ++nCommand)
@@ -1737,6 +1766,11 @@ void CSettingsScreen::UpdatePlayerDataFromWidgets(
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_GROUPEDITORMENUITEMS));
 	settings.SetVar(Settings::GEMI, pOptionButton->IsChecked());
+
+	//Demo settings
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_PLAY_HOLDMANAGE_DEMO));
+	settings.SetVar(Settings::PlayHoldManagementDemo, pOptionButton->IsChecked());
 
 	//Command settings--these were updated in response to previous UI events, 
 	//so nothing to do here.

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1008,6 +1008,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_Hiding: strText = "Hiding"; break;
 	case MID_WaitForPlayerState: strText = "Wait for player state"; break;
 	case MID_VarCombo: strText = "_Combo"; break;
+	case MID_ExportSaves: strText = "&Export saves"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1009,6 +1009,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_WaitForPlayerState: strText = "Wait for player state"; break;
 	case MID_VarCombo: strText = "_Combo"; break;
 	case MID_ExportSaves: strText = "&Export saves"; break;
+	case MID_PlayHoldManagementDemo: strText = "Play demo on Hold Management screen"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1010,6 +1010,10 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_VarCombo: strText = "_Combo"; break;
 	case MID_ExportSaves: strText = "&Export saves"; break;
 	case MID_PlayHoldManagementDemo: strText = "Play demo on Hold Management screen"; break;
+	case MID_DemoDateFormat: strText = "Demo date format"; break;
+	case MID_DateFormatMDY: strText = "MM/DD/YY"; break;
+	case MID_DateFormatDMY: strText = "DD/MM/YY"; break;
+	case MID_DateFormatYMD: strText = "YYYY-MM-DD"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -48,6 +48,7 @@ namespace Settings
 	DEF(CloudHoldDemosVersion);
 	DEF(CNetProgressIsOld);
 	DEF(ConnectToInternet);
+	DEF(DemoDateFormat);
 	DEF(DisplayCombos);
 	DEF(EnableChatInGame);
 	DEF(ExportPath);

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -65,6 +65,7 @@ namespace Settings
 	DEF(Music);
 	DEF(MusicVolume);
 	DEF(NoFocusPlaysMusic);
+	DEF(PlayHoldManagementDemo);
 	DEF(PlaySessions);
 	DEF(PuzzleMode);
 	DEF(ReceiveWhispersOnlyInGame);

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -48,6 +48,7 @@ namespace Settings
 	DEF(CloudHoldDemosVersion);
 	DEF(CNetProgressIsOld);
 	DEF(ConnectToInternet);
+	DEF(DemoDateFormat);
 	DEF(DisplayCombos);
 	DEF(EnableChatInGame);
 	DEF(ExportPath);

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -65,6 +65,7 @@ namespace Settings
 	DEF(Music);
 	DEF(MusicVolume);
 	DEF(NoFocusPlaysMusic);
+	DEF(PlayHoldManagementDemo);
 	DEF(PlaySessions);
 	DEF(PuzzleMode);
 	DEF(ReceiveWhispersOnlyInGame);

--- a/Data/Help/1/restore.html
+++ b/Data/Help/1/restore.html
@@ -54,6 +54,8 @@ point being reset to the way they were then.</p>
 
 <p><a name="viewing-challenges">Click</a> the &quot;Challenges&quot; button to view a list of all scripted challenges you have completed in the current hold.</p>
 
+<p><a name="export-saves">Click</a> the &quot;Export saves&quot; button to export all your saved game data for the current hold. You can use this to share progress for that hold, without sharing author access to your levels.</p>
+
 <p><a name="demos"><b>Viewing demos</b></a> - Press F6 to view <a href="demos.html">demos</a> recorded in the highlighted room.</p>
 
 <hr />

--- a/Data/Help/1/settings.html
+++ b/Data/Help/1/settings.html
@@ -21,6 +21,7 @@ automatically" is checked, changes you make to a room in the <a
 &nbsp;Turn this option off if you want to be prompted before saving any
 room changes. &nbsp;Check "Show item tips" to receive help placing
 special objects in the room. </p>
+<p><a name="demos"></a><b>Demos</b> - "Play demo on Hold Management screen" controls if the room preview on the <a href="holdselect.html">Hold Management</a> screen should replay the player's actions in that room.</p>
 
 <p><a name="graphics"><b>Graphics</b></a> - Click "Use <a name="fullscreen">full screen</a>" to toggle between
 full screen and windowed mode (1024x768). &nbsp;Note that you can also

--- a/Data/Help/1/settings.html
+++ b/Data/Help/1/settings.html
@@ -21,7 +21,8 @@ automatically" is checked, changes you make to a room in the <a
 &nbsp;Turn this option off if you want to be prompted before saving any
 room changes. &nbsp;Check "Show item tips" to receive help placing
 special objects in the room. </p>
-<p><a name="demos"></a><b>Demos</b> - "Play demo on Hold Management screen" controls if the room preview on the <a href="holdselect.html">Hold Management</a> screen should replay the player's actions in that room.</p>
+<p><a name="demos"></a><b>Demos</b> - "Play demo on Hold Management screen" controls if the room preview on the <a href="holdselect.html">Hold Management</a> screen should replay the player's actions in that room. 
+	"Demo data format" controls how the recording date is displayed in the demo list on the <a href="demos.html">Demos</a> screen.</p>
 
 <p><a name="graphics"><b>Graphics</b></a> - Click "Use <a name="fullscreen">full screen</a>" to toggle between
 full screen and windowed mode (1024x768). &nbsp;Note that you can also

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1396,6 +1396,7 @@ enum MID_CONSTANT {
   MID_AutoUndoOnDeath = 1786,
   MID_ActivateCloudSync = 1794,
   MID_ResizableWindow = 2027,
+  MID_PlayHoldManagementDemo = 2124,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1204,6 +1204,7 @@ enum MID_CONSTANT {
   MID_RestoreToFurthestSave = 1771,
   MID_Challenges = 1847,
   MID_CompletedChallenges = 1848,
+  MID_ExportSaves = 2123,
 
   //Messages from SelectScreens.uni:
   MID_HoldManagementTitle = 1207,

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1397,6 +1397,10 @@ enum MID_CONSTANT {
   MID_ActivateCloudSync = 1794,
   MID_ResizableWindow = 2027,
   MID_PlayHoldManagementDemo = 2124,
+  MID_DemoDateFormat = 2125,
+  MID_DateFormatMDY = 2126,
+  MID_DateFormatDMY = 2127,
+  MID_DateFormatYMD = 2128,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/Texts/RestoreScreen.uni
+++ b/Texts/RestoreScreen.uni
@@ -117,3 +117,7 @@ Completed Challenges
 Completed Challenges!!translate
 [fra]
 Completed Challenges!!translate
+
+[MID_ExportSaves]
+[eng]
+&Export saves

--- a/Texts/SettingsScreen.uni
+++ b/Texts/SettingsScreen.uni
@@ -673,3 +673,19 @@ Resizable Window
 [MID_PlayHoldManagementDemo]
 [eng]
 Play demo on Hold Management screen
+
+[MID_DemoDateFormat]
+[eng]
+Demo date format
+
+[MID_DateFormatMDY]
+[eng]
+MM/DD/YY
+
+[MID_DateFormatDMY]
+[eng]
+DD/MM/YY
+
+[MID_DateFormatYMD]
+[eng]
+YYYY-MM-DD

--- a/Texts/SettingsScreen.uni
+++ b/Texts/SettingsScreen.uni
@@ -669,3 +669,7 @@ Activate Cloud Sync
 [MID_ResizableWindow]
 [eng]
 Resizable Window
+
+[MID_PlayHoldManagementDemo]
+[eng]
+Play demo on Hold Management screen


### PR DESCRIPTION
A bundle of changes to improve somethings around demos and saves:

- Added a button to the restore screen to export saves for the current hold. To do this, the save export code was moved to a new function, `CDrodScreen::ExportSaves`, which can be flagged to filter to a single hold before doing the export. ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=45202))
- Changed how exported demo files are named if they contain multiple demos. The hold and level name are used, along with the number of demos that will be exported, ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=45978))
- Added an option to activate/deactive playing demos on the hold management screen ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=40769))
- Added an option to change the date format used on the demos screen. ([Thread](https://forum.caravelgames.com/viewtopic.php?TopicID=46171))