### PR TITLE
RPG: Small UI improvements

### DIFF
--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -93,6 +93,7 @@ const UINT TAG_SWORD_MENU = 1036;
 const UINT TAG_SHIELD_MENU = 1037;
 const UINT TAG_ACCESSORY_MENU = 1038;
 const UINT TAG_KEY_MENU = 1039;
+const UINT TAG_HEALTH_MENU = 1043;
 
 const UINT TAG_UNDO = 1040;
 const UINT TAG_REDO = 1041;
@@ -839,6 +840,11 @@ CEditRoomScreen::CEditRoomScreen()
 	const UINT CX_KEYMENU = (CDrodBitmapManager::CX_TILE + CX_MENUSPACE) * 3; //3x2
 	const UINT CY_KEYMENU = (CDrodBitmapManager::CY_TILE + CY_MENUSPACE) * 2;
 
+	static const int X_HEALTH_MENU = X_OBSMENU;
+	static const int Y_HEALTH_MENU = Y_LIGHTMENU + CDrodBitmapManager::CY_TILE/2;
+	const UINT CX_HEALTH_MENU = (CDrodBitmapManager::CX_TILE + CX_MENUSPACE) * 2; //2x2
+	const UINT CY_HEALTH_MENU = (CDrodBitmapManager::CY_TILE + CY_MENUSPACE) * 2;
+
 	//Pop-up map
 	static const UINT BIGMAP_MARGIN = 100;
 	const UINT CX_BIGMAP = CDrodBitmapManager::CX_ROOM - 2*BIGMAP_MARGIN;
@@ -985,6 +991,17 @@ CEditRoomScreen::CEditRoomScreen()
 	pObjectMenu->DrawBackground(true);
 	for (UINT key=0; key<KeyCount; ++key)
 		pObjectMenu->AddObject(key, 1, 1, KeyDisplayTiles + key);
+	pObjectMenu->Hide();
+	AddWidget(pObjectMenu);
+
+	pObjectMenu = new CObjectMenuWidget(TAG_HEALTH_MENU, X_HEALTH_MENU, Y_HEALTH_MENU,
+		CX_HEALTH_MENU, CY_HEALTH_MENU, CX_MENUSPACE, CY_MENUSPACE, MenuBGColor);
+	if (!pObjectMenu) throw CException("CEditRoomScreen: Couldn't allocate resources");
+	pObjectMenu->DrawBackground(true);
+	pObjectMenu->AddObject(T_HEALTH_SM, 1, 1, MenuDisplayTiles[T_HEALTH_SM]);
+	pObjectMenu->AddObject(T_HEALTH_MED, 1, 1, MenuDisplayTiles[T_HEALTH_MED]);
+	pObjectMenu->AddObject(T_HEALTH_BIG, 1, 1, MenuDisplayTiles[T_HEALTH_BIG]);
+	pObjectMenu->AddObject(T_HEALTH_HUGE, 1, 1, MenuDisplayTiles[T_HEALTH_HUGE]);
 	pObjectMenu->Hide();
 	AddWidget(pObjectMenu);
 
@@ -2351,6 +2368,19 @@ void CEditRoomScreen::IncrementMenuSelection(const bool bForward) //[default=tru
 			this->pRoomWidget->SetAnimateMoves(false);
 			pObsMenu->PopUp();
 			SetMenuItem(wLastFloor, pObsMenu->GetSelectedObject());
+			this->pRoomWidget->SetAnimateMoves(true);
+			Paint();
+		}
+		break;
+
+		case T_HEALTH_SM: case T_HEALTH_MED:
+		case T_HEALTH_BIG: case T_HEALTH_HUGE:
+		{
+			CObjectMenuWidget* pObsMenu = DYN_CAST(CObjectMenuWidget*, CWidget*, GetWidget(TAG_HEALTH_MENU));
+			pObsMenu->SetSelectedObject(this->wSelectedObject);
+			this->pRoomWidget->SetAnimateMoves(false);
+			pObsMenu->PopUp();
+			SetMenuItem(this->wSelectedObject, pObsMenu->GetSelectedObject());
 			this->pRoomWidget->SetAnimateMoves(true);
 			Paint();
 		}

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1806,7 +1806,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 					def = (int)pCharacter->getDEF();
 					ability = EquipmentDescription::GetEquipmentAbility(pCharacter, ScriptFlag::Weapon, wszCRLF);
 				}
