### PR TITLE
RPG: Move bonus preview to bottom of tile to prevent overlap with dam…

### DIFF
--- a/drodrpg/DROD/DamagePreviewEffect.cpp
+++ b/drodrpg/DROD/DamagePreviewEffect.cpp
@@ -44,10 +44,10 @@ CBonusPreviewEffect::CBonusPreviewEffect(
 	: CEffect(pSetWidget, (UINT)-1, EDAMAGEPREVIEW)
 	, wX(wX), wY(wY)
 	, pTextSurface(NULL)
+	, YOFFSET(-29)
 {
 	ASSERT(pSetWidget);
 	ASSERT(pSetWidget->GetType() == WT_Room);
-	this->YOFFSET = -29;
 
 	this->pRoomWidget = DYN_CAST(CRoomWidget*, CWidget*, pSetWidget);
 	CDbRoom *pRoom = this->pRoomWidget->GetRoom();
@@ -64,9 +64,10 @@ CBonusPreviewEffect::CBonusPreviewEffect(
 	}
 }
 
-CBonusPreviewEffect::CBonusPreviewEffect(CWidget* pSetWidget)
+CBonusPreviewEffect::CBonusPreviewEffect(CWidget* pSetWidget, int yOffset)
 	: CEffect(pSetWidget, (UINT)-1, EDAMAGEPREVIEW)
 	, pTextSurface(NULL)
+	, YOFFSET(yOffset)
 { }
 
 //********************************************************************************
@@ -191,7 +192,7 @@ CDamagePreviewEffect::CDamagePreviewEffect(
 //Params:
 	CWidget *pSetWidget,          //(in)   Should be a room widget.
 	const CMonster *pMonster)     //(in)   Enemy to display damage preview for.
-	: CBonusPreviewEffect(pSetWidget)
+	: CBonusPreviewEffect(pSetWidget, 3)
 	, pMonster(const_cast<CMonster*>(pMonster))  //Though non-const, everything in this effect should leave monster state as-is
 {
 	ASSERT(pSetWidget);
@@ -200,7 +201,6 @@ CDamagePreviewEffect::CDamagePreviewEffect(
 
 	this->wX = this->pMonster->wX;
 	this->wY = this->pMonster->wY;
-	this->YOFFSET = 3;
 
 	this->pRoomWidget = DYN_CAST(CRoomWidget*, CWidget*, pSetWidget);
 	CDbRoom *pRoom = this->pRoomWidget->GetRoom();

--- a/drodrpg/DROD/DamagePreviewEffect.cpp
+++ b/drodrpg/DROD/DamagePreviewEffect.cpp
@@ -33,8 +33,6 @@
 #include <BackEndLib/Assert.h>
 #include <FrontEndLib/Screen.h>
 
-const int YOFFSET = 3;   //this font draws a bit too low
-
 //********************************************************************************
 CBonusPreviewEffect::CBonusPreviewEffect(
 	//Constructor.
@@ -49,6 +47,7 @@ CBonusPreviewEffect::CBonusPreviewEffect(
 {
 	ASSERT(pSetWidget);
 	ASSERT(pSetWidget->GetType() == WT_Room);
+	this->YOFFSET = -29;
 
 	this->pRoomWidget = DYN_CAST(CRoomWidget*, CWidget*, pSetWidget);
 	CDbRoom *pRoom = this->pRoomWidget->GetRoom();
@@ -103,7 +102,7 @@ void CBonusPreviewEffect::Draw(SDL_Surface& destSurface)
 	this->dirtyRects[0].x = destX;
 	this->dirtyRects[0].y = destY;
 
-	SDL_Rect SrcRect = MAKE_SDL_RECT(0, YOFFSET, this->dirtyRects[0].w, this->dirtyRects[0].h);
+	SDL_Rect SrcRect = MAKE_SDL_RECT(0, this->YOFFSET, this->dirtyRects[0].w, this->dirtyRects[0].h);
 	SDL_Rect ScreenRect = MAKE_SDL_RECT(destX, destY, this->dirtyRects[0].w, this->dirtyRects[0].h);
 	SDL_BlitSurface(this->pTextSurface, &SrcRect, &destSurface, &ScreenRect);
 
@@ -181,7 +180,7 @@ void CBonusPreviewEffect::PrepWidgetForValue(const int value)
 
 	g_pTheFM->SetFontColor(eFontType, origColor);
 
-	SDL_Rect Dest = MAKE_SDL_RECT(0, 0, wLineW, wLineH - YOFFSET);
+	SDL_Rect Dest = MAKE_SDL_RECT(0, 0, wLineW, wLineH - this->YOFFSET);
 	this->dirtyRects.push_back(Dest);
 }
 
@@ -201,6 +200,7 @@ CDamagePreviewEffect::CDamagePreviewEffect(
 
 	this->wX = this->pMonster->wX;
 	this->wY = this->pMonster->wY;
+	this->YOFFSET = 3;
 
 	this->pRoomWidget = DYN_CAST(CRoomWidget*, CWidget*, pSetWidget);
 	CDbRoom *pRoom = this->pRoomWidget->GetRoom();
@@ -339,6 +339,6 @@ void CDamagePreviewEffect::PrepWidget()
 
 	g_pTheFM->SetFontColor(eFontType, origColor);
 
-	SDL_Rect Dest = MAKE_SDL_RECT(0, 0, wLineW, wLineH - YOFFSET);
+	SDL_Rect Dest = MAKE_SDL_RECT(0, 0, wLineW, wLineH - this->YOFFSET);
 	this->dirtyRects.push_back(Dest);
 }

--- a/drodrpg/DROD/DamagePreviewEffect.h
+++ b/drodrpg/DROD/DamagePreviewEffect.h
@@ -42,13 +42,13 @@ public:
 	virtual ~CBonusPreviewEffect();
 
 protected:
-	CBonusPreviewEffect(CWidget* pSetWidget);
+	CBonusPreviewEffect(CWidget* pSetWidget, int yOffset);
 	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
 	virtual void Draw(SDL_Surface& destSurface);
 
 	UINT         wX, wY;
 	UINT         wValidTurn;   //game turn this display is valid for
-	int          YOFFSET;      //must set in the constructor, different derived classes need a different value
+	const int    YOFFSET;
 
 	CRoomWidget* pRoomWidget;
 

--- a/drodrpg/DROD/DamagePreviewEffect.h
+++ b/drodrpg/DROD/DamagePreviewEffect.h
@@ -48,6 +48,7 @@ protected:
 
 	UINT         wX, wY;
 	UINT         wValidTurn;   //game turn this display is valid for
+	int          YOFFSET;      //must set in the constructor, different derived classes need a different value
 
 	CRoomWidget* pRoomWidget;
 


### PR DESCRIPTION
…age preview

![image](https://github.com/user-attachments/assets/13a2c804-7c75-4de5-8671-e80798aa949c)

Given the damage preview class inherits from the bonus damage class, I wanted to have a single constant YOFFSET value for both but this couldn't be set directly in the header file. If you know of a better way, feel free to advise.

Forum thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46316