### PR TITLE
RPG: Fix regression that stopped End on Room Exit working correctly

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -1787,10 +1787,6 @@ void CCharacter::Process(
 	if (this->wCurrentCommandIndex >= this->commands.size())
 		goto Finish;
 
-	//Skip script execution if script is already ended.
-	if (this->bScriptDone)
-		goto Finish;
-
 	{ //scoping
 	CCurrentGame *pGame = const_cast<CCurrentGame*>(this->pCurrentGame);
 	if (HasUnansweredQuestion(CueEvents) || pGame->HasUnansweredQuestion(this)) //don't execute further commands until current question is answered
@@ -1809,6 +1805,11 @@ void CCharacter::Process(
 
 	// Some commands should not have side effects when previewing a room remotely
 	const bool bRoomBeingDisplayedOnly = pGame->IsRoomBeingDisplayedOnly();
+
+	// Don't process a character script when previewing a room if the script is marked as ended
+	// This prevents removed characters from coming back when previewing the room you are currently in
+	if (bRoomBeingDisplayedOnly && this->bScriptDone)
+		goto Finish;
 
 	//Keep track of swordsman's orientation on previous and current turn.
 	this->wLastSO = this->wSO;


### PR DESCRIPTION
Fix regression caused by #702 .

We had an issue where an ended character script would restart if you scrolled into the room you're currently in in preview mode. To fix this, I persisted the bScriptDone flag and made scripts not process if this was true. But I overlooked that End on Room Exit also sets this flag.

Now we only stop processing the script if this flag is set if we're in room preview mode, which was the specific use case we were originally trying to avoid..