### PR TITLE
RPG: Update identity variable when copying a character

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -298,13 +298,12 @@ void CCharacter::SyncCustomCharacterData(
 	CDbHold* pDestHold,
 	CImportInfo& info)
 {
-	SyncCustomCharacterData(this->wIdentity, this->wInitialIdentity, this->wLogicalIdentity, pSrcHold, pDestHold, info);
+	SyncCustomCharacterData(this->wLogicalIdentity, pSrcHold, pDestHold, info);
+	this->wInitialIdentity = this->wLogicalIdentity;
 }
 
 //Returns: whether something was changed
 void CCharacter::SyncCustomCharacterData(
-	UINT& wIdentity,
-	UINT& wInitialIdentity,
 	UINT& wLogicalIdentity,
 	const CDbHold* pSrcHold,
 	CDbHold* pDestHold,
@@ -333,7 +332,7 @@ void CCharacter::SyncCustomCharacterData(
 
 				pSrcHold->CopyCustomCharacterData(*pDestCustomChar, pDestHold, info);
 			}
-			wIdentity = wInitialIdentity = wLogicalIdentity = charID;
+			wLogicalIdentity = charID;
 		}
 	}
 }
@@ -404,10 +403,10 @@ void CCharacter::ChangeHoldForCommands(
 				break;
 				case CCharacterCommand::CC_SetNPCAppearance:
 				case CCharacterCommand::CC_SetPlayerAppearance:
-					SyncCustomCharacterData(c.x, c.x, c.x, pOldHold, pNewHold, info);
+					SyncCustomCharacterData(c.x, pOldHold, pNewHold, info);
 					break;
 				case CCharacterCommand::CC_GenerateEntity:
-					SyncCustomCharacterData(c.h, c.h, c.h, pOldHold, pNewHold, info);
+					SyncCustomCharacterData(c.h, pOldHold, pNewHold, info);
 					break;
 
 				case CCharacterCommand::CC_LevelEntrance:
@@ -416,7 +415,7 @@ void CCharacter::ChangeHoldForCommands(
 
 				case CCharacterCommand::CC_Speech:
 					if (c.pSpeech)
-						SyncCustomCharacterData(c.pSpeech->wCharacter, c.pSpeech->wCharacter, c.pSpeech->wCharacter, pOldHold, pNewHold, info);
+						SyncCustomCharacterData(c.pSpeech->wCharacter, pOldHold, pNewHold, info);
 				break;
 
 				default: break;

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -298,11 +298,13 @@ void CCharacter::SyncCustomCharacterData(
 	CDbHold* pDestHold,
 	CImportInfo& info)
 {
-	SyncCustomCharacterData(this->wLogicalIdentity, pSrcHold, pDestHold, info);
+	SyncCustomCharacterData(this->wIdentity, this->wInitialIdentity, this->wLogicalIdentity, pSrcHold, pDestHold, info);
 }
 
 //Returns: whether something was changed
 void CCharacter::SyncCustomCharacterData(
+	UINT& wIdentity,
+	UINT& wInitialIdentity,
 	UINT& wLogicalIdentity,
 	const CDbHold* pSrcHold,
 	CDbHold* pDestHold,
@@ -327,10 +329,11 @@ void CCharacter::SyncCustomCharacterData(
 				pDestCustomChar->dwDataID_Avatar = pCustomChar->dwDataID_Avatar;
 				pDestCustomChar->dwDataID_Tiles = pCustomChar->dwDataID_Tiles;
 				pDestCustomChar->ExtraVars = pCustomChar->ExtraVars;
+				pDestCustomChar->ExtraVars.SetVar(initialIdStr, charID);
 
 				pSrcHold->CopyCustomCharacterData(*pDestCustomChar, pDestHold, info);
 			}
-			wLogicalIdentity = charID;
+			wIdentity = wInitialIdentity = wLogicalIdentity = charID;
 		}
 	}
 }
@@ -401,10 +404,10 @@ void CCharacter::ChangeHoldForCommands(
 				break;
 				case CCharacterCommand::CC_SetNPCAppearance:
 				case CCharacterCommand::CC_SetPlayerAppearance:
-					SyncCustomCharacterData(c.x, pOldHold, pNewHold, info);
+					SyncCustomCharacterData(c.x, c.x, c.x, pOldHold, pNewHold, info);
 					break;
 				case CCharacterCommand::CC_GenerateEntity:
-					SyncCustomCharacterData(c.h, pOldHold, pNewHold, info);
+					SyncCustomCharacterData(c.h, c.h, c.h, pOldHold, pNewHold, info);
 					break;
 
 				case CCharacterCommand::CC_LevelEntrance:
@@ -413,7 +416,7 @@ void CCharacter::ChangeHoldForCommands(
 
 				case CCharacterCommand::CC_Speech:
 					if (c.pSpeech)
-						SyncCustomCharacterData(c.pSpeech->wCharacter, pOldHold, pNewHold, info);
+						SyncCustomCharacterData(c.pSpeech->wCharacter, c.pSpeech->wCharacter, c.pSpeech->wCharacter, pOldHold, pNewHold, info);
 				break;
 
 				default: break;

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -270,7 +270,7 @@ private:
 	void SetArrayVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 
 	void SyncCustomCharacterData(const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);
-	static void SyncCustomCharacterData(UINT& wLogicalIdentity, const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);
+	static void SyncCustomCharacterData(UINT& wIdentity, UINT& wInitialIdentity, UINT& wLogicalIdentity, const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);
 
 	//Internal command storage representation --> 3.1.0+
 	static void  DeserializeCommand(BYTE* buffer, UINT& index, CCharacterCommand& command);

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -270,7 +270,7 @@ private:
 	void SetArrayVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 
 	void SyncCustomCharacterData(const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);
-	static void SyncCustomCharacterData(UINT& wIdentity, UINT& wInitialIdentity, UINT& wLogicalIdentity, const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);
+	static void SyncCustomCharacterData(UINT& wLogicalIdentity, const CDbHold* pSrcHold, CDbHold* pDestHold, CImportInfo& info);
 
 	//Internal command storage representation --> 3.1.0+
 	static void  DeserializeCommand(BYTE* buffer, UINT& index, CCharacterCommand& command);


### PR DESCRIPTION
Fixing yet another fallout of fixing this rotten bug:
https://forum.caravelgames.com/viewtopic.php?TopicID=40625

When copying a character, were were only updating the logical identity of the character, and not its identity and initial identity, which are used to figure out which default script to run.

I don't like the look of having to triple the arguments into the static method SyncCustomCharacterData but was unsure how else to deal with the fact it's static.