### PR TITLE
RPG: When loading a game, convert mapOnly rooms to preview rooms

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -422,7 +422,12 @@ void CCurrentGame::AddRoomToMap(
 			pRoom->PreprocessMonsters(Ignored);
 			this->bExecuteNoMoveCommands = bExecOriginal;
 */
-
+			if (!bSaveRoom)
+			{
+				// If we don't want to include the room in save data, then we are adding a preview room.
+				// Any mapOnly room will need converting to a preview room by unsetting bSave.
+				pExpRoom->bSave = false;
+			}
 			SaveExploredRoomData(*pRoom);
 
 			this->pRoom = pOrigRoom;


### PR DESCRIPTION
When you load a saved game that has no detail rooms on the minimap from the basic map item pickup, we might want to convert some of those to preview rooms if we have since explored it on a different save.