### PR TITLE
RPG: Add function that can update views to current definitions

### DIFF
--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -30,6 +30,9 @@
 //Define DbProps in this object
 #define INCLUDED_FROM_DBBASE_CPP
 
+//Uncomment to update dat files to latest DBProps.h definitions after loading.
+//#define REDEFINE_DATABASE
+
 #include "DbBase.h"
 #include "Db.h"
 #include "DbProps.h"
@@ -543,6 +546,16 @@ MESSAGE_ID CDbBase::Open(
 		if (!m_pDataStorage || !m_pHoldStorage ||
 				!m_pPlayerStorage || !m_pSaveStorage || !m_pSaveMoveStorage || !m_pTextStorage)
 			throw MID_CouldNotOpenDB;
+
+#ifdef REDEFINE_DATABASE
+		RedefineDatabase(m_pDataStorage);
+		RedefineDatabase(m_pHoldStorage);
+		RedefineDatabase(m_pPlayerStorage);
+		RedefineDatabase(m_pSaveStorage);
+		RedefineDatabase(m_pSaveMoveStorage);
+		RedefineDatabase(m_pTextStorage);
+#endif // REDEFINE_DATABASE
+
 #endif
 
 		buildIndex();
@@ -639,6 +652,31 @@ bool CDbBase::CreateDatabase(const WSTRING& wstrFilepath, int initIncrementedIDs
 	newStorage.Commit();
 
 	return true;
+}
+
+//*****************************************************************************
+void CDbBase::RedefineDatabase(
+//Update all views in the specificed dat file to match the definitions from
+//DBProps.h
+c4_Storage* storage) //(in) metakit storage object for dat file
+{
+#ifdef REDEFINE_DATABASE
+	//Calling GetAs with the appropriate VIEWDEF will update the view.
+	storage->GetAs(INCREMENTEDIDS_VIEWDEF);
+	storage->GetAs(DATA_VIEWDEF);
+	storage->GetAs(DEMOS_VIEWDEF);
+	storage->GetAs(HOLDS_VIEWDEF);
+	storage->GetAs(LEVELS_VIEWDEF);
+	storage->GetAs(MESSAGETEXTS_VIEWDEF);
+	storage->GetAs(PLAYERS_VIEWDEF);
+	storage->GetAs(ROOMS_VIEWDEF);
+	storage->GetAs(SAVEDGAMES_VIEWDEF);
+	storage->GetAs(SAVEDGAMEMOVES_VIEWDEF);
+	storage->GetAs(SPEECH_VIEWDEF);
+
+	//Now commit the changes
+	storage->Commit();
+#endif // REDEFINE_DATABASE
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/DbBase.h
+++ b/drodrpg/DRODLib/DbBase.h
@@ -132,6 +132,8 @@ private:
 	WCHAR*        SetLastMessageText(const WCHAR *pwczNewMessageText, const UINT dwNewMessageTextLen);
 	WCHAR*  pwczLastMessageText;
 
+	static void   RedefineDatabase(c4_Storage* storage);
+
 	PREVENT_DEFAULT_COPY(CDbBase);
 };
 


### PR DESCRIPTION
For active development, it's useful to have a way to update existing database views without having to create new `dat` files. metakit allows that to be done with `c4_Storage::GetAs`, which changes the view it gets. A new function has been added to `DbBase` which does this for all views for a `dat` file.

For safety, the redefinition call is gated behind `#ifdef`, and can be enabled by defining `REDEFINE_DATABASE`.