### PR TITLE
RPG: Add wall-dwelling behavior for NPCs

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1537,6 +1537,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pBehaviorListBox->AddItem(ScriptFlag::FiretrapImmune, g_pTheDB->GetMessageText(MID_FiretrapImmune));
 	this->pBehaviorListBox->AddItem(ScriptFlag::MistImmune, g_pTheDB->GetMessageText(MID_MistImmune));
 	this->pBehaviorListBox->AddItem(ScriptFlag::Metal, g_pTheDB->GetMessageText(MID_BehaviorMetal));
+	this->pBehaviorListBox->AddItem(ScriptFlag::WallDwelling, g_pTheDB->GetMessageText(MID_SeepAbility));
 	this->pBehaviorListBox->AddItem(ScriptFlag::LuckyGR, g_pTheDB->GetMessageText(MID_BehaviorLuckyGR));
 	this->pBehaviorListBox->AddItem(ScriptFlag::LuckyXP, g_pTheDB->GetMessageText(MID_DoubleXP));
 	this->pBehaviorListBox->AddItem(ScriptFlag::Briar, g_pTheDB->GetMessageText(MID_BehaviorBriarCut));

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2088,6 +2088,16 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		wstr += g_pTheDB->GetMessageText(MID_RoachQueenAbility);
 		++count;
 	}
+	if (pMonster->IsWallDwelling())
+	{
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_SeepAbility);
+		++count;
+	}
 	if (!pMonster->DamagedByHotTiles())
 	{
 		if (count)
@@ -2176,7 +2186,6 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 	{
 		case M_MIMIC: mid = MID_MimicAbility; break;
 		case M_WATERSKIPPER: mid = MID_WaterSkipperAbility; break;
-		case M_SEEP: mid = MID_SeepAbility; break;
 		case M_TARMOTHER: case M_MUDMOTHER: case M_GELMOTHER: mid = MID_TarMotherAbility; break;
 		default: break;
 	}

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2097,6 +2097,14 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		}
 		wstr += g_pTheDB->GetMessageText(MID_SeepAbility);
 		++count;
+	} else if (pMonster->IsSwimming()) {
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_WaterSkipperAbility);
+		++count;
 	}
 	if (!pMonster->DamagedByHotTiles())
 	{
@@ -2185,7 +2193,6 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 	switch (pMonster->wType)
 	{
 		case M_MIMIC: mid = MID_MimicAbility; break;
-		case M_WATERSKIPPER: mid = MID_WaterSkipperAbility; break;
 		case M_TARMOTHER: case M_MUDMOTHER: case M_GELMOTHER: mid = MID_TarMotherAbility; break;
 		default: break;
 	}

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -178,6 +178,7 @@ public:
 
 	virtual bool   IsVisible() const {return this->bVisible;}
 	virtual bool   IsVulnerable() const {return this->bVulnerable;}
+	virtual bool   IsWallDwelling() const { return this->bWallDwelling; }
 	bool           IsWeaponAt(const CCharacterCommand& command, const CCurrentGame* pGame) const;
 	static void    LoadCommands(const CDbPackedVars& ExtraVars, COMMAND_VECTOR& commands);
 	static void    LoadCommands(const CDbPackedVars& ExtraVars, COMMANDPTR_VECTOR& commands);
@@ -332,6 +333,7 @@ private:
 	bool bHotTileImmune;       //not damaged by hotiles
 	bool bFiretrapImmune;      //not damaged by firetraps
 	bool bMistImmune;          //DEF not negated by mist
+	bool bWallDwelling;        //dies outside of solid tile
 
 	UINT wJumpLabel;			//if non-zero, jump to the label if this command is satisfied
 	bool bWaitingForCueEvent;

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -155,6 +155,7 @@ namespace ScriptFlag
 		HotTileImmune=31,       //not damaged by hotiles
 		FiretrapImmune=32,      //not damaged by firetraps
 		MistImmune=33,          //DEF not negated by mist
+		WallDwelling=34,        //dies outside of solid tile
 	};
 
 	//Inventory and global script types.

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -3000,14 +3000,8 @@ void CDbRoom::KillSeepOutsideWall(CCueEvents &CueEvents)
 	while (pMonster)
 	{
 		pNext = pMonster->pNext;
-		switch (pMonster->wType)
-		{
-			case M_SEEP:
-			{
-				CSeep *pWallMonster = DYN_CAST(CSeep*, CMonster*, pMonster);
-				pWallMonster->KillIfOutsideWall(CueEvents);
-			}
-			break;
+		if (pMonster->IsWallDwelling()) {
+			pMonster->KillIfOutsideWall(CueEvents);
 		}
 		pMonster = pNext;
 	}

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1894,6 +1894,28 @@ const
 }
 
 //*****************************************************************************
