### PR TITLE
RPG: Ensure monster sword is clipped during animations

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -7986,8 +7986,12 @@ void CRoomWidget::DrawSwordFor(
 
 	//Sword isn't fully in display -- just draw it clipped.
 	//(This is needed for when stepping onto room edge.)
+	UINT offsetCol = ((blit.wCol * CX_TILE) + blit.wXOffset) / CX_TILE;
+	UINT offsetRow = ((blit.wRow * CY_TILE) + blit.wYOffset) / CY_TILE;
+
 	if (!IS_COLROW_IN_DISP(blit.wCol, blit.wRow) ||
-		!IS_COLROW_IN_DISP(blit.wCol + nSgnX, blit.wRow + nSgnY))
+		!IS_COLROW_IN_DISP(blit.wCol + nSgnX, blit.wRow + nSgnY) ||
+		!IS_COLROW_IN_DISP(offsetCol, offsetRow))
 		blit.bClipped = true;
 
 	DrawTileImage(blit, pDestSurface);


### PR DESCRIPTION
Animations can move a monster's sword out of the room area. It needs to be clipped to prevent a crash.

Forum thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46261