### PR TITLE
RPG: Don't count slots as the best equipment for stats

### DIFF
--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -784,9 +784,9 @@ WSTRING CDrodScreen::getStatsText(
 	wstr += wszSpace;
 	wstr += _itoW(st.shovels, num, 10);
 
-	const bool bHasSword = st.sword != NoSword;
-	const bool bHasShield = st.shield != NoShield;
-	const bool bHasAccessory = st.accessory != NoAccessory;
+	const bool bHasSword = st.sword != NoSword && st.sword != WeaponSlot;
+	const bool bHasShield = st.shield != NoShield && st.shield != ArmorSlot;
+	const bool bHasAccessory = st.accessory != NoAccessory && st.accessory != AccessorySlot;
 	const bool bHasEquipment = bHasSword || bHasShield || bHasAccessory;
 	if (bHasEquipment)
 	{

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -5690,7 +5690,7 @@ void CDbRoom::getStats(RoomStats& stats, const CDbLevel *pLevel) const
 					const UINT tParam = GetTParam(wX,wY);
 					const UINT power = CCurrentGame::getPredefinedWeaponPower(tParam);
 					const UINT oldPower = CCurrentGame::getPredefinedWeaponPower(stats.sword);
-					if (power > oldPower || (power == oldPower && tParam > stats.sword))
+					if ((power > oldPower || (power == oldPower && tParam > stats.sword)) && tParam != WeaponSlot)
 						stats.sword = tParam;
 				}
 				break;
@@ -5700,7 +5700,7 @@ void CDbRoom::getStats(RoomStats& stats, const CDbLevel *pLevel) const
 					const UINT tParam = GetTParam(wX,wY);
 					const UINT power = CCurrentGame::getPredefinedShieldPower(tParam);
 					const UINT oldPower = CCurrentGame::getPredefinedShieldPower(stats.shield);
-					if (power > oldPower || (power == oldPower && tParam > stats.shield))
+					if ((power > oldPower || (power == oldPower && tParam > stats.shield)) && tParam != ArmorSlot)
 						stats.shield = tParam;
 				}
 				break;
@@ -5709,7 +5709,8 @@ void CDbRoom::getStats(RoomStats& stats, const CDbLevel *pLevel) const
 					//Display any accessory available, as they are not ordered by power.
 					const UINT tParam = GetTParam(wX,wY);
 					ASSERT(tParam < AccessoryCount);
-					stats.accessory = tParam;
+					if (tParam != AccessorySlot)
+						stats.accessory = tParam;
 				}
 				break;
 			}

--- a/drodrpg/DRODLib/RoomData.h
+++ b/drodrpg/DRODLib/RoomData.h
@@ -287,9 +287,9 @@ enum AccessoryType
 			//original accessory values into the current values.
 };
 
-static inline bool bIsValidStandardWeapon(const UINT t) { return t < WeaponSlot; }
-static inline bool bIsValidStandardShield(const UINT t) { return t < ArmorSlot; }
-static inline bool bIsValidStandardAccessory(const UINT t) { return t < AccessorySlot; }
+static inline bool bIsValidStandardWeapon(const UINT t) { return t < SwordCount && t != WeaponSlot; }
+static inline bool bIsValidStandardShield(const UINT t) { return t < ShieldCount && t != ArmorSlot; }
+static inline bool bIsValidStandardAccessory(const UINT t) { return t < AccessoryCount && t != AccessorySlot; }
 
 //******************************************************************************************
 //Environmental weather conditions.


### PR DESCRIPTION
When pressing F3 or F4 on the primary editor screen to see stats about the level or hold, the equipment slots could appear as the best in-slot for each equipment type. Now they won't.