### PR TITLE
RPG: Fix clicking beyond the end of scrollable text box lines

### DIFF
--- a/FrontEndLib/TextBox2DWidget.cpp
+++ b/FrontEndLib/TextBox2DWidget.cpp
@@ -431,6 +431,7 @@ void CTextBox2DWidget::SetCursorByPos(
 		UINT wFirstPos = wIndex, wLastPos = wIndex;
 		if (!getLineStartIndexFollowingIndex(wLastPos))
 			wLastPos = wLength;
+		UINT originalLastPos = wLastPos;
 		while (wFirstPos < wLastPos)
 		{
 			wIndex = wFirstPos + (wLastPos - wFirstPos + 1) / 2;
@@ -449,6 +450,9 @@ void CTextBox2DWidget::SetCursorByPos(
 		}
 		//Get final position.
 		wIndex = wFirstPos;
+		//LastPos is actually the character after this line, unless it's the actual last character.
+		if (wIndex == originalLastPos && wIndex != this->text.size())
+			wIndex -= 1;
 		if (wIndex > wLength)
 			SetCursorIndex(wLength);
 		else


### PR DESCRIPTION
#664 broke clicking further to the right of a line of text, setting the cursor at the start of the next line instead of the end of the current one. This fixes that.

Forum thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45919