### PR TITLE
RPG: Add Minimap treasure behavior

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1536,6 +1536,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBehaviorListBox->AddItem(ScriptFlag::NormalMovement, g_pTheDB->GetMessageText(MID_NormalMovement));
 	this->pBehaviorListBox->AddItem(ScriptFlag::SmarterMovement, g_pTheDB->GetMessageText(MID_SmarterMovement));
 	this->pBehaviorListBox->AddItem(ScriptFlag::OmniMovement, g_pTheDB->GetMessageText(MID_OmniMovement));
+	this->pBehaviorListBox->AddItem(ScriptFlag::MinimapTreasure, g_pTheDB->GetMessageText(MID_MinimapTreasure));
 	this->pBehaviorListBox->SelectLine(0);
 
 	//Custom equipment.

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -132,6 +132,7 @@ const UINT MAX_ANSWERS = 9;
 #define SpawnEggsStr "SpawnEggs"
 #define RemovesSwordStr "RemovesSword"
 #define ExplosiveKegSafeStr "ExplosiveSafe"
+#define MinimapTreasureStr "MinimapTreasure"
 #define MovementTypeStr "MovementType"
 
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
@@ -249,7 +250,7 @@ CCharacter::CCharacter(
 	, bMetal(false), bLuckyGR(false), bLuckyXP(false), bBriar(false), bNoEnemyDEF(false)
 	, bAttackFirst(false), bAttackLast(false)
 	, bDropTrapdoors(false), bMoveIntoSwords(false), bPushObjects(false), bSpawnEggs(false)
-	, bRemovesSword(false) , bExplosiveSafe(false)
+	, bRemovesSword(false) , bExplosiveSafe(false), bMinimapTreasure(false)
 
 	, wJumpLabel(0)
 	, bWaitingForCueEvent(false)
@@ -2749,7 +2750,7 @@ void CCharacter::Process(
 						this->bMetal = this->bLuckyGR = this->bLuckyXP = this->bBriar = this->bNoEnemyDEF =
 						this->bAttackFirst = this->bAttackLast = this->bRemovesSword =
 						this->bDropTrapdoors = this->bMoveIntoSwords = this->bPushObjects = this->bSpawnEggs =
-						this->bExplosiveSafe =
+						this->bExplosiveSafe = this->bMinimapTreasure =
 							false;
 						this->movementIQ = SmartDiagonalOnly;
 					break;
@@ -2839,6 +2840,9 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::ExplosiveSafe:
 						this->bExplosiveSafe = true;
+					break;
+					case ScriptFlag::MinimapTreasure:
+						this->bMinimapTreasure = true;
 					break;
 
 					default:
@@ -5158,6 +5162,15 @@ bool CCharacter::IsCombatable() const
 }
 
 //*****************************************************************************
+bool CCharacter::IsMinimapTreasure() const
+//Returns: whether this character should allow the room to be marked as having
+//a collectable item. It only counts if the character can be seen by the player
+{
+	return bMinimapTreasure && !bScriptDone && (bVisible || bGhostImage);
+}
+
+
+//*****************************************************************************
 bool CCharacter::IsTileObstacle(
 //Override for NPCs.
 //
@@ -5685,6 +5698,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bSpawnEggs = vars.GetVar(SpawnEggsStr, this->bSpawnEggs);
 	this->bRemovesSword = vars.GetVar(RemovesSwordStr, this->bRemovesSword);
 	this->bExplosiveSafe = vars.GetVar(ExplosiveKegSafeStr, this->bExplosiveSafe);
+	this->bMinimapTreasure = vars.GetVar(MinimapTreasureStr, this->bMinimapTreasure);
 
 	if (vars.DoesVarExist(MovementTypeStr)) {
 		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
@@ -5838,6 +5852,8 @@ const
 		vars.SetVar(RemovesSwordStr, this->bRemovesSword);
 	if (this->bExplosiveSafe)
 		vars.SetVar(ExplosiveKegSafeStr, this->bExplosiveSafe);
+	if (this->bMinimapTreasure)
+		vars.SetVar(MinimapTreasureStr, this->bMinimapTreasure);
 	if (this->eMovement)
 		vars.SetVar(MovementTypeStr, this->eMovement);
 

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -159,6 +159,7 @@ public:
 	bool           IsSafeToPlayer() const {return this->bSafeToPlayer;}
 	bool           IsSwordSafeToPlayer() const {return this->bSwordSafeToPlayer;}
 	virtual bool   IsTileObstacle(const UINT wTileNo) const;
+	virtual bool   IsMinimapTreasure() const;
 	bool IsValidEntityWait(const CCharacterCommand& command, const CDbRoom& room) const;
 	bool           RemovesSword() const {return this->bRemovesSword;}
 
@@ -316,6 +317,7 @@ private:
 	bool bSpawnEggs;           //will spawn eggs in reaction to combats
 	bool bRemovesSword;        //prevents player having sword when equipped
 	bool bExplosiveSafe;       //sword does not detonate powder kegs
+	bool bMinimapTreasure;     //counts as collectable item for minimap when visible and not ended
 
 	UINT wJumpLabel;			//if non-zero, jump to the label if this command is satisfied
 	bool bWaitingForCueEvent;

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -149,6 +149,7 @@ namespace ScriptFlag
 		SpawnEggs=25,           //will spawn eggs in reaction to combats
 		RemovesSword=26,        //prevents player having sword when equipped
 		ExplosiveSafe=27,       //sword does not detonate powder kegs
+		MinimapTreasure=28,     //counts as collectable item for minimap when visible and not ended
 	};
 
 	//Inventory and global script types.

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -857,6 +857,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_ArrayVarNameExpression: strText = "Variable Name/Expression"; break;
 		case MID_ArrayIndexLabel: strText = "Index"; break;
 		case MID_CantChangeVarType: strText = "Var type can't be changed between array and non-array"; break;
+		case MID_MinimapTreasure: strText = "Minimap treasure"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -2818,6 +2818,14 @@ bool CDbRoom::HasGrabbableItems() const
 			return true;
 	}
 
+	for (CMonster* pMonster = this->pFirstMonster; pMonster != NULL;
+		pMonster = pMonster->pNext)
+	{
+		//Monster flagged as being a collectable treasure
+		if (pMonster->IsMinimapTreasure())
+			return true;
+	}
+
 	return false;
 }
 

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -239,6 +239,7 @@ public:
 	bool          IsSpawnEggTriggered(const CCueEvents& CueEvents) const;
 	virtual bool  IsSwimming() const {return this->eMovement == WATER;}
 	virtual bool  IsTileObstacle(const UINT wTileNo) const;
