### PR TITLE
RPG: Prevent some script commands processing when room previewing

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2361,27 +2361,31 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_AddRoomToMap:
 			{
-				if (bRoomBeingDisplayedOnly) break;
-				//Add room at (x,y) to player's mapped rooms.
-				const UINT roomID = pGame->pLevel->GetRoomIDAtCoords(
-						command.x, pGame->pLevel->dwLevelID*100 + command.y);
-				if (roomID)
+				if (!bRoomBeingDisplayedOnly)
 				{
-					const bool bMarkExplored = command.w != 0;
-					pGame->AddRoomToMap(roomID, bMarkExplored);
-					CueEvents.Add(CID_LevelMap, new CAttachableWrapper<UINT>(
+					//Add room at (x,y) to player's mapped rooms.
+					const UINT roomID = pGame->pLevel->GetRoomIDAtCoords(
+						command.x, pGame->pLevel->dwLevelID * 100 + command.y);
+					if (roomID)
+					{
+						const bool bMarkExplored = command.w != 0;
+						pGame->AddRoomToMap(roomID, bMarkExplored);
+						CueEvents.Add(CID_LevelMap, new CAttachableWrapper<UINT>(
 							bMarkExplored ? T_MAP_DETAIL : T_MAP));
+					}
 				}
 				bProcessNextCommand = true;
 			}
 			break;
 			case CCharacterCommand::CC_Autosave:
 			{
-				if (bRoomBeingDisplayedOnly) break;
-				//Autosave with identifier 'label'.
-				WSTRING saveName = pGame->ExpandText(command.label.c_str(), this);
-				if (pGame->Autosave(saveName))
-					CueEvents.Add(CID_Autosave);
+				if (!bRoomBeingDisplayedOnly)
+				{
+					//Autosave with identifier 'label'.
+					WSTRING saveName = pGame->ExpandText(command.label.c_str(), this);
+					if (pGame->Autosave(saveName))
+						CueEvents.Add(CID_Autosave);
+				}
 				bProcessNextCommand = true;
 			}
 			break;
@@ -3120,19 +3124,20 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_ScoreCheckpoint:
 			{
-				if (bRoomBeingDisplayedOnly) break;
-				//Defines a scoring point with identifier 'label'.
-				const bool bNotFrozen = !this->pCurrentGame->Commands.IsFrozen();
-				if (bNotFrozen ||  //when playing back commands, don't do this stuff
-						this->pCurrentGame->IsValidatingPlayback()) //unless we're validating
+				if (!bRoomBeingDisplayedOnly)
 				{
-					CDbMessageText *pScoreIDText = new CDbMessageText();
-					*pScoreIDText = command.label.c_str();
-					CueEvents.Add(CID_ScoreCheckpoint, pScoreIDText, true);
-					if (bNotFrozen)
-						const_cast<CCurrentGame*>(this->pCurrentGame)->WriteScoreCheckpointSave(command.label);
+					//Defines a scoring point with identifier 'label'.
+					const bool bNotFrozen = !this->pCurrentGame->Commands.IsFrozen();
+					if (bNotFrozen ||  //when playing back commands, don't do this stuff
+						this->pCurrentGame->IsValidatingPlayback()) //unless we're validating
+					{
+						CDbMessageText* pScoreIDText = new CDbMessageText();
+						*pScoreIDText = command.label.c_str();
+						CueEvents.Add(CID_ScoreCheckpoint, pScoreIDText, true);
+						if (bNotFrozen)
+							const_cast<CCurrentGame*>(this->pCurrentGame)->WriteScoreCheckpointSave(command.label);
+					}
 				}
-
 				bProcessNextCommand = true;
 			}
 			break;
@@ -3350,16 +3355,19 @@ void CCharacter::Process(
 
 			case CCharacterCommand::CC_SetPlayerAppearance:
 			{
-				if (bRoomBeingDisplayedOnly) break;
-				if (this->bIfBlock)
+				if (!bRoomBeingDisplayedOnly)
 				{
-					//As an If condition, this acts as a query that is true when
-					//the player is in this role.
-					if (player.wIdentity != command.x)
-						STOP_COMMAND;
-				} else {
-					//Sets player's identity to entity X.
-					pGame->SetPlayerRole(command.x);
+					if (this->bIfBlock)
+					{
+						//As an If condition, this acts as a query that is true when
+						//the player is in this role.
+						if (player.wIdentity != command.x)
+							STOP_COMMAND;
+					}
+					else {
+						//Sets player's identity to entity X.
+						pGame->SetPlayerRole(command.x);
+					}
 				}
 				bProcessNextCommand = true;
 			}

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -1807,6 +1807,9 @@ void CCharacter::Process(
 	CDbRoom& room = *(pGame->pRoom);
 	CSwordsman& player = *pGame->pPlayer;
 
+	// Some commands should not be executed when previewing a room remotely
+	const bool bRoomBeingDisplayedOnly = pGame->IsRoomBeingDisplayedOnly();
+
 	//Keep track of swordsman's orientation on previous and current turn.
 	this->wLastSO = this->wSO;
 	this->wSO = player.wO;
@@ -2358,6 +2361,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_AddRoomToMap:
 			{
+				if (bRoomBeingDisplayedOnly) return;
 				//Add room at (x,y) to player's mapped rooms.
 				const UINT roomID = pGame->pLevel->GetRoomIDAtCoords(
 						command.x, pGame->pLevel->dwLevelID*100 + command.y);
@@ -2373,6 +2377,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_Autosave:
 			{
+				if (bRoomBeingDisplayedOnly) return;
 				//Autosave with identifier 'label'.
 				WSTRING saveName = pGame->ExpandText(command.label.c_str(), this);
 				if (pGame->Autosave(saveName))
@@ -2472,6 +2477,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_WaitForPlayerToFace:
 			{
+				if (bRoomBeingDisplayedOnly) return;
 				//Wait until player faces orientation X.
 				if (!IsPlayerFacing(command, player))
 					STOP_COMMAND;
@@ -2481,6 +2487,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_WaitForPlayerToMove:
 			{
+				if (bRoomBeingDisplayedOnly) return;
 				//Wait until player moves in direction X.
 				if (!DidPlayerMove(command, player, nLastCommand))
 					STOP_COMMAND;
@@ -2490,6 +2497,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_WaitForPlayerToTouchMe:
 			{
+				if (bRoomBeingDisplayedOnly) return;
 				//Wait until player bumps into me (on this turn).
 				if (player.wX == this->wX && player.wY == this->wY)
 					this->bPlayerTouchedMe = true; //standing on an invisible NPC counts
@@ -3112,6 +3120,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_ScoreCheckpoint:
 			{
+				if (bRoomBeingDisplayedOnly) return;
 				//Defines a scoring point with identifier 'label'.
 				const bool bNotFrozen = !this->pCurrentGame->Commands.IsFrozen();
 				if (bNotFrozen ||  //when playing back commands, don't do this stuff
@@ -3200,6 +3209,7 @@ void CCharacter::Process(
 			break;
 
 			case CCharacterCommand::CC_LevelEntrance:
+				if (bRoomBeingDisplayedOnly) return;
 				//Takes player to level entrance X.  If Y is set, skip level entrance display.
 				if (!pGame->wTurnNo)
 					return; //don't execute on the room entrance move -- execute next turn

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2482,7 +2482,7 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_WaitForPlayerToFace:
 			{
 				//Wait until player faces orientation X.
-				if (bRoomBeingDisplayedOnly || !IsPlayerFacing(command, player))
+				if (!IsPlayerFacing(command, player))
 					STOP_COMMAND;
 
 				bProcessNextCommand = true;
@@ -2491,7 +2491,7 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_WaitForPlayerToMove:
 			{
 				//Wait until player moves in direction X.
-				if (bRoomBeingDisplayedOnly || !DidPlayerMove(command, player, nLastCommand))
+				if (!DidPlayerMove(command, player, nLastCommand))
 					STOP_COMMAND;
 
 				bProcessNextCommand = true;
@@ -2499,11 +2499,8 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_WaitForPlayerToTouchMe:
 			{
-				if (bRoomBeingDisplayedOnly)
-					STOP_COMMAND;
-
 				//Wait until player bumps into me (on this turn).
-				if (player.wX == this->wX && player.wY == this->wY)
+				if (player.wX == this->wX && player.wY == this->wY && !bRoomBeingDisplayedOnly)
 					this->bPlayerTouchedMe = true; //standing on an invisible NPC counts
 
 				if (!this->bPlayerTouchedMe)
@@ -3843,7 +3840,8 @@ bool CCharacter::IsEntityAt(
 		//Check for player by default if no flags are selected.
 		if (player.IsInRoom() &&
 			player.wX >= px && player.wX <= px + pw &&
-			player.wY >= py && player.wY <= py + ph)
+			player.wY >= py && player.wY <= py + ph &&
+			!this->pCurrentGame->IsRoomBeingDisplayedOnly())
 			return true;
 	}
 	if ((pflags & ScriptFlag::HALPH) != 0)
@@ -4317,7 +4315,7 @@ bool CCharacter::IsPlayerFacing(
 	const CSwordsman& player
 ) const
 {
-	if (!player.IsInRoom())
+	if (!player.IsInRoom() || this->pCurrentGame->IsRoomBeingDisplayedOnly())
 		return false;
 
 	UINT px;  //command parameter
@@ -4341,7 +4339,7 @@ bool CCharacter::DidPlayerMove(
 	const int nLastCommand
 ) const
 {
-	if (!player.IsInRoom())
+	if (!player.IsInRoom() || this->pCurrentGame->IsRoomBeingDisplayedOnly())
 		return false;
 
 	const bool bPlayerMoved = player.wX != player.wPrevX ||
@@ -4520,7 +4518,7 @@ bool CCharacter::EvaluateConditionalCommand(
 		}
 		case CCharacterCommand::CC_WaitForPlayerToTouchMe:
 		{
-			if (pGame->pPlayer->wX == this->wX && pGame->pPlayer->wY == this->wY)
+			if (pGame->pPlayer->wX == this->wX && pGame->pPlayer->wY == this->wY && !pGame->IsRoomBeingDisplayedOnly())
 				this->bPlayerTouchedMe = true; //standing on an invisible NPC counts
 
 			return this->bPlayerTouchedMe;

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2361,7 +2361,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_AddRoomToMap:
 			{
-				if (bRoomBeingDisplayedOnly) return;
+				if (bRoomBeingDisplayedOnly) break;
 				//Add room at (x,y) to player's mapped rooms.
 				const UINT roomID = pGame->pLevel->GetRoomIDAtCoords(
 						command.x, pGame->pLevel->dwLevelID*100 + command.y);
@@ -2377,7 +2377,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_Autosave:
 			{
-				if (bRoomBeingDisplayedOnly) return;
+				if (bRoomBeingDisplayedOnly) break;
 				//Autosave with identifier 'label'.
 				WSTRING saveName = pGame->ExpandText(command.label.c_str(), this);
 				if (pGame->Autosave(saveName))
@@ -3120,7 +3120,7 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_ScoreCheckpoint:
 			{
-				if (bRoomBeingDisplayedOnly) return;
+				if (bRoomBeingDisplayedOnly) break;
 				//Defines a scoring point with identifier 'label'.
 				const bool bNotFrozen = !this->pCurrentGame->Commands.IsFrozen();
 				if (bNotFrozen ||  //when playing back commands, don't do this stuff
@@ -3350,6 +3350,7 @@ void CCharacter::Process(
 
 			case CCharacterCommand::CC_SetPlayerAppearance:
 			{
+				if (bRoomBeingDisplayedOnly) break;
 				if (this->bIfBlock)
 				{
 					//As an If condition, this acts as a query that is true when

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -297,6 +297,7 @@ public:
 	bool     IsPlayerDying() const;
 	bool     IsPlayerSwordAt(const UINT wX, const UINT wY) const;
 	bool     IsRoomAtCoordsExplored(const UINT dwRoomX, const UINT dwRoomY) const;
+	bool     IsRoomBeingDisplayedOnly() const {return this->bRoomDisplayOnly;}
 	bool     IsPlayerAccessoryDisabled() const;
 	bool     IsPlayerItemDisabled(const UINT type) const;
 	bool     IsPlayerShieldDisabled() const;


### PR DESCRIPTION
Forum thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46392

When room previewing, we need to do a turn 0 process of the scripts in the room, so that e.g. custom monsters will have stats so we can look at them.

Some commands should not work in this case, such as checking if the player is touching an NPC, because they should not be in the room. This PR blocks some important commands form processing in room preview mode. Most importantly are score checkpoints and autosaves. These were submitting (invalid) scores to the spider, and with autosaves you could actually warp to other rooms in the game by loading the newly-created save.