### PR TITLE
RPG: Apply character preview option to main editor screen

### DIFF
--- a/drodrpg/DROD/EditSelectScreen.cpp
+++ b/drodrpg/DROD/EditSelectScreen.cpp
@@ -2067,6 +2067,11 @@ void CEditSelectScreen::SetSelectedRoom(
 	//Update the room widget with new room.
 	GetLevelEntrancesInRoom();
 	this->pRoomWidget->LoadFromRoom(pRoom, &this->LevelEntrances);
+
+	CDbPlayer* pCurrentPlayer = g_pTheDB->GetCurrentPlayer();
+	if (!pCurrentPlayer) { ASSERT(!"Couldn't retrieve player."); return; } //Corrupt db.
+	this->pRoomWidget->characterPreview = pCurrentPlayer->Settings.GetVar(Settings::CharacterPreview, false);
+
 	this->pRoomWidget->Paint();
 
 	//Select room style from the list box.


### PR DESCRIPTION
There's an option to display characters as their identity instead of a generic character in the editor. This change also applies this setting to the room preview widget in the main editor screen.