### PR TITLE
RPG: Change default shovel score value

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1600,7 +1600,8 @@ void CCurrentGame::InitRPGStats(PlayerStats& s)
 	s.scoreYellowKeys = 10;
 	s.scoreGreenKeys = 20;
 	s.scoreBlueKeys = s.scoreSkeletonKeys = 30;
-	s.scoreGOLD = s.scoreXP = s.scoreShovels = 0;
+	s.scoreGOLD = s.scoreXP = 0;
+	s.scoreShovels = 1;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -354,6 +354,8 @@ UINT ScriptVars::getVarDefault(const ScriptVars::Predefined var)
 		case P_SCORE_BKEY:
 		case P_SCORE_SKEY:
 			return 30;
+		case P_SCORE_SHOVEL:
+			return 1;
 		case P_BEAM:
 			return 50;
 		case P_FIRETRAP:


### PR DESCRIPTION
Change the default score value for shovels to 1 per shovel, so players that aren't messing with score multipliers get some value from them. This will cause it to show up by default in all the score checkpoint breakdowns, including for older holds, but so do other commonly unused resources like Skeleton keys, so I figure it's fine.