### PR TITLE
Make CDbDemo::GetTimeElapsed return early for empty demos

### DIFF
--- a/DRODLib/DbDemos.cpp
+++ b/DRODLib/DbDemos.cpp
@@ -907,7 +907,8 @@ bool CDbDemo::GetTimeElapsed(UINT &dwTimeElapsed) const
 		if (pGame->Commands.Count() > 0) {
 			wEndTurn = pGame->Commands.Count() - 1;
 		} else {
-			wEndTurn = 0;
+			//No time is elapsed by an empty demo
+			return true;
 		}
 	}
 


### PR DESCRIPTION
`CDbDemo::GetTimeElapsed` has an assert with a comment that suggests zero-turn demos shouldn't get that far. So return early in that case, since a demo with no turns logically takes zero time.