### PR TITLE
RPG: Fix bad remote damage calcuation after changing equipment

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8396,6 +8396,10 @@ void CGameScreen::ShowRoomTemporarily(UINT roomID)
 Loop:
 	CCurrentGame *pTempGame = g_pTheDB->GetDummyCurrentGame();
 	*pTempGame = *this->pCurrentGame;
+	//PrepTempGameForRoomDisplay will restart the room, which replaces the monster
+	//list with the start of turn version. This is not really what we want, so we
+	//update the starting list to be the current list.
+	pTempGame->SetMonsterListAtRoomStart();
 	if (!pTempGame->PrepTempGameForRoomDisplay(roomID)) {
 		delete pTempGame;
 		return;


### PR DESCRIPTION
If you collect a piece of custom equipment, the damage calculation when remotely viewing another room doesn't update until you actually move to another room.

The cause of this is a little trap in how remote room viewing works. The current game is copied, including its monster list, which holds custom equipment characters. However, part of setting up the remote room includes restarting the room, which sets the monster list to be the start of room version, which doesn't match the current game state if custom equipment has been collect after room entry.

To fix, we just need update the room start monster list to be the same as the current list before any restarting, which `CDbSavedGame` helpfully has a function for.

https://forum.caravelgames.com/viewtopic.php?TopicID=45906