-			} else {
+			} else if (st.sword) {
 				ability = EquipmentDescription::GetPredefinedWeaponAbility(st.sword, wszCRLF);
 			}
 		break;
@@ -1822,7 +1822,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 					atk = (int)pCharacter->getATK();
 					ability = EquipmentDescription::GetEquipmentAbility(pCharacter, ScriptFlag::Armor, wszCRLF);
 				}
-			} else {
+			} else if (st.shield) {
 				ability = EquipmentDescription::GetPredefinedShieldAbility(st.shield);
 			}
 		break;
@@ -1839,7 +1839,7 @@ WSTRING CGameScreen::GetEquipmentPropertiesText(const UINT eCommand)
 					def = (int)pCharacter->getDEF();
 					ability = EquipmentDescription::GetEquipmentAbility(pCharacter, ScriptFlag::Accessory, wszCRLF);
 				}
-			} else {
+			} else if (st.accessory) {
 				ability = EquipmentDescription::GetPredefinedAccessoryAbility(st.accessory);
 			}
 		break;

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -874,7 +874,9 @@ void CRoomWidget::HandleMouseUp(const SDL_MouseButtonEvent &Button)
 	if (Button.button == SDL_BUTTON_RIGHT ||
 			(bDisableMouseMovement && Button.button == SDL_BUTTON_LEFT))
 	{
-		DisplayRoomCoordSubtitle(wX,wY);
+		if ((SDL_GetModState() & KMOD_CTRL) == 0) {
+			DisplayRoomCoordSubtitle(wX, wY);
+		}
 
 		//Highlighting a customized item.
 		this->wHighlightX = wX;

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1957,6 +1957,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 
 	bool bAttackAdj = pMonster->wType == M_WATERSKIPPER || pMonster->wType == M_SEEP;
 	bool bAttackInFront = pMonster->wType == M_EYE || pMonster->wType == M_MADEYE;
+	bool bSurprisedBehind = pMonster->wType == M_EYE || pMonster->wType == M_MADEYE;
 	bool bAttackInFrontWhenBack = pMonster->wType == M_GOBLIN || pMonster->wType == M_GOBLINKING;
 	bool bSpawnEggs = pMonster->wType == M_QROACH;
 	bool bCustomWeakness = false, bCustomDescription = false;
@@ -1967,6 +1968,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
 		bAttackAdj |= pCharacter->AttacksWhenAdjacent();
 		bAttackInFront |= pCharacter->AttacksInFront();
+		bSurprisedBehind |= pCharacter->TurnToFacePlayerWhenFighting();
 		bAttackInFrontWhenBack |= pCharacter->AttacksInFrontWhenBackTurned();
 		bSpawnEggs |= pCharacter->CanSpawnEggs();
 		bCustomWeakness = pCharacter->HasCustomWeakness();
@@ -2043,6 +2045,16 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 			wstr += wszSpace;
 		}
 		wstr += g_pTheDB->GetMessageText(MID_GoblinAbility);
+		++count;
+	}
+	if (bSurprisedBehind)
+	{
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_BehaviorSurprisedBehind);
 		++count;
 	}
 	if (pMonster->CanAttackFirst())

--- a/drodrpg/Data/Help/1/keyboard.html
+++ b/drodrpg/Data/Help/1/keyboard.html
@@ -145,6 +145,8 @@ contextual information.  For instance, right-clicking <b>door openers</b> will
 highlight the doors affected (green: opens, orange: toggles, red: closes).</p>
 <p><b>Right-clicking a monster</b> will display its stats, any special properties,
 the damage you should expect to receive from fighting it, and the expected reward.</p>
+<p>If you hold control while right-clicking, only contextual information will be shown.
+This can be helpful if the tooltip is blocking an area of interest in the room.</p>
 <p><b>Clicking the <a name="minimap">minimap</a></b> will display a larger
 map of all the explored rooms in the level.  Clicking a room will temporarily
 display the current state of that room.


### PR DESCRIPTION
- Adds a pop-out menu for health potions in the editor
- Empty equipment slots aren't described, fixing an issue where they would get a tooltip saying they were metal
- Holding control when right-clicking suppresses the tooltip, only showing highlighting
- "Surprise from behind" is now included in monster descriptions when appropriate