### PR TITLE
RPG: Add six additional function primitives

### DIFF
--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -263,20 +263,26 @@ const char* ScriptVars::globalVarShortNames[numGlobals] = {
 
 //*****************************************************************************
 // Values are not case sensitive; caps added here for readability
-const char ScriptVars::primitiveNames[PrimitiveCount][11] =
+const char ScriptVars::primitiveNames[PrimitiveCount][15] =
 {
 	"_abs",
 	"_min",
 	"_max",
 	"_orient",
+	"_facing",
 	"_ox",
 	"_oy",
 	"_rotateCW",
 	"_rotateCCW",
+	"_rotateDist",
 	"_dist0",
 	"_dist1",
 	"_dist2",
-	"_EnemyStat"
+	"_ArrowDir",
+	"_RoomTile",
+	"_EnemyStat",
+	"_MonsterType",
+	"_CharacterType"
 };
 
 //*****************************************************************************
@@ -450,8 +456,14 @@ UINT ScriptVars::getPrimitiveRequiredParameters(PrimitiveType eType)
 		case P_Min:
 		case P_Max:
 		case P_Orient:
+		case P_Facing:
+		case P_RotateDist:
+		case P_ArrowDir:
+		case P_MonsterType:
+		case P_CharacterType:
 			return 2;
 		case P_EnemyStat:
+		case P_RoomTile:
 			return 3;
 		case P_Dist0:
 		case P_Dist1:

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -175,14 +175,20 @@ namespace ScriptVars
 		P_Min,       //(x,y) --> min(x,y)
 		P_Max,       //(x,y) --> max(x,y)
 		P_Orient,    //(dx,dy) --> o
+		P_Facing,    //(dx,dy) --> o
 		P_OrientX,   //o --> dx
 		P_OrientY,   //o --> dy
 		P_RotateCW,  //o --> cw(o)
 		P_RotateCCW, //o --> ccw(o)
+		P_RotateDist,//(o1, o2) --> number of turns between the two
 		P_Dist0,     //L-infinity norm
 		P_Dist1,     //L-1 norm (Manhattan distance)
 		P_Dist2,     //L-2 norm (Euclidean distance)
+		P_ArrowDir,  //(x,y) --> direction of arrow at (x,y)
+		P_RoomTile,  //(x,y,z) --> id of room tile at (x,y) on layer z
 		P_EnemyStat, //(x,y,stat) --> stat value of enemy at (x,y)
+		P_MonsterType,//(x,y) --> type of monster at (x,y), or -1 if no monster is there
+		P_CharacterType,//(x,y) --> appearance of character at (x,y) or -1 if no character is there
 		PrimitiveCount
 	};
 
@@ -207,7 +213,7 @@ namespace ScriptVars
 	extern const char predefinedVarTexts[PredefinedVarCount][16];
 	extern const UINT predefinedVarMIDs[PredefinedVarCount];
 	extern string midTexts[PredefinedVarCount];
-	extern const char primitiveNames[PrimitiveCount][11]; //expand buffer size as needed
+	extern const char primitiveNames[PrimitiveCount][15]; //expand buffer size as needed
 
 	//Global game var subset quick reference.
 	static const UINT numGlobals=47;

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -40,6 +40,7 @@
 #define TILECONSTANTS_H
 
 #include <BackEndLib/Types.h>
+#include "GameConstants.h"
 #include "../Texts/MIDs.h"
 
 //Tile constants--reordering existing constants may break macros.  Add new
@@ -231,6 +232,21 @@ static inline UINT getToggledForceArrow(const UINT t) {
 		case T_ARROW_OFF_N:  return T_ARROW_N;
 
 		default: return T_EMPTY;
+	}
+}
+
+static inline UINT getForceArrowDirection(const UINT t) {
+	switch (t) {
+		case T_ARROW_NE: return NE;
+		case T_ARROW_E:  return E;
+		case T_ARROW_SE: return SE;
+		case T_ARROW_S:  return S;
+		case T_ARROW_SW: return SW;
+		case T_ARROW_W:  return W;
+		case T_ARROW_NW: return NW;
+		case T_ARROW_N:  return N;
+
+		default: return NO_ORIENTATION;
 	}
 }
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -945,13 +945,20 @@ The variable names are case-insensitive.
 <p><a name="min">* <b>_min(x,y)</b></a> - Returns the lesser of two values</p>
 <p><a name="max">* <b>_max(x,y)</b></a> - Returns the greater of two values</p>
 <p><a name="orient">* <b>_orient(dx,dy)</b></a> - Returns an orientation id (0-8), given x,y directional offsets</p>
