### PR TITLE
RPG: Trigger post-combat growths when fighting mothers

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3179,11 +3179,12 @@ void CCurrentGame::AdvanceCombat(CCueEvents& CueEvents)
 					//NPC script is responsible for what happens after tarstuff defeat,
 					//e.g., resetting HP for subsequent tarstuff battles.
 				} else {
-				//Reset the tarstuff mother's HP back to full to allow attacking another tile.
-				ASSERT(pDefeatedMonster->wX != this->pCombat->wX || pDefeatedMonster->wY != this->pCombat->wY);
-				ASSERT(!pDefeatedMonster->getHP());
-				pDefeatedMonster->SetHP();
+					//Reset the tarstuff mother's HP back to full to allow attacking another tile.
+					ASSERT(pDefeatedMonster->wX != this->pCombat->wX || pDefeatedMonster->wY != this->pCombat->wY);
+					ASSERT(!pDefeatedMonster->getHP());
+					pDefeatedMonster->SetHP();
 				}
+				ProcessPostCombatExpansions(CueEvents);
 			} else {
 				ProcessMonsterDefeat(CueEvents, pDefeatedMonster, this->pCombat->wX, this->pCombat->wY, GetSwordMovement());
 			}
@@ -3240,9 +3241,7 @@ void CCurrentGame::ProcessMonsterDefeat(
 		}
 	}
 
-	//Each time a monster is fought, briar roots expand.
-	this->pRoom->ExpandMist(CueEvents);
-	this->pRoom->ExpandBriars(CueEvents);
+	ProcessPostCombatExpansions(CueEvents);
 }
 
 //*****************************************************************************
@@ -3254,6 +3253,14 @@ void CCurrentGame::ProcessNPCDefeat(CCharacter* pDefeatedNPC, CCueEvents& CueEve
 	pDefeatedNPC->ProcessAfterDefeat(CueEvents);
 	this->bExecuteNoMoveCommands = false;
 	CueEvents.Add(CID_NPC_Defeated, pDefeatedNPC);
+}
+
+//*****************************************************************************
+//Each time a monster is fought, expand things that grow.
+void CCurrentGame::ProcessPostCombatExpansions(CCueEvents& CueEvents)
+{
+	this->pRoom->ExpandMist(CueEvents);
+	this->pRoom->ExpandBriars(CueEvents);
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -335,6 +335,7 @@ public:
 			CMonster* pDefeatedMonster, const UINT wSX, const UINT wSY,
 			const UINT wSwordMovement);
 	void     ProcessNPCDefeat(CCharacter* pDefeatedNPC, CCueEvents& CueEvents);
+	void     ProcessPostCombatExpansions(CCueEvents& CueEvents);
 	void     ProcessMoveFreeScripts(CCueEvents& CueEvents, CMonster* pMonsterList);
 	void     ProcessScripts(int nCommand, CCueEvents& CueEvents, CMonster* pMonsterList);
 	void     ProcessSwordHit(const UINT wX, const UINT wY, CCueEvents &CueEvents,

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -7704,7 +7704,7 @@ void CDbRoom::ConvertUnstableTar(
 			CMonster *pMonster = GetMonsterAtSquare(wX,wY);
 
 			//Don't spawn tar babies under living monsters
-			if (!pMonster)
+			if (this->pCurrentGame && !pMonster)
 			{
 				//Spawn a tarbaby.
 				const UINT wOSquare = GetOSquare(wX,wY);
@@ -7717,8 +7717,8 @@ void CDbRoom::ConvertUnstableTar(
 					UINT monsterID;
 					CMonster *m = NULL;
 					const UINT wO = nGetO(sgn(wSX - wX), sgn(wSY - wY));
-					switch (wTarType)
-					{
+						switch (wTarType)
+						{
 						case T_TAR:
 							monsterID = this->pCurrentGame->getSpawnID(M_TARBABY);
 							m = this->pCurrentGame->AddNewEntity(CueEvents, monsterID, wX, wY, wO, true);
@@ -7738,11 +7738,11 @@ void CDbRoom::ConvertUnstableTar(
 								CueEvents.Add(CID_GelBabyFormed, m);
 							break;
 						default: ASSERT(!"Bad tar type"); continue;
+						}
 					}
 				}
 			}
 		}
-	}
 	
 	this->NewBabies.Clear();
 }

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -7717,8 +7717,8 @@ void CDbRoom::ConvertUnstableTar(
 					UINT monsterID;
 					CMonster *m = NULL;
 					const UINT wO = nGetO(sgn(wSX - wX), sgn(wSY - wY));
-						switch (wTarType)
-						{
+					switch (wTarType)
+					{
 						case T_TAR:
 							monsterID = this->pCurrentGame->getSpawnID(M_TARBABY);
 							m = this->pCurrentGame->AddNewEntity(CueEvents, monsterID, wX, wY, wO, true);
@@ -7738,11 +7738,11 @@ void CDbRoom::ConvertUnstableTar(
 								CueEvents.Add(CID_GelBabyFormed, m);
 							break;
 						default: ASSERT(!"Bad tar type"); continue;
-						}
 					}
 				}
 			}
 		}
+	}
 	
 	this->NewBabies.Clear();
 }


### PR DESCRIPTION
Fighting mothers bypasses the usual monster defeat code because we often don't want to kill them, however the expansion of post-combat growing elements lived there. This adds those growths to the special case carved out for fighting mothers.

Forum thread: https://forum.caravelgames.com/viewboard.php?BoardID=277

While I was there, found an edge case where clicking on a bomb in the editor could cause a crash if it reaches any tarstuff because there's no CurrentGame instance when simulating a bomb explosion.