### PR TITLE
Fix tooltip for multi-tile monsters

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1556,7 +1556,7 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 			}
 		}
 
-		if (pMonster->wX != wX || pMonster->wY != wY)
+		if ((pMonster->wX != wX || pMonster->wY != wY) && !pMonster->HasPieceAt(wX, wY))
 			goto SkipDescribingMonster;
 
 		if (!bCharacterName) {

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -1865,6 +1865,22 @@ bool CMonster::GetTarget(
 }
 
 //*****************************************************************************
+bool CMonster::HasPieceAt(const UINT wX, const UINT wY) const
+//Returns: if part of this monster is at (x,y)
+{
+	for (MonsterPieces::const_iterator piece = this->Pieces.begin();
+		piece != this->Pieces.end(); ++piece)
+	{
+		const CMonsterPiece* pPiece = *piece;
+		if (pPiece->wX == wX && pPiece->wY == wY) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//*****************************************************************************
 bool CMonster::HasSwordAt(const UINT wX, const UINT wY) const
 //Returns: whether this monster has a sword at (x,y)
 {

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -298,6 +298,7 @@ public:
 	virtual WeaponType GetWeaponType() const { return WT_Sword; }
 	bool          GetTarget(UINT &wX, UINT &wY, const bool bConsiderDecoys=true);
 
+	bool          HasPieceAt(const UINT wX, const UINT wY) const;
 	virtual bool  HasSword() const { return false; }
 	bool          HasSwordAt(const UINT wX, const UINT wY) const;
 	virtual bool  IsAggressive() const {return true;}


### PR DESCRIPTION
Changes to allow invisible inspectable monsters were causing multi-tile monsters to only display on tooltips if the main, non-piece monster was right-clicked. The position check has been updated to also check for pieces.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46306