+<p><a name="facing">* <b>_facing(dx,dy)</b></a> - Returns the orientation id (0-8) most directly facing in the direction of the given x,y vector</p>
 <p><a name="ox">* <b>_ox(o)</b></a> - Given an orientation id (0-8), returns its x component offset (-1, 0, 1).  Given an invalid orientation value, the same value is returned.</p>
 <p><a name="oy">* <b>_oy(o)</b></a> - Given an orientation id (0-8), returns its y component offset (-1, 0, 1).  Given an invalid orientation value, the same value is returned.</p>
 <p><a name="rotatecw">* <b>_rotateCW(o)</b></a> - Given an orientation id (0-8), returns the id of the orientation in a clockwise direction.  Given an invalid orientation value, the same value is returned.</p>
 <p><a name="rotateccw">* <b>_rotateCCW(o)</b></a> - Given an orientation id (0-8), returns the id of the orientation in a counter-clockwise direction.  Given an invalid orientation value, the same value is returned.</p>
+<p><a name="rotatedist">* <b>_rotateDist(o1, o2)</b></a> - Give two orientation ids (0-8), returns the number of rotations between them. If either value is invalid, or has a value of 4, returns a value of zero.</p>
 <p><a name="dist0">* <b>_dist0(x1,y1,x2,y2)</b></a> - Returns the L-infinity norm (max axial distance) between two 2-D coordinates.</p>
 <p><a name="dist1">* <b>_dist1(x1,y1,x2,y2)</b></a> - Returns the L-1 norm (Manhattan distance) between two 2-D coordinates.</p>
 <p><a name="dist2">* <b>_dist2(x1,y1,x2,y2)</b></a> - Returns the L-2 norm (Euclidean distance) between two 2-D coordinates.</p>
+<p><a name="arrowdir">* <b>_ArrowDir(x,y)</b></a> - Returns the the orientation id (0-8) for the arrow at the room location (x,y). If no arrow is present, returns a value of 4.</p>
+<p><a name="roomtile">* <b>_RoomTile(x,y,z)</b></a> - Returns the numeric id of the room tile at (x,y). Use the z parameter to select the tile layer.<br/>
+Supported layer values - 0 -> O Layer, 1 -> F Layer, 2 -> T Layer <br/>
+Hint: Each layer corresponds to a tab in the editor's tile selection dialog.
+</p>
 <p><a name="enemystat">* <b>_EnemyStat(x,y,stat)</b></a> - Returns the stat value of the
   enemy at room location (x,y).  If no enemy is at the current location, the result
   is zero.<br />
@@ -959,6 +966,12 @@ The variable names are case-insensitive.
   <i>Hint:</i> Use within the value expression of <i>Set monster var</i> to make
   relative offsets to an enemy's stats.<br />
   <i>Example to reduce HP of the enemy at room position (10,10) by 1:</i> Set monster var HP,10,10,_EnemyStat(10, 10, 0) - 1
+</p>
+<p><a name="monstertype">* <b>_MonsterType(x,y)</b></a> - Returns the numeric monster type of the monster at (x,y). If no monster is present on the tile, -1 is returned.<br/>
+Hint: This can be used to compare the monsters in different tiles, or for providing a value for _MyScript injection.
+</p>
+<p><a name="charactertype">* <b>_CharacterType(x,y)</b></a> - Returns the logical type of the scripted character at (x,y). If no character is present on the tile, -1 is returned.<br/>
+  Hint: This can be used to provide a value for _MyScript injection.
 </p>
 
 <p><a name="playerinputvars"><b>List of player command input variables</b></a></p>


### PR DESCRIPTION
Ports over the following function primitives that exist in TSS to RPG:

- `_facing` - The orientation that is closest to the given (x,y) vector
- `_rotateDist` - How many rotations are between (o1,o2)
- `_ArrowDir` - Which way is an arrow at (x,y) pointing
- `_RoomTile` - The tile type at (x,y,layer)
- `_MonsterType` - Type of monster at (x,y)
- `_CharacterType` - Type of NPC at (x,y)