### PR TITLE
RPG: Fix disabled equipment retaining combat abilities

### DIFF
--- a/drodrpg/DRODLib/Combat.cpp
+++ b/drodrpg/DRODLib/Combat.cpp
@@ -432,8 +432,11 @@ bool CCombat::PlayerDoesStrongHit(const CMonster* pMonster) const
 		if (this->pGame->IsSwordStrongAgainst(pMonster))
 			return true;
 	}
-	if (this->pGame->IsEquipmentStrongAgainst(pMonster, ScriptFlag::Accessory)) {
-		return true;
+	if (!this->pGame->IsPlayerAccessoryDisabled())
+	{
+		if (this->pGame->IsEquipmentStrongAgainst(pMonster, ScriptFlag::Accessory)) {
+			return true;
+		}
 	}
 
 	return false;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3558,15 +3558,22 @@ bool CCurrentGame::DoesPlayerAttackFirst() const
 	if (this->pPlayer->IsHasted() || this->pPlayer->IsInvisible())
 		return true;
 
-	CCharacter* pCharacter = getCustomEquipment(ScriptFlag::Weapon);
-	if (pCharacter && pCharacter->CanAttackFirst())
-		return true;
-	pCharacter = getCustomEquipment(ScriptFlag::Armor);
-	if (pCharacter && pCharacter->CanAttackFirst())
-		return true;
-	pCharacter = getCustomEquipment(ScriptFlag::Accessory);
-	if (pCharacter && pCharacter->CanAttackFirst())
-		return true;
+	CCharacter* pCharacter;
+	if (!IsPlayerSwordDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Weapon);
+		if (pCharacter && pCharacter->CanAttackFirst())
+			return true;
+	}
+	if (!IsPlayerShieldDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Armor);
+		if (pCharacter && pCharacter->CanAttackFirst())
+			return true;
+	}
+	if (!IsPlayerAccessoryDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Accessory);
+		if (pCharacter && pCharacter->CanAttackFirst())
+			return true;
+	}
 
 	return false;
 }
@@ -3578,15 +3585,22 @@ bool CCurrentGame::DoesPlayerAttackLast() const
 	if (this->pPlayer->IsHasted() || this->pPlayer->IsInvisible())
 		return false; //these attributes override a last attack behavior
 
-	CCharacter* pCharacter = getCustomEquipment(ScriptFlag::Weapon);
-	if (pCharacter && pCharacter->CanAttackLast())
-		return true;
-	pCharacter = getCustomEquipment(ScriptFlag::Armor);
-	if (pCharacter && pCharacter->CanAttackLast())
-		return true;
-	pCharacter = getCustomEquipment(ScriptFlag::Accessory);
-	if (pCharacter && pCharacter->CanAttackLast())
-		return true;
+	CCharacter* pCharacter;
+	if (!IsPlayerSwordDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Weapon);
+		if (pCharacter && pCharacter->CanAttackLast())
+			return true;
+	}
+	if (!IsPlayerShieldDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Armor);
+		if (pCharacter && pCharacter->CanAttackLast())
+			return true;
+	}
+	if (!IsPlayerAccessoryDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Accessory);
+		if (pCharacter && pCharacter->CanAttackLast())
+			return true;
+	}
 
 	return false;
 }
@@ -3595,15 +3609,22 @@ bool CCurrentGame::DoesPlayerAttackLast() const
 bool CCurrentGame::DoesPlayerBackstab() const
 //Returns: whether the player has an ability to perform a strong backstab attack
 {
-	CCharacter* pCharacter = getCustomEquipment(ScriptFlag::Weapon);
-	if (pCharacter && pCharacter->TurnToFacePlayerWhenFighting())
-		return true;
-	pCharacter = getCustomEquipment(ScriptFlag::Armor);
-	if (pCharacter && pCharacter->TurnToFacePlayerWhenFighting())
-		return true;
-	pCharacter = getCustomEquipment(ScriptFlag::Accessory);
-	if (pCharacter && pCharacter->TurnToFacePlayerWhenFighting())
-		return true;
+	CCharacter* pCharacter;
+	if (!IsPlayerSwordDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Weapon);
+		if (pCharacter && pCharacter->TurnToFacePlayerWhenFighting())
+			return true;
+	}
+	if (!IsPlayerShieldDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Armor);
+		if (pCharacter && pCharacter->TurnToFacePlayerWhenFighting())
+			return true;
+	}
+	if (!IsPlayerAccessoryDisabled()) {
+		pCharacter = getCustomEquipment(ScriptFlag::Accessory);
+		if (pCharacter && pCharacter->TurnToFacePlayerWhenFighting())
+			return true;
+	}
 
 	return false;
 }
@@ -3614,6 +3635,10 @@ bool CCurrentGame::DoesPlayerItemHaveNoEnemyDefense(const UINT type) const
 //         or armor that protects against nullified DEF
 {
 	//No predefined weapons have this attribute.
+
+	if (IsPlayerItemDisabled(type)) {
+		return false;
+	}
 
 	CCharacter* pCharacter = getCustomEquipment(type);
 	if (pCharacter && pCharacter->HasNoEnemyDefense())
@@ -3632,6 +3657,20 @@ bool CCurrentGame::DoesTileDisableMetal(const UINT wX, const UINT wY) const
 	const UINT wTTile = this->pRoom->GetTSquare(wX, wY);
 	return wOTile == T_GOO && wTTile != T_CRATE;
 }
+
+//*****************************************************************************
+bool CCurrentGame::IsPlayerItemDisabled(const UINT type) const
+//Returns: true if the given equipment type is not usable at present, else false
+{
+	switch (type) {
+		case ScriptFlag::Weapon: return IsPlayerSwordDisabled();
+		case ScriptFlag::Armor: return IsPlayerShieldDisabled();
+		case ScriptFlag::Accessory:return IsPlayerAccessoryDisabled();
+	}
+
+	return false;
+}
+
 
 //*****************************************************************************
 bool CCurrentGame::IsPlayerShieldDisabled() const

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -298,6 +298,7 @@ public:
 	bool     IsPlayerSwordAt(const UINT wX, const UINT wY) const;
 	bool     IsRoomAtCoordsExplored(const UINT dwRoomX, const UINT dwRoomY) const;
 	bool     IsPlayerAccessoryDisabled() const;
+	bool     IsPlayerItemDisabled(const UINT type) const;
 	bool     IsPlayerShieldDisabled() const;
 	bool     IsPlayerSwordDisabled() const;
 	bool     IsPlayerDamagedByHotTile() const;


### PR DESCRIPTION
If a piece of equipment is disabled, it's behaviours that affect combat shouldn't apply.

I'm fairly certain this change won't break anything. In addition to require very specific circumstances to manifest, I think most of these behaviours are used in published holds, in part because people are unaware of what they do.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=46292