### PR TITLE
Fix command classification breaking chat, demo and help commands

### DIFF
--- a/DROD/EditRoomScreen.cpp
+++ b/DROD/EditRoomScreen.cpp
@@ -1744,7 +1744,8 @@ void CEditRoomScreen::DisplayChatText(const WSTRING& text, const SDL_Color& colo
 bool CEditRoomScreen::IsCommandSupported(int command) const
 //Returns: if the given command does something on this screen.
 {
-	return bIsGameCommand(command) || bIsEditorCommand(command);
+	return bIsGameCommand(command) || bIsEditorCommand(command)
+		|| bIsSharedCommand(command);
 }
 
 //*****************************************************************************

--- a/DRODLib/GameConstants.h
+++ b/DRODLib/GameConstants.h
@@ -373,8 +373,14 @@ static inline int ConvertToBumpCommand(const int command)
 
 static inline bool bIsEditorCommand(const int command)
 {
-		return command == CMD_EXTRA_STATS || command == CMD_EXTRA_CHAT_HISTORY ||
-			(command >= CMD_EXTRA_WATCH_DEMOS && command <= CMD_EXTRA_SHOW_HELP);
+		return (command >= CMD_EXTRA_EDITOR_CUT && command <= CMD_EXTRA_EDITOR_NEXT_LEVEL);
+}
+
+static inline bool bIsSharedCommand(const int command)
+{
+	return command == CMD_EXTRA_SKIP_SPEECH || command == CMD_EXTRA_CHAT_HISTORY
+		|| command == CMD_EXTRA_STATS || command == CMD_EXTRA_WATCH_DEMOS
+		|| command == CMD_EXTRA_SHOW_HELP;
 }
 
 static inline bool IsValidOrientation(const UINT o) {return o<ORIENTATION_COUNT;}


### PR DESCRIPTION
The way I classified controls to allow editor and non-editor commands to share key bindings wasn't quite right when it came to commands that interact with chat commands. This is now fixed to allow the optimal chatting experience when playing and editing.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46308