### PR TITLE
Add ability to toggle cloud sync activation

### DIFF
--- a/DROD/SettingsScreen.h
+++ b/DROD/SettingsScreen.h
@@ -66,6 +66,9 @@ private:
 	bool     AreCNetDetailsChanged(CDbPlayer *pPlayer);
 	bool     CanCommandsShareInput(int command, int otherCommand) const;
 	void     CloudActivate();
+	void     CloudReactivate();
+	void     CloudToggle();
+	bool     DoesCloudPlayerMatchLocalPlayer(CDbPlayer* pPlayer, const string cloudPlayerXML) const;
 	bool     GetCommandKeyRedefinition(const InputCommands::DCMD eCommand, const InputKey CurrentKey, InputKey &NewKey, const bool bAllowSpecial);
 	virtual void OnKeyDown(const UINT dwTagNo, const SDL_KeyboardEvent &Key);
 	virtual void OnClick(const UINT dwTagNo);
@@ -77,6 +80,7 @@ private:
 	void     SetUndoLevelNumLabel();
 	void     SetUnspecifiedPlayerSettings(CDbPackedVars &Settings);
 	void     SetWidgetStates();
+	void     SetCloudWidgetStates();
 	void     SynchOption(const UINT dwTagNo);
 	void     SynchScreenSizeWidget();
 	void     UpdatePlayerDataFromWidgets(CDbPlayer *pPlayer);

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1022,6 +1022,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_TargetNearestOpenRoomEdge: strText = "Nearest open room edge to me"; break;
 	case MID_TargetNearestOpenRoomEdgePlayer: strText = "Nearest open room edge to player"; break;
 	case MID_WaitForBrainSense: strText = "Wait for brain sensing player"; break;
+	case MID_DeactivateCloudSyncPrompt: strText = "Deactivate cloud sync for this profile? This will only affect the local profile."; break;
+	case MID_ReactivateCloudSyncPrompt: strText = "A cloud player profile was already set for this CaravelNet account, which matches the local profile. Reactivate cloud sync?"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1397,6 +1397,8 @@ enum MID_CONSTANT {
   MID_UnlimitedUndo = 1757,
   MID_AutoUndoOnDeath = 1786,
   MID_ActivateCloudSync = 1794,
+  MID_DeactivateCloudSyncPrompt = 2137,
+  MID_ReactivateCloudSyncPrompt = 2138,
   MID_ResizableWindow = 2027,
   MID_PlayHoldManagementDemo = 2124,
   MID_DemoDateFormat = 2125,

--- a/Texts/SettingsScreen.uni
+++ b/Texts/SettingsScreen.uni
@@ -674,6 +674,14 @@ Auto undo on death
 [eng]
 Activate Cloud Sync
 
+[MID_DeactivateCloudSyncPrompt]
+[eng]
+Deactivate cloud sync for this profile? This will only affect the local profile.
+
+[MID_ReactivateCloudSyncPrompt]
+[eng]
+A cloud player profile was already set for this CaravelNet account, which matches the local profile. Reactivate cloud sync?
+
 [MID_ResizableWindow]
 [eng]
 Resizable Window


### PR DESCRIPTION
The people want to disable cloud sync sometimes. This adds a button to do that, and makes it so that you can reactivate the sync afterwards without having to delete your data.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=42719