### PR TITLE
RPG: Prevent mist affecting player during room preview

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8205,6 +8205,7 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents) //room to disp
 	this->pTempRoomWidget->HidePlayer();
 	VERIFY(this->pTempRoomWidget->LoadFromRoom(pRoom));
 	this->pTempRoomWidget->pCurrentGame = pRoom->GetCurrentGame();
+	this->pTempRoomWidget->pCurrentGame->pPlayer->wIdentity = this->pTempRoomWidget->pCurrentGame->pPlayer->wAppearance = M_NONE;
 
 	if (this->bShowingBigMap)
 		this->pBigMapWidget->Hide(); //hide big map while displaying another room

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3475,7 +3475,7 @@ int CCurrentGame::getPlayerDEF() const
 	if (def > 0 &&
 		this->pRoom->GetTSquare(this->pPlayer->wX, this->pPlayer->wY) == T_MIST &&
 		!IsPlayerMistImmune() &&
-		!this->IsRoomBeingDisplayedOnly())
+		this->pPlayer->IsInRoom())
 		return 0;
 
 	return def;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3472,8 +3472,10 @@ int CCurrentGame::getPlayerDEF() const
 	}
 
 	//Mist negates positive defense value
-	if (def > 0 && this->pRoom->GetTSquare(this->pPlayer->wX, this->pPlayer->wY) == T_MIST &&
-		!IsPlayerMistImmune())
+	if (def > 0 &&
+		this->pRoom->GetTSquare(this->pPlayer->wX, this->pPlayer->wY) == T_MIST &&
+		!IsPlayerMistImmune() &&
+		!this->IsRoomBeingDisplayedOnly())
 		return 0;
 
 	return def;


### PR DESCRIPTION
If a player previews a room containing mist at the coordinate the player is standing, it would affect all of the damage calculations. This stops mist impacting player stats when the player is not in that room.

A bug is also fixed where the player was not considered outside that room when you previewed a room by clicking on the minimap, only when scrolling into the room via room preview mode.