### PR TITLE
RPG: Room previews checking for character visibility too early

### DIFF
--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -9571,10 +9571,6 @@ void CDbRoom::SetMonstersFromExploredRoomData(
 		if (bCharacter)
 		{
 			pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
-
-			//Invisible characters are not in room.
-			if (!pCharacter->IsVisible())
-				bInRoom = false;
 		}
 
 		CMonster *pNew = AddNewMonster(pMonster->wType, pMonster->wX, pMonster->wY, bInRoom);
@@ -9591,6 +9587,9 @@ void CDbRoom::SetMonstersFromExploredRoomData(
 			} else {
 				pNew->SetMembers(pCharacter->ExtraVars); //don't need script data, just pre-existing stats
 			}
+			//Invisible characters are not in room.
+			if (!pCharacter->IsVisible())
+				bInRoom = false;
 		}
 
 		ASSERT(pNew->IsLongMonster() || pMonster->Pieces.empty());


### PR DESCRIPTION
When a character has its visibility changed during its lifetime, this was not reflected in room previews as they were checking if the character was invisible before recovering the extra vars for the character.

Forum thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46010