### PR TITLE
RPG: Allow queen to spawn on closed firetraps

### DIFF
--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1054,7 +1054,7 @@ void CMonster::SpawnEgg(CCueEvents& CueEvents)
 				((bIsPlainFloor(wOSquare) || wOSquare == T_PRESSPLATE) ||
 					bIsOpenDoor(wOSquare) || bIsMistVent(wOSquare) ||
 					bIsPlatform(wOSquare) || bIsBridge(wOSquare) ||
-					wOSquare == T_GOO)
+					wOSquare == T_GOO || wOSquare == T_FIRETRAP)
 				)
 			{
 				//Spot is open for placing an egg.

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -121,7 +121,7 @@
 #define T_DOOR_RO       70 //Red Open
 #define T_DOOR_BO       71 //Black Open
 #define T_TRAPDOOR2     72 //trapdoor over water
-#define T_GOO           73
+#define T_GOO           73 //oremites
 #define T_LIGHT         74 //light source
 #define T_HOT           75 //hot tile
 #define T_GEL           76 //gel (tarstuff)


### PR DESCRIPTION
Note this is a change in behaviour from classic DROD where they can't lay eggs on firetraps regardless of state, but here there is a difference in intended function for eggs, being immovable barriers. It seems nice to have a tile queens can lay onto that has a way to clear that one egg without having the required stats.

This does not allow them to lay an egg on an active firetrap, with the same reasoning of them not being able to lay on a hot tile: the queen knows the egg will just immediately take damage.