### PR TITLE
RPG: Add more room interaction behaviours

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1542,6 +1542,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBehaviorListBox->AddItem(ScriptFlag::AttackLast, g_pTheDB->GetMessageText(MID_AttackLast));
 	this->pBehaviorListBox->AddItem(ScriptFlag::RemovesSword, g_pTheDB->GetMessageText(MID_RemovesSword));
 	this->pBehaviorListBox->AddItem(ScriptFlag::ExplosiveSafe, g_pTheDB->GetMessageText(MID_ExplosiveSafe));
+	this->pBehaviorListBox->AddItem(ScriptFlag::WallMirrorSafe, g_pTheDB->GetMessageText(MID_WallMirrorSafe));
 	this->pBehaviorListBox->AddItem(ScriptFlag::DropTrapdoors, g_pTheDB->GetMessageText(MID_DropTrapdoors));
 	this->pBehaviorListBox->AddItem(ScriptFlag::MoveIntoSwords, g_pTheDB->GetMessageText(MID_MoveIntoSwords));
 	this->pBehaviorListBox->AddItem(ScriptFlag::PushObjects, g_pTheDB->GetMessageText(MID_PushObjects));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1532,6 +1532,9 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBehaviorListBox->AddItem(ScriptFlag::SpawnEggs, g_pTheDB->GetMessageText(MID_SpawnEggs));
 	this->pBehaviorListBox->AddItem(ScriptFlag::GoblinWeakness, g_pTheDB->GetMessageText(MID_BehaviorGoblinWeakness));
 	this->pBehaviorListBox->AddItem(ScriptFlag::SerpentWeakness, g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness));
+	this->pBehaviorListBox->AddItem(ScriptFlag::HotTileImmune, g_pTheDB->GetMessageText(MID_HotTileImmune));
+	this->pBehaviorListBox->AddItem(ScriptFlag::FiretrapImmune, g_pTheDB->GetMessageText(MID_FiretrapImmune));
+	this->pBehaviorListBox->AddItem(ScriptFlag::MistImmune, g_pTheDB->GetMessageText(MID_MistImmune));
 	this->pBehaviorListBox->AddItem(ScriptFlag::Metal, g_pTheDB->GetMessageText(MID_BehaviorMetal));
 	this->pBehaviorListBox->AddItem(ScriptFlag::LuckyGR, g_pTheDB->GetMessageText(MID_BehaviorLuckyGR));
 	this->pBehaviorListBox->AddItem(ScriptFlag::LuckyXP, g_pTheDB->GetMessageText(MID_DoubleXP));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1536,6 +1536,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBehaviorListBox->AddItem(ScriptFlag::LuckyGR, g_pTheDB->GetMessageText(MID_BehaviorLuckyGR));
 	this->pBehaviorListBox->AddItem(ScriptFlag::LuckyXP, g_pTheDB->GetMessageText(MID_DoubleXP));
 	this->pBehaviorListBox->AddItem(ScriptFlag::Briar, g_pTheDB->GetMessageText(MID_BehaviorBriarCut));
+	this->pBehaviorListBox->AddItem(ScriptFlag::CutTarAnywhere, g_pTheDB->GetMessageText(MID_CutTarAnywhere));
 	this->pBehaviorListBox->AddItem(ScriptFlag::NoEnemyDefense, g_pTheDB->GetMessageText(MID_NoEnemyDefense));
 	this->pBehaviorListBox->AddItem(ScriptFlag::AttackFirst, g_pTheDB->GetMessageText(MID_AttackFirst));
 	this->pBehaviorListBox->AddItem(ScriptFlag::AttackLast, g_pTheDB->GetMessageText(MID_AttackLast));

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -152,6 +152,27 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 		text += g_pTheDB->GetMessageText(MID_BehaviorBeamBlock);
 		needSeparator = true;
 	}
+	if (!pCharacter->DamagedByHotTiles())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_HotTileImmune);
+		needSeparator = true;
+	}
+	if (!pCharacter->DamagedByFiretraps())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_FiretrapImmune);
+		needSeparator = true;
+	}
+	if (pCharacter->IsMistImmune())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_MistImmune);
+		needSeparator = true;
+	}
 	if (pCharacter->CanCutBriar())
 	{
 		if (needSeparator)

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -222,6 +222,13 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 		text += g_pTheDB->GetMessageText(MID_ExplosiveSafe);
 		needSeparator = true;
 	}