+bool CMonster::KillIfOutsideWall(CCueEvents& CueEvents)
+//Kill the monster if it's not on a wall or door.
+//
+//Returns: If it died
+{
+	//If ghost was on a door that opened, kill it.
+	const UINT dwTileNo = this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY);
+	if (bIsOpenDoor(dwTileNo) || bIsFloor(dwTileNo))
+	{
+		CCurrentGame* pGame = (CCurrentGame*)this->pCurrentGame; //non-const
+		if (pGame->IsFighting(this))
+			return false; //if terrain changes during a fight, just let the combat play out
+
+		pGame->pRoom->KillMonster(this, CueEvents);
+		SetKillInfo(NO_ORIENTATION); //center stab effect
+		CueEvents.Add(CID_MonsterDiedFromStab, this);
+		return true;
+	}
+	return false;
+}
+
+//*****************************************************************************
 bool CMonster::MakeSlowTurn(const UINT wDesiredO)
 //Make a 45 degree (1/8th rotation) turn toward the desired orientation.
 //

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -245,6 +245,8 @@ public:
 	virtual bool  IsMinimapTreasure() const { return false; }
 	virtual bool  IsVisible() const {return true;}
 	virtual bool  IsWallAndMirrorSafe() const { return false; }
+	virtual bool  IsWallDwelling() const { return false; }
+	bool          KillIfOutsideWall(CCueEvents& CueEvents);
 	bool          MakeSlowTurn(const UINT wDesiredO);
 	void          MakeStandardMove(CCueEvents &CueEvents,
 			const int dx, const int dy);

--- a/drodrpg/DRODLib/Seep.cpp
+++ b/drodrpg/DRODLib/Seep.cpp
@@ -35,32 +35,6 @@
 //
 
 //*****************************************************************************************
-bool CSeep::KillIfOutsideWall(CCueEvents &CueEvents)
-//Kill the monster if outside wall.
-//
-//Returns: whether monster was killed
-{
-//	if (IsOnSwordsman())
-//		return false; //retain for front end display death sequence
-
-	//If ghost was on a door that opened, kill it.
-	const UINT dwTileNo = this->pCurrentGame->pRoom->GetOSquare(this->wX, this->wY);
-	if (bIsOpenDoor(dwTileNo) || bIsFloor(dwTileNo))
-	{
-		CCurrentGame *pGame = (CCurrentGame*)this->pCurrentGame; //non-const
-		if (pGame->IsFighting(this))
-			return false; //if terrain changes during a fight, just let the combat play out
-
-		pGame->pRoom->KillMonster(this, CueEvents);
-//		pGame->TallyKill();
-		SetKillInfo(NO_ORIENTATION); //center stab effect
-		CueEvents.Add(CID_MonsterDiedFromStab, this);
-		return true;
-	}
-	return false;
-}
-
-//*****************************************************************************************
 void CSeep::Process(
 //Process a seep for movement.
 //

--- a/drodrpg/DRODLib/Seep.h
+++ b/drodrpg/DRODLib/Seep.h
@@ -40,7 +40,7 @@ public:
 	CSeep(CCurrentGame *pSetCurrentGame = NULL) : CMonster(M_SEEP, pSetCurrentGame, WALL) {}
 	IMPLEMENT_CLONE_REPLICATE(CMonster, CSeep);
 
-	bool           KillIfOutsideWall(CCueEvents &CueEvents);
+	virtual bool   IsWallDwelling() const { return true; }
 	virtual void   Process(const int nLastCommand, CCueEvents &CueEvents);
 };
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -574,6 +574,8 @@ that may be set with the <a href="#behavior">Behavior</a> command.</p>
   <li><a name="be_metal"><u>Metal</u></a>:
       Metal monsters will be damaged on oremites the same as if on a hot tile.
 	  Embues custom equipment with metal attribute (disabled on oremites).</li>
+  <li><a name="be_wall_dwelling"><u>Wall-dwelling</u></a>:
+      A wall-dwelling monster will die if it is not on wall or closed door tile.</li>
   <li><a name="be_lucky"><u>Lucky</u></a>:
 	  Embues custom equipment with lucky attribute (x2 GR from combat
 	  for each lucky item held).</li>


### PR DESCRIPTION
Adds the Wall-dwelling behaviour, that makes NPCs die if they aren't on a solid tile, just like seep. To make this work, a few functions have been shuffled around.

As a related change, all monsters with water movement are now labled as "water-dwelling", not just waterskippers.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46193