### PR TITLE
RPG: Persist when a script has ended

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -57,6 +57,7 @@ const UINT MAX_ANSWERS = 9;
 #define numCommandsStr "NumCommands"
 #define scriptIDstr "ScriptID"
 #define startLineStr "StartLine"
+#define scriptDoneStr "ScriptDone"
 #define visibleStr "visible"
 #define equipTypeStr "equipType"
 
@@ -1784,6 +1785,10 @@ void CCharacter::Process(
 
 	//Skip script execution if no commands to play.
 	if (this->wCurrentCommandIndex >= this->commands.size())
+		goto Finish;
+
+	//Skip script execution if script is already ended.
+	if (this->bScriptDone)
 		goto Finish;
 
 	{ //scoping
@@ -6010,6 +6015,8 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 
 	this->wInitialIdentity = vars.GetVar(initialIdStr, this->wLogicalIdentity); // Note the default is wLogicalIdentity
 
+	this->bScriptDone = vars.GetVar(scriptDoneStr, false);
+
 	this->bVisible = vars.GetVar(visibleStr, this->bVisible);
 	if (!this->bVisible)
 		this->bSwordSheathed = true;
@@ -6303,6 +6310,8 @@ const
 		vars.SetVar(TooltipStr, this->customDescription.c_str());
 
 	vars.SetVar(scriptIDstr, this->dwScriptID);
+	if (this->bScriptDone)
+		vars.SetVar(scriptDoneStr, this->bScriptDone);
 
 	vars.SetVar(startLineStr, this->wCurrentCommandIndex);
 }

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -9565,6 +9565,9 @@ void CDbRoom::SetMonstersFromExploredRoomData(
 		if (bCharacter)
 		{
 			pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
+			//Invisible characters are not in room.
+			if (!pCharacter->IsVisible())
+				bInRoom = false;
 		}
 
 		CMonster *pNew = AddNewMonster(pMonster->wType, pMonster->wX, pMonster->wY, bInRoom);
@@ -9581,9 +9584,6 @@ void CDbRoom::SetMonstersFromExploredRoomData(
 			} else {
 				pNew->SetMembers(pCharacter->ExtraVars); //don't need script data, just pre-existing stats
 			}
-			//Invisible characters are not in room.
-			if (!pCharacter->IsVisible())
-				bInRoom = false;
 		}
 
 		ASSERT(pNew->IsLongMonster() || pMonster->Pieces.empty());


### PR DESCRIPTION
Undo PR #694 and replace with a proper solution. 694 accidentally blew up linking monsters with a NONE identity which had all manner of bad side effects.

This is a another attempt at fixing https://forum.caravelgames.com/viewtopic.php?TopicID=46010

When a character ends their script, there's a brief period of time until you leave the room where the character still exists but the script is done. When you preview another room before leaving the current one, a temporary game is created, but the fact the character's script had ended was not persisted. This caused the room preview to re-process that character's script from the beginning as part of turn 0 processing, which in this case included an Appear command.