### PR TITLE
RPG: Fix scrolled text boxes setting cursor by pos incorrectly

### DIFF
--- a/FrontEndLib/TextBox2DWidget.cpp
+++ b/FrontEndLib/TextBox2DWidget.cpp
@@ -436,7 +436,7 @@ void CTextBox2DWidget::SetCursorByPos(
 			wIndex = wFirstPos + (wLastPos - wFirstPos + 1) / 2;
 			GetPixelLocationAt(this->wTextDisplayIndex, wIndex, wWidth, wHeight);
 
-			if (static_cast<int>(wWidth) > xPos || static_cast<int>(wHeight) > yPos)
+			if (static_cast<int>(wWidth) > xPos)
 			{
 				//We are past the correct character position or line of text.
 				wLastPos = wIndex - 1;


### PR DESCRIPTION
When editing a scroll in the editor, you get a text box that might eventually scroll down. As soon as you scrolled down any amount so that the first line scrolled off the top, clicking on any line of text always set the cursor to the start of the line.

This was happening because it used a binary search to narrow down on the correct location in the line, but included a check on the y position despite us only changing the x position as part of the binary search. As soon as you scrolled, this y check always passed, meaning the binary search kept going for the maximum length of time, always ending up at the start of the line.

This bug is also present in classic DROD, but only reported for RPG because the scrolls are bigger and so fit more text there.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45919

