### PR TITLE
RPG: Don't try to apply the jitter effect to a dead entity

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -3917,7 +3917,8 @@ void CGameScreen::AddDamageEffect(
 //Params:
 	const UINT wMonsterType,
 	const CMoveCoord& coord,
-	float fDamagePercent) //[default=1.0]
+	float fDamagePercent, //[default=1.0]
+	const bool bApplyJitter) //[default=true]
 {
 	if (fDamagePercent > 1.0)
 		fDamagePercent = 1.0;
@@ -4023,7 +4024,8 @@ void CGameScreen::AddDamageEffect(
 		break;
 	}
 
-	this->pRoomWidget->AddJitter(coord, fDamagePercent);
+	if (bApplyJitter)
+		this->pRoomWidget->AddJitter(coord, fDamagePercent);
 }
 
 //*****************************************************************************
@@ -4055,7 +4057,7 @@ void CGameScreen::AddKillEffect(const UINT wMonsterType, const CMoveCoord& coord
 	}
 	g_pTheSound->PlaySoundEffect(soundID, this->fPos);
 
-	AddDamageEffect(wMonsterType, coord);
+	AddDamageEffect(wMonsterType, coord, 1.0, false);
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -134,7 +134,7 @@ protected:
 private:
 	void           AddChatDialog();
 	bool           AddMonsterStats(CDbRoom* pRoom, CRoomWidget* pRoomWidget, CMonster* pMonster, WSTRING& text);
-	void           AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coord, float fDamagePercent=1.0f);
+	void           AddDamageEffect(const UINT wMonsterType, const CMoveCoord& coord, float fDamagePercent=1.0f, const bool bApplyJitter=true);
 	void           AddKillEffect(const UINT wMonsterType, const CMoveCoord& coord);
 	void           AmbientSoundSetup();
 	void           ApplyPlayerSettings();


### PR DESCRIPTION
When an entity is killed, we apply the damage effect to it at 100% intensity. This is primarily to get a big blood splatter effect. However this also includes targeting that tile with a big jitter effect. Most of the time this is irrelevant, the enemy is killed and so there's nothing to jitter.

However it's possible, if the kill happened as part of Imperative: Die, for another entity later in the processing sequence to move into that square. In this case, it gets a full jitter applied to it. This not only looks weird, but the entity is in the wrong tile when the jitter is animated, causing assertion errors.

This fixes this by not applying any jitter effect when the damage effect is being called by AddKillEffect.