### PR TITLE
Fix unset flashing text opacity

### DIFF
--- a/FrontEndLib/FlashMessageEffect.cpp
+++ b/FrontEndLib/FlashMessageEffect.cpp
@@ -234,6 +234,7 @@ void CFlashMessageEffect::SetColor(int r, int g, int b)
 	this->customColor.r = (unsigned char)r;
 	this->customColor.g = (unsigned char)g;
 	this->customColor.b = (unsigned char)b;
+	this->customColor.a = 255;
 
 	RenderText();
 }


### PR DESCRIPTION
Fix flashing text color opacity being unset, causing inconsistent results. What value of opacity it was using was essentially random, whatever value happened to be in that part of memory at that time.

This is the same as #631 but for classic DROD instead of RPG.

I believe this is the cause of https://forum.caravelgames.com/viewtopic.php?TopicID=46235