### PR TITLE
RPG: Fix crash with Attack in front behavior

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3543,7 +3543,14 @@ Finish:
 		if (this->bAttackInFront && !this->bAttacked)
 		{
 			this->bAttacked = true;
-			if (this->bAttacked = AttackPlayerWhenInFront(CueEvents) && (this->pCustomChar->wType == M_EYE || this->pCustomChar->wType == M_MADEYE))
+			bool bIsEye = false;
+			if (this->pCustomChar) {
+				bIsEye = (this->pCustomChar->wType == M_EYE || this->pCustomChar->wType == M_MADEYE);
+			} else {
+				bIsEye = (this->wIdentity == M_EYE || this->wIdentity == M_MADEYE);
+			}
+
+			if (this->bAttacked = AttackPlayerWhenInFront(CueEvents) && bIsEye)
 				CueEvents.Add(CID_EvilEyeWoke);
 				
 		}


### PR DESCRIPTION
When a character with "Attack in front" attacks, it now checks to see if its base type is an eye, and if so, sends an "Evil eye woke" event. However, if the character doesn't have a `pCustomChar` set, the game crashes.

The logic has been made more robust to prevent this problem.