### PR TITLE
RPG: Fix minor typos in help for new behaviours

### DIFF
--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -555,9 +555,9 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
       Embues custom equipment with the ability to block beam attacks. Swords will prevent beams passing through them, shields protect from beams the player is facing, and accessories will protect from beams in all directions.</li>
   <li><a name="be_hot_tile_immune"><u>Heatproof</u></a>:
       Prevents the NPC from being harmed by hot tiles, and custom equipment with this ability protects the player from hot tiles.</li>
-  <li><a name="be_hot_tile_immune"><u>Heatproof</u></a>:
+  <li><a name="be_firetrap_immune"><u>Fireproof</u></a>:
       Prevents the NPC from being harmed by firetraps, and custom equipment with this ability protects the player from firetraps.</li>
-  <li><a name="be_hot_tile_immune"><u>Heatproof</u></a>:
+  <li><a name="be_mist_immune"><u>Mist protection</u></a>:
       The NPC's DEF is not nullified by mist, and custom equipment with this ability stops the player's DEF being nullified by mist.</li>
   <li><a name="be_surprised"><u>Surprised from behind</u></a>:
 	  If the player attacks a monster with this attribute from behind,


### PR DESCRIPTION
Help files for new behaviours in last commit had some minor copy/paste errors.