### PR TITLE
RPG: Add new sword names to EditScreens.uni

### DIFF
--- a/drodrpg/Texts/EditScreens.uni
+++ b/drodrpg/Texts/EditScreens.uni
@@ -1353,3 +1353,15 @@ Construct
 [MID_FluffBaby]
 [eng]
 Puff
+
+[MID_Sword11]
+[eng]
+Dagger
+
+[MID_Sword12]
+[eng]
+Staff
+
+[MID_Sword13]
+[eng]
+Spear


### PR DESCRIPTION
When I added the new swords I forgot to add the entries to EditScreens.uni