+	virtual bool  IsMinimapTreasure() const { return false; }
 	virtual bool  IsVisible() const {return true;}
 	bool          MakeSlowTurn(const UINT wDesiredO);
 	void          MakeStandardMove(CCueEvents &CueEvents,

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -607,6 +607,8 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
   <li><a name="be_omnimovement"><u>Omni movement</u></a>: When a
 	  desired diagonal or orthogonal movement is blocked, then attempt to make
 	  a movement to the side that might help to approach the destination.</li>
+  <li><a name="be_minimaptreasure"><u>Minimap treasure</u></a>:
+      A character with this behavior will count as a collectable item for the purpose of setting the room color on the minimap. This only applies if the character is visible or has the <a href="#ghost">Ghost display</a> imperative.</li>
 </ol>
 <p><a name="attack"><b>*Attack</b></a> - Monsters may not attack the player
 when the player is above the monster, e.g. standing on a raised door when

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1564,6 +1564,7 @@ enum MID_CONSTANT {
   MID_StrongAgainstAspect = 1830,
   MID_RemovesSword = 1832,
   MID_ExplosiveSafe = 1894,
+  MID_MinimapTreasure = 1943,
   MID_CharOptionsTitle = 1836,
   MID_CharOptions = 1837,
   MID_ProcessingSequence = 1838,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1344,6 +1344,10 @@ Removes sword
 [eng]
 Explosive safe
 
+[MID_MinimapTreasure]
+[eng]
+Minimap Treasure
+
 [MID_CharOptionsTitle]
 [eng]
 Character Options


### PR DESCRIPTION
This is effectively a flag you can add to characters so that they make the minimap yellow. To reduce the possibility of mischief, it only works for characters that are visible in some way and haven't ended.