### PR TITLE
RPG: Allow mouse movement pathfinding to walk over thin ice

### DIFF
--- a/drodrpg/DRODLib/Swordsman.cpp
+++ b/drodrpg/DRODLib/Swordsman.cpp
@@ -375,7 +375,7 @@ const
 	//Items the player can step on while executing a smart intra-room path.
 	if (this->bIntraRoomPath)
 	{
-		if (bIsTrapdoor(wLookTileNo))
+		if (bIsFallingTile(wLookTileNo))
 			return false;
 		if (bIsPowerUp(wLookTileNo) || bIsEquipment(wLookTileNo) ||
 				bIsMap(wLookTileNo) || bIsShovel(wLookTileNo) ||


### PR DESCRIPTION
While fast travel prevents you walking over trapdoors and thin ice, an exception is made for trapdoors for mouse movement pathfinding so you can actually walk on them. This change adds thin ice to that same exception.