### PR TITLE
RPG: Only allow attacking when back is turned if movement is not blocked

### DIFF
--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -2175,6 +2175,11 @@ bool CMonster::AttackPlayerInFrontWhenBackIsTurned(CCueEvents &CueEvents)
 	if (bPlayerIsFacingMe)
 		return false;
 
+	//Attack if movement in this direction is not forbidden.
+	if (DoesArrowPreventMovement(dx, dy) ||
+		this->pCurrentGame->pRoom->DoesSquarePreventDiagonal(this->wX, this->wY, dx, dy))
+		return false;
+
 	//Cannot attack something above me.
 	if (IsTileAboveMe(wTX, wTY))
 		return false;


### PR DESCRIPTION
"Attack when adjacent" behaviour cannot attack when movement is blocked, but the same was not also true of "attack when back is turned" behaviour. This copies across the same check to "attack when back is turned".

https://forum.caravelgames.com/viewtopic.php?TopicID=46269