### PR TITLE
RPG: Let explosions destroy equipment

### DIFF
--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -4915,9 +4915,9 @@ void CDbRoom::ProcessExplosionSquare(
 			Plot(wX,wY,T_EMPTY);
 		break;
 		default:
-			if (bIsPowerUp(wTileNo))
+			if (bIsPowerUp(wTileNo) || bIsEquipment(wTileNo))
 			{
-				//power up items are destroyed
+				//power up items and equipment are destroyed
 				Plot(wX,wY,T_EMPTY);
 			}
 			//Explosion passes through everything else.


### PR DESCRIPTION
Allows equipment to be destroyed by explosions. This also destroys empty slots as they technically count as equipment.

https://forum.caravelgames.com/viewtopic.php?TopicID=46275