### PR TITLE
RPG: Prevent flickering of characters and rock giants with cloud shadows

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -7808,6 +7808,9 @@ void CRoomWidget::DrawCharacter(
 	}
 
 	//Draw character.
+	// must dirty their tiles to ensure RedrawMonsters doesn't cause flickering
+	this->pTileImages[this->pRoom->ARRAYINDEX(pCharacter->wX, pCharacter->wY)].dirty = 1;
+
 	TileImageBlitParams blit(pCharacter->wX, pCharacter->wY, wTileImageNo, wXOffset, wYOffset,
 			bMoveInProgress || wXOffset || wYOffset, fRaisedFactor);
 	blit.nOpacity = opacity;
@@ -7818,6 +7821,10 @@ void CRoomWidget::DrawCharacter(
 	if (bHasSword) {
 		blit.wCol = wSX;
 		blit.wRow = wSY;
+
+		// must dirty their tiles to ensure RedrawMonsters doesn't cause flickering
+		if (this->pRoom->IsValidColRow(pCharacter->GetSwordX(), pCharacter->GetSwordY()))
+			this->pTileImages[this->pRoom->ARRAYINDEX(pCharacter->GetSwordX(), pCharacter->GetSwordY())].dirty = 1;
 		DrawSwordFor(pCharacter, wIdentity, blit, pDestSurface);
 	}
 }
@@ -7909,6 +7916,9 @@ void CRoomWidget::DrawRockGiant(
 		blit.wCol = (*piece)->wX;
 		blit.wRow = (*piece)->wY;
 		blit.wTileImageNo = GetTileImageForRockGiantPiece(wI, pMonster->wO, wFrame);
+
+		// must dirty their tiles to ensure RedrawMonsters doesn't cause flickering
+		this->pTileImages[this->pRoom->ARRAYINDEX((*piece)->wX, (*piece)->wY)].dirty = 1;
 		DrawTileImage(blit, pDestSurface);
 	}
 }


### PR DESCRIPTION
Characters and rock giants would flicker when cloud shadows were enabled due to their tiles not correctly being marked dirty.

Forum thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45390