### PR TITLE
RPG: Fix clipboard paste of set monster var

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -7112,7 +7112,7 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 		parseNumber(pCommand->x); skipComma;
 		parseNumber(pCommand->y); skipComma;
 		if (isWInteger(pText + pos))
-			pCommand->w = _Wtoi(pText + pos); //get number
+			pCommand->h = _Wtoi(pText + pos); //get number
 		else
 			pCommand->label = pText + pos; //get text expression
 	break;


### PR DESCRIPTION
Fix error in the clipboard pasting of the Set Monster Var command that was overwriting parameter w with the stat amount