+	if (pCharacter->IsWallAndMirrorSafe())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_WallMirrorSafe);
+		needSeparator = true;
+	}
 	if (pCharacter->HasCustomDescription()) {
 		vector<WSTRING> descriptions = pCharacter->GetCustomDescriptions();
 

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -159,6 +159,13 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 		text += g_pTheDB->GetMessageText(MID_BehaviorBriarCut);
 		needSeparator = true;
 	}
+	if (pCharacter->CanCutTarAnywhere())
+	{
+		if (needSeparator)
+			text += separator;
+		text += g_pTheDB->GetMessageText(MID_CutTarAnywhere);
+		needSeparator = true;
+	}
 	if (pCharacter->IsLuckyGR())
 	{
 		if (needSeparator)

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2095,6 +2095,15 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		wstr += g_pTheDB->GetMessageText(MID_ExplosiveSafe);
 		++count;
 	}
+	if (pMonster->IsWallAndMirrorSafe()) {
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_WallMirrorSafe);
+		++count;
+	}
 	if (bCustomWeakness) {
 		if (count)
 		{

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1961,7 +1961,8 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 	bool bAttackInFrontWhenBack = pMonster->wType == M_GOBLIN || pMonster->wType == M_GOBLINKING;
 	bool bSpawnEggs = pMonster->wType == M_QROACH;
 	bool bCustomWeakness = false, bCustomDescription = false;
-	bool bExplosiveSafe = pMonster->IsExplosiveSafe();;
+	bool bExplosiveSafe = pMonster->IsExplosiveSafe();
+	bool bMistImmune = false;
 
 	if (pMonster->wType == M_CHARACTER)
 	{
@@ -1973,6 +1974,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		bSpawnEggs |= pCharacter->CanSpawnEggs();
 		bCustomWeakness = pCharacter->HasCustomWeakness();
 		bCustomDescription = pCharacter->HasCustomDescription();
+		bMistImmune = pCharacter->IsMistImmune();
 	}
 
 	if (pMonster->HasRayGun())
@@ -2084,6 +2086,36 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 			wstr += wszSpace;
 		}
 		wstr += g_pTheDB->GetMessageText(MID_RoachQueenAbility);
+		++count;
+	}
+	if (!pMonster->DamagedByHotTiles())
+	{
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_HotTileImmune);
+		++count;
+	}
+	if (!pMonster->DamagedByFiretraps())
+	{
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_FiretrapImmune);
+		++count;
+	}
+	if (bMistImmune)
+	{
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_MistImmune);
 		++count;
 	}
 	if (bExplosiveSafe) {

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -136,6 +136,9 @@ const UINT MAX_ANSWERS = 9;
 #define CutTarAnywhereStr "CutTarAnywhere"
 #define MovementTypeStr "MovementType"
 #define WallMirrorSafeStr "WallMirrorSafe"
+#define HotTileImmuneStr "HotTileImmune"
+#define FiretrapImmuneStr "FiretrapImmune"
+#define MistImmuneStr "MistImmune"
 
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
 
@@ -253,7 +256,7 @@ CCharacter::CCharacter(
 	, bAttackFirst(false), bAttackLast(false)
 	, bDropTrapdoors(false), bMoveIntoSwords(false), bPushObjects(false), bSpawnEggs(false)
 	, bRemovesSword(false) , bExplosiveSafe(false), bMinimapTreasure(false), bCutTarAnywhere(false)
-	, bWallMirrorSafe(false)
+	, bWallMirrorSafe(false), bHotTileImmune(false), bFiretrapImmune(false), bMistImmune(false)
 
 	, wJumpLabel(0)
 	, bWaitingForCueEvent(false)
@@ -2769,6 +2772,7 @@ void CCharacter::Process(
 						this->bAttackFirst = this->bAttackLast = this->bRemovesSword =
 						this->bDropTrapdoors = this->bMoveIntoSwords = this->bPushObjects = this->bSpawnEggs =
 						this->bExplosiveSafe = this->bMinimapTreasure = this->bCutTarAnywhere = this->bWallMirrorSafe =
+						this->bHotTileImmune = this->bFiretrapImmune = this->bMistImmune =
 							false;
 						this->movementIQ = SmartDiagonalOnly;
 					break;
@@ -2867,6 +2871,15 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::MinimapTreasure:
 						this->bMinimapTreasure = true;
+					break;
+					case ScriptFlag::HotTileImmune:
+						this->bHotTileImmune = true;
+					break;
+					case ScriptFlag::FiretrapImmune:
+						this->bFiretrapImmune = true;
+					break;
+					case ScriptFlag::MistImmune:
+						this->bMistImmune = true;
 					break;
 
 					default:
@@ -5493,6 +5506,15 @@ bool CCharacter::IsMinimapTreasure() const
 	return bMinimapTreasure && !bScriptDone && (bVisible || bGhostImage);
 }
 
+//*****************************************************************************
+bool CCharacter::IsOnMistTile() const
+{
+	// If immune to mist, always act as if not on mist
+	if (bMistImmune)
+		return false;
+
+	return CMonster::IsOnMistTile();
+}
 
 //*****************************************************************************
 bool CCharacter::IsTileObstacle(
@@ -6025,6 +6047,9 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bMinimapTreasure = vars.GetVar(MinimapTreasureStr, this->bMinimapTreasure);
 	this->bCutTarAnywhere = vars.GetVar(CutTarAnywhereStr, this->bCutTarAnywhere);
 	this->bWallMirrorSafe = vars.GetVar(WallMirrorSafeStr, this->bWallMirrorSafe);
+	this->bHotTileImmune = vars.GetVar(HotTileImmuneStr, this->bHotTileImmune);
+	this->bFiretrapImmune = vars.GetVar(FiretrapImmuneStr, this->bFiretrapImmune);
+	this->bMistImmune = vars.GetVar(MistImmuneStr, this->bMistImmune);
 
 	if (vars.DoesVarExist(MovementTypeStr)) {
 		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
@@ -6184,6 +6209,12 @@ const
 		vars.SetVar(CutTarAnywhereStr, this->bCutTarAnywhere);
 	if (this->bWallMirrorSafe)
 		vars.SetVar(WallMirrorSafeStr, this->bWallMirrorSafe);
+	if (this->bHotTileImmune)
+		vars.SetVar(HotTileImmuneStr, this->bHotTileImmune);
+	if (this->bFiretrapImmune)
+		vars.SetVar(FiretrapImmuneStr, this->bFiretrapImmune);
+	if (this->bMistImmune)
+		vars.SetVar(MistImmuneStr, this->bMistImmune);
 	if (this->eMovement)
 		vars.SetVar(MovementTypeStr, this->eMovement);
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -133,6 +133,7 @@ const UINT MAX_ANSWERS = 9;
 #define RemovesSwordStr "RemovesSword"
 #define ExplosiveKegSafeStr "ExplosiveSafe"
 #define MinimapTreasureStr "MinimapTreasure"
+#define CutTarAnywhereStr "CutTarAnywhere"
 #define MovementTypeStr "MovementType"
 
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
@@ -250,7 +251,7 @@ CCharacter::CCharacter(
 	, bMetal(false), bLuckyGR(false), bLuckyXP(false), bBriar(false), bNoEnemyDEF(false)
 	, bAttackFirst(false), bAttackLast(false)
 	, bDropTrapdoors(false), bMoveIntoSwords(false), bPushObjects(false), bSpawnEggs(false)
-	, bRemovesSword(false) , bExplosiveSafe(false), bMinimapTreasure(false)
+	, bRemovesSword(false) , bExplosiveSafe(false), bMinimapTreasure(false), bCutTarAnywhere(false)
 
 	, wJumpLabel(0)
 	, bWaitingForCueEvent(false)
@@ -2765,7 +2766,7 @@ void CCharacter::Process(
 						this->bMetal = this->bLuckyGR = this->bLuckyXP = this->bBriar = this->bNoEnemyDEF =
 						this->bAttackFirst = this->bAttackLast = this->bRemovesSword =
 						this->bDropTrapdoors = this->bMoveIntoSwords = this->bPushObjects = this->bSpawnEggs =
-						this->bExplosiveSafe = this->bMinimapTreasure =
+						this->bExplosiveSafe = this->bMinimapTreasure = this->bCutTarAnywhere =
 							false;
 						this->movementIQ = SmartDiagonalOnly;
 					break;
@@ -2855,6 +2856,9 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::ExplosiveSafe:
 						this->bExplosiveSafe = true;
+					break;
+					case ScriptFlag::CutTarAnywhere:
+						this->bCutTarAnywhere = true;
 					break;
 					case ScriptFlag::MinimapTreasure:
 						this->bMinimapTreasure = true;
@@ -6014,6 +6018,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bRemovesSword = vars.GetVar(RemovesSwordStr, this->bRemovesSword);
 	this->bExplosiveSafe = vars.GetVar(ExplosiveKegSafeStr, this->bExplosiveSafe);
 	this->bMinimapTreasure = vars.GetVar(MinimapTreasureStr, this->bMinimapTreasure);
+	this->bCutTarAnywhere = vars.GetVar(CutTarAnywhereStr, this->bCutTarAnywhere);
 
 	if (vars.DoesVarExist(MovementTypeStr)) {
 		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
@@ -6169,6 +6174,8 @@ const
 		vars.SetVar(ExplosiveKegSafeStr, this->bExplosiveSafe);
 	if (this->bMinimapTreasure)
 		vars.SetVar(MinimapTreasureStr, this->bMinimapTreasure);
+	if (this->bCutTarAnywhere)
+		vars.SetVar(CutTarAnywhereStr, this->bCutTarAnywhere);
 	if (this->eMovement)
 		vars.SetVar(MovementTypeStr, this->eMovement);
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -135,6 +135,7 @@ const UINT MAX_ANSWERS = 9;
 #define MinimapTreasureStr "MinimapTreasure"
 #define CutTarAnywhereStr "CutTarAnywhere"
 #define MovementTypeStr "MovementType"
+#define WallMirrorSafeStr "WallMirrorSafe"
 
 #define SKIP_WHITESPACE(str, index) while (iswspace(str[index])) ++index
 
@@ -252,6 +253,7 @@ CCharacter::CCharacter(
 	, bAttackFirst(false), bAttackLast(false)
 	, bDropTrapdoors(false), bMoveIntoSwords(false), bPushObjects(false), bSpawnEggs(false)
 	, bRemovesSword(false) , bExplosiveSafe(false), bMinimapTreasure(false), bCutTarAnywhere(false)
+	, bWallMirrorSafe(false)
 
 	, wJumpLabel(0)
 	, bWaitingForCueEvent(false)
@@ -2766,7 +2768,7 @@ void CCharacter::Process(
 						this->bMetal = this->bLuckyGR = this->bLuckyXP = this->bBriar = this->bNoEnemyDEF =
 						this->bAttackFirst = this->bAttackLast = this->bRemovesSword =
 						this->bDropTrapdoors = this->bMoveIntoSwords = this->bPushObjects = this->bSpawnEggs =
-						this->bExplosiveSafe = this->bMinimapTreasure = this->bCutTarAnywhere =
+						this->bExplosiveSafe = this->bMinimapTreasure = this->bCutTarAnywhere = this->bWallMirrorSafe =
 							false;
 						this->movementIQ = SmartDiagonalOnly;
 					break;
@@ -2856,6 +2858,9 @@ void CCharacter::Process(
 					break;
 					case ScriptFlag::ExplosiveSafe:
 						this->bExplosiveSafe = true;
+					break;
+					case ScriptFlag::WallMirrorSafe:
+						this->bWallMirrorSafe = true;
 					break;
 					case ScriptFlag::CutTarAnywhere:
 						this->bCutTarAnywhere = true;
@@ -6019,6 +6024,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 	this->bExplosiveSafe = vars.GetVar(ExplosiveKegSafeStr, this->bExplosiveSafe);
 	this->bMinimapTreasure = vars.GetVar(MinimapTreasureStr, this->bMinimapTreasure);
 	this->bCutTarAnywhere = vars.GetVar(CutTarAnywhereStr, this->bCutTarAnywhere);
+	this->bWallMirrorSafe = vars.GetVar(WallMirrorSafeStr, this->bWallMirrorSafe);
 
 	if (vars.DoesVarExist(MovementTypeStr)) {
 		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
@@ -6176,6 +6182,8 @@ const
 		vars.SetVar(MinimapTreasureStr, this->bMinimapTreasure);
 	if (this->bCutTarAnywhere)
 		vars.SetVar(CutTarAnywhereStr, this->bCutTarAnywhere);
+	if (this->bWallMirrorSafe)
+		vars.SetVar(WallMirrorSafeStr, this->bWallMirrorSafe);
 	if (this->eMovement)
 		vars.SetVar(MovementTypeStr, this->eMovement);
 

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -79,6 +79,7 @@ public:
 	virtual bool   CanAttackFirst() const {return this->bAttackFirst;}
 	virtual bool   CanAttackLast() const {return this->bAttackLast;}
 	virtual bool   CanCutBriar() const {return this->bBriar;}
+	virtual bool   CanCutTarAnywhere() const { return this->bCutTarAnywhere; }
 	virtual bool   CanSpawnEggs() const {return this->bSpawnEggs;}
 	void           ChangeHold(const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info, const bool bGetNewScriptID=true);
 	static void    ChangeHoldForCommands(COMMAND_VECTOR& commands, const CDbHold* pOldHold, CDbHold* pNewHold, CImportInfo& info, bool bUpdateSpeech);
@@ -321,6 +322,7 @@ private:
 	bool bRemovesSword;        //prevents player having sword when equipped
 	bool bExplosiveSafe;       //sword does not detonate powder kegs
 	bool bMinimapTreasure;     //counts as collectable item for minimap when visible and not ended
+	bool bCutTarAnywhere;      //can cut tarstuff on otherwise non-vulnerable areas
 
 	UINT wJumpLabel;			//if non-zero, jump to the label if this command is satisfied
 	bool bWaitingForCueEvent;

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -163,6 +163,7 @@ public:
 	virtual bool   IsMinimapTreasure() const;
 	bool           IsOpenTileAt(const CCharacterCommand& command, const CCurrentGame* pGame);
 	bool IsValidEntityWait(const CCharacterCommand& command, const CDbRoom& room) const;
+	virtual bool   IsWallAndMirrorSafe() const { return this->bWallMirrorSafe; }
 	bool           RemovesSword() const {return this->bRemovesSword;}
 
 	static bool    IsValidExpression(const WCHAR *pwStr, UINT& index, CDbHold *pHold, const char closingChar=0);
@@ -323,6 +324,7 @@ private:
 	bool bExplosiveSafe;       //sword does not detonate powder kegs
 	bool bMinimapTreasure;     //counts as collectable item for minimap when visible and not ended
 	bool bCutTarAnywhere;      //can cut tarstuff on otherwise non-vulnerable areas
+	bool bWallMirrorSafe;      //sword doesn't break walls or mirrors
 
 	UINT wJumpLabel;			//if non-zero, jump to the label if this command is satisfied
 	bool bWaitingForCueEvent;

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -85,6 +85,8 @@ public:
 	static void    ChangeHoldForCommands(COMMAND_VECTOR& commands, const CDbHold* pOldHold, CDbHold* pNewHold, CImportInfo& info, bool bUpdateSpeech);
 	void           CheckForCueEvent(CCueEvents &CueEvents);
 	virtual bool   CheckForDamage(CCueEvents& CueEvents);
+	virtual bool   DamagedByFiretraps() const { return !bFiretrapImmune; }
+	virtual bool   DamagedByHotTiles() const { return !bHotTileImmune; }
 	void           Defeat();
 	bool           DidPlayerMove(const CCharacterCommand& command, const CSwordsman& player, const int nLastCommand) const;
 	virtual bool   DoesSquareContainObstacle(const UINT wCol, const UINT wRow) const;
@@ -155,6 +157,8 @@ public:
 	bool           IsLuckyXP() const {return this->bLuckyXP;}
 	bool           IsMetal() const {return this->bMetal;}
 	virtual bool   IsMissionCritical() const {return this->bMissionCritical;}
+	bool           IsMistImmune() const { return this->bMistImmune; }
+	virtual bool   IsOnMistTile() const;
 	bool           IsPlayerFacing(const CCharacterCommand& command, const CSwordsman& player) const;
 	bool           IsRestartScriptOnRoomEntrance() const {return this->bRestartScriptOnRoomEntrance;}
 	bool           IsSafeToPlayer() const {return this->bSafeToPlayer;}
@@ -325,6 +329,9 @@ private:
 	bool bMinimapTreasure;     //counts as collectable item for minimap when visible and not ended
 	bool bCutTarAnywhere;      //can cut tarstuff on otherwise non-vulnerable areas
 	bool bWallMirrorSafe;      //sword doesn't break walls or mirrors
+	bool bHotTileImmune;       //not damaged by hotiles
+	bool bFiretrapImmune;      //not damaged by firetraps
+	bool bMistImmune;          //DEF not negated by mist
 
 	UINT wJumpLabel;			//if non-zero, jump to the label if this command is satisfied
 	bool bWaitingForCueEvent;

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -150,6 +150,7 @@ namespace ScriptFlag
 		RemovesSword=26,        //prevents player having sword when equipped
 		ExplosiveSafe=27,       //sword does not detonate powder kegs
 		MinimapTreasure=28,     //counts as collectable item for minimap when visible and not ended
+		CutTarAnywhere=29,      //can cut tarstuff on otherwise non-vulnerable areas
 	};
 
 	//Inventory and global script types.

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -151,6 +151,7 @@ namespace ScriptFlag
 		ExplosiveSafe=27,       //sword does not detonate powder kegs
 		MinimapTreasure=28,     //counts as collectable item for minimap when visible and not ended
 		CutTarAnywhere=29,      //can cut tarstuff on otherwise non-vulnerable areas
+		WallMirrorSafe=30,      //sword doesn't break walls or mirrors
 	};
 
 	//Inventory and global script types.

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -152,6 +152,9 @@ namespace ScriptFlag
 		MinimapTreasure=28,     //counts as collectable item for minimap when visible and not ended
 		CutTarAnywhere=29,      //can cut tarstuff on otherwise non-vulnerable areas
 		WallMirrorSafe=30,      //sword doesn't break walls or mirrors
+		HotTileImmune=31,       //not damaged by hotiles
+		FiretrapImmune=32,      //not damaged by firetraps
+		MistImmune=33,          //DEF not negated by mist
 	};
 
 	//Inventory and global script types.

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3597,6 +3597,30 @@ bool CCurrentGame::IsPlayerSwordExplosiveSafe() const
 }
 
 //*****************************************************************************
+bool CCurrentGame::IsPlayerSwordWallAndMirrorSafe() const
+//Returns: if the player's weapon can't break walls and mirrors
+{
+	CCharacter* pCharacter;
+	if (!IsPlayerSwordDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Weapon);
+		if (pCharacter && pCharacter->IsWallAndMirrorSafe())
+			return true;
+	}
+	if (!IsPlayerShieldDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Armor);
+		if (pCharacter && pCharacter->IsWallAndMirrorSafe())
+			return true;
+	}
+	if (!IsPlayerAccessoryDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Accessory);
+		if (pCharacter && pCharacter->IsWallAndMirrorSafe())
+			return true;
+	}
+
+	return false;
+}
+
+//*****************************************************************************
 bool CCurrentGame::IsPlayerAccessoryDisabled() const
 //Returns: true if the player's accessory is not usable at present, else false
 {
@@ -3874,7 +3898,8 @@ void CCurrentGame::ProcessSwordHit(
 				wSrcX = this->pPlayer->wX;
 				wSrcY = this->pPlayer->wY;
 			}
-			if (wSrcX + nGetOX(wSwordMovement) == wSX && wSrcY + nGetOY(wSwordMovement) == wSY)
+			if (wSrcX + nGetOX(wSwordMovement) == wSX && wSrcY + nGetOY(wSwordMovement) == wSY &&
+				!(pDouble ? pDouble->IsWallAndMirrorSafe() : IsPlayerSwordWallAndMirrorSafe()))
 			{
 				//Head on strike shatters mirror.
 				this->pRoom->Plot(wSX, wSY, T_EMPTY);
@@ -3900,7 +3925,9 @@ void CCurrentGame::ProcessSwordHit(
 	{
 		case T_WALL_B:
 		case T_WALL_H:
-		   this->pRoom->DestroyCrumblyWall(wSX, wSY, CueEvents, wSwordMovement);
+			if (!(pDouble ? pDouble->IsWallAndMirrorSafe() : IsPlayerSwordWallAndMirrorSafe())) {
+				this->pRoom->DestroyCrumblyWall(wSX, wSY, CueEvents, wSwordMovement);
+			}
 		break;
 		default: break;
 	}

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -301,6 +301,7 @@ public:
 	bool     IsPlayerShieldDisabled() const;
 	bool     IsPlayerSwordDisabled() const;
 	bool     IsPlayerSwordExplosiveSafe() const;
+	bool     IsPlayerSwordWallAndMirrorSafe() const;
 	bool     IsSwordMetal(const UINT type) const;
 	bool     IsShieldMetal(const UINT type) const;
 	bool     IsSwordStrongAgainst(const CMonster* pMonster) const;

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -231,6 +231,7 @@ public:
 //	void     BeginDemoRecording(const WCHAR* pwczSetDescription,
 //			const bool bUseCurrentTurnNo=true);
 	bool     CanPlayerCutBriars() const;
+	bool     CanPlayerCutTarAnywhere() const;
 	bool     CanPlayerMoveTo(const UINT wX, const UINT wY) const;
 	bool     changingInventory(CCueEvents& CueEvents, const UINT type, const UINT newEquipment);
 	void     Clear(const bool bNewGame=true);

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -300,6 +300,9 @@ public:
 	bool     IsPlayerAccessoryDisabled() const;
 	bool     IsPlayerShieldDisabled() const;
 	bool     IsPlayerSwordDisabled() const;
+	bool     IsPlayerDamagedByHotTile() const;
+	bool     IsPlayerDamagedByFiretrap() const;
+	bool     IsPlayerMistImmune() const;
 	bool     IsPlayerSwordExplosiveSafe() const;
 	bool     IsPlayerSwordWallAndMirrorSafe() const;
 	bool     IsSwordMetal(const UINT type) const;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -888,6 +888,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_DefenseUpGroup: strText = "Defense gem"; break;
 		case MID_PowerupGroup: strText = "Health potion or stat gem"; break;
 		case MID_EquipmentGroup: strText = "Any equipment or slot"; break;
+		case MID_CutTarAnywhere: strText = "Cut tarstuff anywhere"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -890,6 +890,9 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_EquipmentGroup: strText = "Any equipment or slot"; break;
 		case MID_CutTarAnywhere: strText = "Cut tarstuff anywhere"; break;
 		case MID_WallMirrorSafe: strText = "Wall and mirror safe"; break;
+		case MID_HotTileImmune: strText = "Heatproof"; break;
+		case MID_FiretrapImmune: strText = "Fireproof"; break;
+		case MID_MistImmune: strText = "Mist protection"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -889,6 +889,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_PowerupGroup: strText = "Health potion or stat gem"; break;
 		case MID_EquipmentGroup: strText = "Any equipment or slot"; break;
 		case MID_CutTarAnywhere: strText = "Cut tarstuff anywhere"; break;
+		case MID_WallMirrorSafe: strText = "Wall and mirror safe"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -6043,13 +6043,14 @@ void CDbRoom::ActivateFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEven
 
 	//Damage
 	CSwordsman& player = *(this->pCurrentGame->pPlayer);
+	bool bPlayerHarmed = this->pCurrentGame->IsPlayerDamagedByFiretrap();
 	int damageVal = (int)player.st.firetrapVal;
 
 	if (!damageVal) {
 		return;
 	}
 
-	if (player.wX == wX && player.wY == wY) {
+	if (bPlayerHarmed && player.wX == wX && player.wY == wY) {
 		//Burn player
 		UINT delta = player.CalcDamage(damageVal);
 		player.DecHealth(CueEvents, delta, CID_ExplosionKilledPlayer);
@@ -6057,7 +6058,7 @@ void CDbRoom::ActivateFiretrap(const UINT wX, const UINT wY, CCueEvents& CueEven
 	}
 
 	CMonster* pMonster = this->GetMonsterAtSquare(wX, wY);
-	if (pMonster) {
+	if (pMonster && pMonster->DamagedByFiretraps()) {
 		//Burn monster
 		if (pMonster->IsPiece())
 		{

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -160,6 +160,7 @@ public:
 	void          Clear();
 //	bool          ConfirmPath();
 	bool          Damage(CCueEvents& CueEvents, int damageVal);
+	virtual bool  DamagedByFiretraps() const { return true; }
 	virtual bool  DamagedByHotTiles() const {return true;}
 	virtual void  Delete() { }
 	UINT          DistToSwordsman(const bool bIncludeNonTarget=false) const;

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -153,6 +153,7 @@ public:
 	virtual bool  CanAttackFirst() const {return false;}
 	virtual bool  CanAttackLast() const {return false;}
 	virtual bool  CanCutBriar() const {return false;}
+	virtual bool  CanCutTarAnywhere() const {return false;}
 	virtual bool  CanFindSwordsman() const;
 	virtual bool  CanSmellObjectAt(const UINT wX, const UINT wY) const;
 	virtual bool  CheckForDamage(CCueEvents& CueEvents);

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -242,6 +242,7 @@ public:
 	virtual bool  IsTileObstacle(const UINT wTileNo) const;
 	virtual bool  IsMinimapTreasure() const { return false; }
 	virtual bool  IsVisible() const {return true;}
+	virtual bool  IsWallAndMirrorSafe() const { return false; }
 	bool          MakeSlowTurn(const UINT wDesiredO);
 	void          MakeStandardMove(CCueEvents &CueEvents,
 			const int dx, const int dy);

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -603,6 +603,8 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
 	  Otherwise, it is not allowed (default).</li>
   <li><a name="be_explodesafe"><u>Explosive safe</u></a>:
 	  A piece of equipment with this behavior will prevent the player's sword from detonating bombs and powder kegs, allowing kegs to be pushed with the sword. An NPC with this behavior will not detonate bombs or kegs with their sword.</li>
+    <li><a name="be_wallsafe"><u>Wall and mirror safe</u></a>:
+	  A piece of equipment with this behavior will prevent the player's sword from breaking walls and shattering mirrors. An NPC with this behavior will not break walls or shatter mirrors with their sword.</li>
   <li><a name="be_directonlymovement"><u>Direct-only movement</u></a>: If the
       target is in a diagonal direction from the NPC, but
 	  diagonal movement is blocked, then don't move at all.  If the target is

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -553,6 +553,12 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
 	  NPC emits a beam that halves the player's health on contact.</li>
   <li><a name="be_beam_block"><u>Beam blocker</u></a>:
       Embues custom equipment with the ability to block beam attacks. Swords will prevent beams passing through them, shields protect from beams the player is facing, and accessories will protect from beams in all directions.</li>
+  <li><a name="be_hot_tile_immune"><u>Heatproof</u></a>:
+      Prevents the NPC from being harmed by hot tiles, and custom equipment with this ability protects the player from hot tiles.</li>
+  <li><a name="be_hot_tile_immune"><u>Heatproof</u></a>:
+      Prevents the NPC from being harmed by firetraps, and custom equipment with this ability protects the player from firetraps.</li>
+  <li><a name="be_hot_tile_immune"><u>Heatproof</u></a>:
+      The NPC's DEF is not nullified by mist, and custom equipment with this ability stops the player's DEF being nullified by mist.</li>
   <li><a name="be_surprised"><u>Surprised from behind</u></a>:
 	  If the player attacks a monster with this attribute from behind,
 	  the NPC loses its first attack turn.  For equipment, it gives the player's

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -578,6 +578,10 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
 	  NPC can cut briars with its sword.
 	  Embues custom equipment with briar-cutting attribute (the player's
 	  sword can cut briars).</li>
+  <li><a name="be_cuttar"><u>Cut tarstuff anywhere</u></a>:
+	  NPC can cut tarstuff at any position, not just weak points.
+	  Embues custom equipment with tar-cutting attribute (the player's
+	  sword can cut tarstuff at any position).</li>
   <li><a name="be_noenemydefense"><u>No enemy defense</u></a>:
 	  Attacks nullify the enemy's DEF rating.  Embues custom armor with
 	  protection against monsters with this attack ability.</li>

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1618,6 +1618,9 @@ enum MID_CONSTANT {
   MID_EquipmentGroup = 1972,
   MID_CutTarAnywhere = 1973,
   MID_WallMirrorSafe = 1974,
+  MID_HotTileImmune = 1975,
+  MID_FiretrapImmune = 1976,
+  MID_MistImmune = 1977,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1617,6 +1617,7 @@ enum MID_CONSTANT {
   MID_PowerupGroup = 1971,
   MID_EquipmentGroup = 1972,
   MID_CutTarAnywhere = 1973,
+  MID_WallMirrorSafe = 1974,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1616,6 +1616,7 @@ enum MID_CONSTANT {
   MID_DefenseUpGroup = 1970,
   MID_PowerupGroup = 1971,
   MID_EquipmentGroup = 1972,
+  MID_CutTarAnywhere = 1973,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1615,3 +1615,15 @@ Cut tarstuff anywhere
 [MID_WallMirrorSafe]
 [eng]
 Wall and mirror safe
+
+[MID_HotTileImmune]
+[eng]
+Heatproof
+
+[MID_FiretrapImmune]
+[eng]
+Fireproof
+
+[MID_MistImmune]
+[eng]
+Mist protection

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1607,3 +1607,7 @@ Health potion or stat gem
 [MID_EquipmentGroup]
 [eng]
 Any equipment or slot
+
+[MID_BehaviorCutTarAnywhere]
+[eng]
+Cut tarstuff anywhere

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1611,3 +1611,7 @@ Any equipment or slot
 [MID_BehaviorCutTarAnywhere]
 [eng]
 Cut tarstuff anywhere
+
+[MID_WallMirrorSafe]
+[eng]
+Wall and mirror safe


### PR DESCRIPTION
More behaviours that change how stuff interacts with thigns in the room:

- `Cut tarstuff anywhere`, which is effectively the spear behaviour, allowing any tarstuff to be damaged on any tile.
- `Wall and mirror safe` which stops the player from breaking things
- `Heatproof` and `Fireproof` which protect from hot tiles and firetraps respectively
- `Mist protection` which negates mist's DEF nullifying properties