### PR TITLE
RPG: Smoother lighting effect across the two steps displayed on each stair tile.

### DIFF
--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -310,8 +310,8 @@ public:
 	void           RemoveOLayerEffectsOfType(const EffectType eEffectType);
 	void           RemoveTLayerEffectsOfType(const EffectType eEffectType);
 	void				RenderEnvironment(SDL_Surface *pDestSurface=NULL);
-	void           RenderRoom(int wCol=0, int wRow=0,
-			int wWidth=CDrodBitmapManager::DISPLAY_COLS, int wHeight=CDrodBitmapManager::DISPLAY_ROWS,
+	void           RenderRoom(int nCol=0, int nRow=0,
+			int nWidth=CDrodBitmapManager::DISPLAY_COLS, int nHeight=CDrodBitmapManager::DISPLAY_ROWS,
 			const bool bEditor=true);
 	void           RenderRoomInPlay(int wCol=0, int wRow=0,
 			int wWidth=CDrodBitmapManager::DISPLAY_COLS, int wHeight=CDrodBitmapManager::DISPLAY_ROWS);

--- a/drodrpg/DROD/TileImageCalcs.cpp
+++ b/drodrpg/DROD/TileImageCalcs.cpp
@@ -2701,6 +2701,7 @@ WALLTYPE GetWallTypeAtSquare(const CDbRoom *pRoom, const int nCol, const int nRo
 //*****************************************************************************
 void CalcStairPosition(
 //Find out what position in a staircase this tile is (from top-left corner).
+//Value is 1-based.
 //
 //Params:
 	const CDbRoom *pRoom,   //(in)   Room to use for calcs--not necessarily the
@@ -2713,29 +2714,29 @@ void CalcStairPosition(
 	wStairsCol = wStairsRow = 0;
 	UINT wPrevTile;
 
-	if (wCol == 0)
+	if (wCol == 0) {
 		wStairsCol = 1;
-	else
-	{
+	} else {
 		wPrevTile = wStairTile;
 		while (wPrevTile==wStairTile)
 		{
 			++wStairsCol;
-			wPrevTile = (wCol-wStairsCol>0) ?
-				pRoom->GetOSquare(wCol-wStairsCol, wRow) : T_WALL;
+			if (wCol - wStairsCol == 0)
+				break;
+			wPrevTile = pRoom->GetOSquare(wCol-wStairsCol, wRow);
 		}
 	}
 
-	if (wRow == 0)
+	if (wRow == 0) {
 		wStairsRow = 1;
-	else
-	{
+	} else {
 		wPrevTile = wStairTile;
 		while (wPrevTile==wStairTile)
 		{
 			++wStairsRow;
-			wPrevTile = (wRow-wStairsRow>0) ?
-				pRoom->GetOSquare(wCol, wRow-wStairsRow) : T_WALL;
+			if (wRow - wStairsRow == 0)
+				break;
+			wPrevTile = pRoom->GetOSquare(wCol, wRow-wStairsRow);
 		}
 	}
 }
@@ -2776,7 +2777,8 @@ UINT CalcTileImageForStairs(
 
 //*****************************************************************************
 void CalcStairUpPosition(
-//Find out what position in a staircase this tile is (from top-left corner).
+//Find out what position in a staircase this tile is (from bottom-left corner).
+//Value is 1-based.
 //
 //Params:
 	const CDbRoom *pRoom,   //(in)   Room to use for calcs--not necessarily the
@@ -2784,35 +2786,34 @@ void CalcStairUpPosition(
 	const UINT wCol, const UINT wRow,   //(in)   Square for which to calc.
 	UINT& wStairsCol, UINT& wStairsRow) //(out)  position
 {
-	//Find out what position in a staircase this tile is (from bottom-left corner).
 	const UINT wStairTile = pRoom->GetOSquare(wCol, wRow);
 	ASSERT(wStairTile==T_STAIRS_UP);
 	wStairsCol = wStairsRow = 0;
 	UINT wPrevTile;
 
-	if (wCol == 0)
+	if (wCol == 0) {
 		wStairsCol = 1;
-	else
-	{
+	} else {
 		wPrevTile = wStairTile;
 		while (wPrevTile==wStairTile)
 		{
 			++wStairsCol;
-			wPrevTile = (wCol-wStairsCol>0) ?
-				pRoom->GetOSquare(wCol-wStairsCol, wRow) : T_WALL;
+			if (wCol - wStairsCol == 0)
+				break;
+			wPrevTile = pRoom->GetOSquare(wCol-wStairsCol, wRow);
 		}
 	}
 
-	if (wRow == pRoom->wRoomRows-1)
+	if (wRow == pRoom->wRoomRows - 1) {
 		wStairsRow = 1;
-	else
-	{
+	} else {
 		wPrevTile = wStairTile;
 		while (wPrevTile==wStairTile)
 		{
 			++wStairsRow;
-			wPrevTile = (wRow+wStairsRow<pRoom->wRoomRows-1) ?
-				pRoom->GetOSquare(wCol, wRow+wStairsRow) : T_WALL;
+			if (wRow + wStairsRow >= pRoom->wRoomRows - 1)
+				break;
+			wPrevTile = pRoom->GetOSquare(wCol, wRow+wStairsRow);
 		}
 	}
 }


### PR DESCRIPTION
Also:
* Rename method params to match var types (also, the inner 'wRow' var was previously shadowing the method parameter of the same name, which makes things harder to maintain and it confused the MSVS debugger when displaying var values).
* Clean up a bad comment. Clarify stair position return vals.
* Remove unnecessary use of magic values to break out of loops.

We could port these changes to 5.x, but I expect they would not be very discernible on the smaller stair tiles.