### PR TITLE
Add script command to prompt tile selection

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -8503,6 +8503,9 @@ void CRoomWidget::DrawDoubleCursor(
 	{
 		g_pTheBM->ShadeTile(xPixel,yPixel,Red,GetDestSurface());
 		this->pTileImages[this->pRoom->ARRAYINDEX(wCol, wRow)].dirty = 1;
+	} else if (bIsSelectSquare(player.wPlacingDoubleType)) {
+		g_pTheBM->ShadeTile(xPixel, yPixel, BlueGreen, GetDestSurface());
+		this->pTileImages[this->pRoom->ARRAYINDEX(wCol, wRow)].dirty = 1;
 	} else {
 		//Fade in and out.
 		static Uint8 nOpacity = 160;

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3749,6 +3749,21 @@ void CCharacter::Process(
 			}
 			break;
 
+			case CCharacterCommand::CC_SelectSquare:
+			{
+				CSwordsman& swordsman = pGame->swordsman;
+				UINT selectionType = command.x ? M_SELECT_SQUARE_RESTRICTED : M_SELECT_SQUARE;
+
+				//Wait if another kind of square selection or double placement is already queued
+				if (!(swordsman.wPlacingDoubleType == 0 || swordsman.wPlacingDoubleType == selectionType))
+					STOP_COMMAND;
+
+				swordsman.wPlacingDoubleType = selectionType;
+				swordsman.wDoubleCursorX = swordsman.wX;
+				swordsman.wDoubleCursorY = swordsman.wY;
+			}
+			break;
+
 			case CCharacterCommand::CC_SetDarkness:
 			{
 				getCommandParams(command, px, py, pw, ph, pflags);

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -436,6 +436,7 @@ public:
 		CC_WaitForNotItemGroup, //Wait until no game element in group (flags) exists in rect (x,y,w,h).
 		CC_WaitForPlayerState,  //Wait until player state (Y) is on or off (x).
 		CC_SetPlayerState,      //Change player state (Y) to on or off (x).
+		CC_SelectSquare,        //Prompt the player to select a position in the room.
 
 		CC_Count
 	};

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -416,6 +416,7 @@ private:
 	void     PreprocessMonsters(CCueEvents &CueEvents);
 	void     ProcessMonsters(int nLastCommand, CCueEvents &CueEvents);
 	void     ProcessMonster(CMonster* pMonster, int nLastCommand, CCueEvents &CueEvents);
+	void     ProcessNoMoveCharacters(CCueEvents& CueEvents);
 	void     ProcessReactionToPlayerMove(int nCommand, CCueEvents& CueEvents);
 	void     ProcessRoomCompletion(RoomCompletionData roomCompletionData, CCueEvents& CueEvents);
 	void     ProcessPlayer(const int nCommand, CCueEvents &CueEvents);

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1017,6 +1017,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_Command_ToggleHoldVars: strText = "Toggle Var Monitor"; break;
 	case MID_Command_ToggleFrameRate: strText = "Toggle Frame Rate"; break;
 	case MID_SetPlayerState: strText = "Set player state"; break;
+	case MID_SelectSquare: strText = "Select square"; break;
+	case MID_Restricted: strText = "Restricted"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2781,6 +2781,10 @@ const
 {
 	ASSERT(IsValidColRow(wX, wY));
 
+	//If M_SELECT_SQUARE is being placed, the player is selecting a square for a script
+	if (wDoubleType == M_SELECT_SQUARE)
+		return false;
+
 	//Is there a monster in the square?
 	if (GetMonsterAtSquare(wX, wY) != NULL)
 		return true;

--- a/DRODLib/MonsterType.h
+++ b/DRODLib/MonsterType.h
@@ -74,6 +74,10 @@ enum MONSTERTYPE {
 	M_BEETHRO_IN_DISGUISE,
 	M_GUNTHRO,
 
+	//Pseudo-types for tile selection command
+	M_SELECT_SQUARE,
+	M_SELECT_SQUARE_RESTRICTED,
+
 	CHARACTER_TYPES,
 
 	CUSTOM_CHARACTER_FIRST=20000, //for custom character IDs
@@ -323,6 +327,10 @@ static inline bool bMonsterCanActivateCheckpoint(const UINT mt) {
 		default:
 			return false;
 	}
+}
+
+static inline bool bIsSelectSquare(const UINT mt) {
+	return mt == M_SELECT_SQUARE || mt == M_SELECT_SQUARE_RESTRICTED;
 }
 
 #endif

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -328,6 +328,8 @@ the state of the room and wait indefinitely until certain events occur.</p>
       <b>Question</b> is executed as the condition for an <a href="#if">
       <b>If ...</b></a> command, the corresponding script block will execute if
       the user answers "Yes".</li>
+  <li><a name="select-square"></a><b>Select square</b> - Causes the next game move to become a position input, as if the player had stepped on a potion. The selected position is placed into the <b>_ReturnX</b> and <b>_ReturnY</b> variables. 
+    The selection can be configured to allow any room tile to be chosen, or to use the same restriction as double potions. If the player has consumed a potion, this command will be delayed until the next full turn has processed.</li>
   <li><a name="wait"><b>Wait</b></a> - This tells the NPC to do nothing until
       the number of game turns you specify has passed.  <b>Wait 0</b> will stop
       the script at the current point until the next turn.</li>

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1900,6 +1900,8 @@ enum MID_CONSTANT {
   MID_Hiding = 2120,
   MID_WaitForPlayerState = 2121,
   MID_SetPlayerState = 2131,
+  MID_SelectSquare = 2132,
+  MID_Restricted = 2133,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3481,3 +3481,11 @@ Wait for player state
 [MID_SetPlayerState]
 [eng]
 Set player state
+
+[MID_SelectSquare]
+[eng]
+Select square
+
+[MID_Restricted]
+[eng]
+Restricted


### PR DESCRIPTION
Add a new command, `Select square`, that enables the user to input a room tile, which is then stored in the `_ReturnX` and `_ReturnY` vars.

This works by hooking into the double placement command, using two new monster pseudo-types. One allows any square to be selected, while the other retains the normal double placement restrictions. The command will wait if a double is already being placed, since only one thing can use the square selection input at once.