### PR TITLE
RPG: Flip pathfinding comparitor

### DIFF
--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -65,7 +65,7 @@ public:
 	//For priority queue insertion:
 	//An element being inserted with equal or higher dwScore gets placed later in the queue.
 	//FIXME: The current operator could have different behavior, based on implementation.
-	bool operator <(const CPathNode& mc) const {return this->wScore >= mc.wScore;}
+	bool operator <(const CPathNode& mc) const {return mc.wScore < this->wScore;}
 };
 
 //


### PR DESCRIPTION
A bit of a weird one.

My local copy of the game would often throw an unhandled exception from the std library when trying to fast travel, but not always. I think I am compiling with a newer version of C++, where the library has some more checks and we were tripping that check.

The pathfinding to find the quickest path to a location implements a custom comparitor. In my version of C++, you must never have a comparitor that, when comparing an item vs itself, result in the comparitor saying it is less than itself, which the one we implemented would do. When it compares the left vs right side, it does a check where it then compares the right vs left and ensures it doesn't get the same result, which it did.

To fix this I've changed A >= B to B < A, which is exactly the same except when A = B. I did a bunch of running around with fast travel and it appears to have identical outcomes on the path chosen, but also no longer crashes my local copy of the game.

In RPG, monsters cannot use pathfinding, the only use that remains is player pathfinding via fast travel. Therefore, even if some difference has crept in, it shouldn't cause any playback desynchs.