### PR TITLE
RPG: Add local score storage

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -2172,6 +2172,13 @@ void CGameScreen::OnBetweenEvents()
 			//No combat and no questions.
 			this->wThisCombatTickSpeed = this->wCombatTickSpeed; //default preference
 
+			if (!this->pCurrentGame->localScoreMessage.empty()) {
+				this->pRoomWidget->AddLastLayerEffect(new CFlashMessageEffect(
+					this->pRoomWidget, this->pCurrentGame->localScoreMessage.c_str(),
+					-300, 3000));	//show at top of room for 3s
+				this->pCurrentGame->localScoreMessage.clear();
+			}
+
 			if (!this->pCurrentGame->dwCutScene)
 			{
 				this->dwLastCutSceneMove = 0;

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3133,8 +3133,10 @@ void CCharacter::Process(
 						CDbMessageText* pScoreIDText = new CDbMessageText();
 						*pScoreIDText = command.label.c_str();
 						CueEvents.Add(CID_ScoreCheckpoint, pScoreIDText, true);
-						if (bNotFrozen)
+						if (bNotFrozen) {
 							const_cast<CCurrentGame*>(this->pCurrentGame)->WriteScoreCheckpointSave(command.label);
+							const_cast<CCurrentGame*>(this->pCurrentGame)->WriteLocalHighScore(command.label);
+						}
 					}
 				}
 				bProcessNextCommand = true;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -8137,7 +8137,7 @@ UINT CCurrentGame::WriteCurrentRoomConquerDemo()
 
 //***************************************************************************************
 UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
-//Creates or updates a high score record for the give scorepoint.
+//Creates or updates a high score record for the given scorepoint.
 //
 //Returns:
 //HighScoreID of the HighScores record.
@@ -8160,7 +8160,7 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 		}
 	}
 
-	CDbLocalHighScore* pHighScore;
+	CDbLocalHighScore* pHighScore = NULL;
 	int score = CDbSavedGames::GetScore(st);
 	CDb db;
 	UINT holdID = this->pHold->dwHoldID;
@@ -8176,9 +8176,12 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 		UINT id = db.HighScores.GetIDForScorepoint(name);
 		ASSERT(id);
 		pHighScore = db.HighScores.GetByID(id);
+		ASSERT(pHighScore);
 		if (score > pHighScore->score) {
 			pHighScore->score = score;
 			pHighScore->stats = stats;
+			pHighScore->Update();
+
 			localScoreMessage = g_pTheDB->GetMessageText(MID_NewLocalHighScore);
 		} else {
 			double ratio = (double)score / (double)pHighScore->score;
@@ -8192,15 +8195,17 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 	} else {
 		//Create new score
 		pHighScore = db.HighScores.GetNew();
+		ASSERT(pHighScore);
 		pHighScore->dwHoldID = holdID;
 		pHighScore->dwPlayerID = playerID;
 		pHighScore->score = score;
 		pHighScore->scorepointName = name;
 		pHighScore->stats = stats;
+		pHighScore->Update();
+
 		localScoreMessage = g_pTheDB->GetMessageText(MID_NewLocalHighScore);
 	}
 
-	pHighScore->Update();
 	UINT highScoreID = pHighScore->dwHighScoreID;
 	delete pHighScore;
 	delete pPlayer;

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -425,6 +425,8 @@ public:
 
 	UINT imageOverlayNextID;
 
+	WSTRING localScoreMessage;
+
 	//Internet.
 //	static queue<DEMO_UPLOAD*> demosForUpload;
 	static queue<SCORE_UPLOAD*> scoresForUpload;

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -381,6 +381,7 @@ public:
 	bool     UseAccessory(CCueEvents &CueEvents);
 	bool     WalkDownStairs();
 //	UINT     WriteCurrentRoomDieDemo();
+	UINT     WriteLocalHighScore(const WSTRING& name);
 	UINT     WriteScoreCheckpointSave(const WSTRING& name);
 
 	bool     PrepTempGameForRoomDisplay(const UINT roomID);

--- a/drodrpg/DRODLib/DRODLib.2019.vcxproj
+++ b/drodrpg/DRODLib/DRODLib.2019.vcxproj
@@ -405,6 +405,7 @@
     <ClCompile Include="DbDemos.cpp" />
     <ClCompile Include="DbHolds.cpp" />
     <ClCompile Include="DbLevels.cpp" />
+    <ClCompile Include="DbLocalHighScores.cpp" />
     <ClCompile Include="DbMessageText.cpp" />
     <ClCompile Include="DbPackedVars.cpp" />
     <ClCompile Include="DbPlayers.cpp" />
@@ -481,6 +482,7 @@
     <ClInclude Include="DbDemos.h" />
     <ClInclude Include="DbHolds.h" />
     <ClInclude Include="DbLevels.h" />
+    <ClInclude Include="DbLocalHighScores.h" />
     <ClInclude Include="DbMessageText.h" />
     <ClInclude Include="DbPackedVars.h" />
     <ClInclude Include="DbPlayers.h" />

--- a/drodrpg/DRODLib/DRODLib.2019.vcxproj.filters
+++ b/drodrpg/DRODLib/DRODLib.2019.vcxproj.filters
@@ -234,6 +234,9 @@
     <ClCompile Include="FluffBaby.cpp">
       <Filter>Monsters</Filter>
     </ClCompile>
+    <ClCompile Include="DbLocalHighScores.cpp">
+      <Filter>DBs</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Combat.h">
@@ -473,6 +476,9 @@
     </ClInclude>
     <ClInclude Include="FluffBaby.h">
       <Filter>Monsters</Filter>
+    </ClInclude>
+    <ClInclude Include="DbLocalHighScores.h">
+      <Filter>DBs</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/drodrpg/DRODLib/Db.cpp
+++ b/drodrpg/DRODLib/Db.cpp
@@ -475,6 +475,7 @@ UINT CDb::LookupRowByPrimaryKey(
 		case V_SavedGames: dwRowCount = g_pTheDB->SavedGames.GetViewSize(dwID); break;
 		case V_SavedGameMoves: dwRowCount = g_pTheDB->SavedGameMoves.GetViewSize(dwID); break;
 		case V_Speech: dwRowCount = g_pTheDB->Speech.GetViewSize(dwID); break;
+		case V_LocalHighScores: dwRowCount = g_pTheDB->HighScores.GetViewSize(dwID); break;
 		default:
 			ASSERT(!"CDb::LookupRowByPrimaryKey: Unexpected property type.");
 			return ROW_NO_MATCH;
@@ -1112,10 +1113,12 @@ void CDb::RemoveEmptyRows()
 		this->Data.RemoveEmptyRows();
 		DirtyData();
 	}
-	if (this->Demos.emptyEndRows || this->SavedGames.emptyEndRows)
+	if (this->Demos.emptyEndRows || this->SavedGames.emptyEndRows ||
+			this->HighScores.emptyEndRows)
 	{
 		this->Demos.RemoveEmptyRows();
 		this->SavedGames.RemoveEmptyRows();
+		this->HighScores.RemoveEmptyRows();
 		DirtySave();
 	}
 	if (this->Holds.emptyEndRows || this->Levels.emptyEndRows ||

--- a/drodrpg/DRODLib/Db.h
+++ b/drodrpg/DRODLib/Db.h
@@ -37,6 +37,7 @@
 #include "DbHolds.h"
 #include "DbData.h"
 #include "DbLevels.h"
+#include "DbLocalHighScores.h"
 #include "DbRooms.h"
 #include "DbPlayers.h"
 #include "DbSavedGameMoves.h"
@@ -104,6 +105,7 @@ public:
 	CDbSavedGameMoves SavedGameMoves;
 	CDbSavedGames  SavedGames;
 	CDbSpeeches    Speech;
+	CDbLocalHighScores HighScores;
 
 	//Accelerated lookups.
 	static void   addDataToHold(const UINT dataID, const UINT holdID);

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -947,7 +947,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_OverheadImage: strText = "Overhead Image"; break;
 		case MID_RemoveOverheadImage: strText = "Remove overhead image"; break;
 		case MID_NewLocalHighScore: strText = "New personal best!"; break;
-		case MID_PercentOptimal: strText = "%s% optimal"; break;
+		case MID_PercentOptimal: strText = "%s% of personal best"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -946,6 +946,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_Shield9: strText = "Aluminum Shield"; break;
 		case MID_OverheadImage: strText = "Overhead Image"; break;
 		case MID_RemoveOverheadImage: strText = "Remove overhead image"; break;
+		case MID_NewLocalHighScore: strText = "New personal best!"; break;
+		case MID_PercentOptimal: strText = "%s% optimal"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -177,6 +177,7 @@ c4_IntProp* CDbBase::GetPrimaryKeyProp(
 		case V_SavedGames: return &p_SavedGameID;
 		case V_SavedGameMoves: return &p_SavedGameID;
 		case V_Speech: return &p_SpeechID;
+		case V_LocalHighScores: return &p_HighScoreID;
 		default:
 			ASSERT(!"CDbBase::GetPrimaryKeyProp: Unexpected property type.");
 		return NULL;
@@ -214,6 +215,7 @@ UINT CDbBase::GetIncrementedID(
 	static const int nRoomID = p_RoomID.GetId();
 	static const int nSavedGameID = p_SavedGameID.GetId();
 	static const int nSpeechID = p_SpeechID.GetId();
+	static const int nHighScoreId = p_HighScoreID.GetId();
 
 	if (nPropID == nDataID)
 	{
@@ -225,7 +227,7 @@ UINT CDbBase::GetIncrementedID(
 	} else if (nPropID == nPlayerID) {
 		pStorage = m_pPlayerStorage;
 		CDbBase::DirtyPlayer();
-	} else if (nPropID == nDemoID || nPropID == nSavedGameID) {
+	} else if (nPropID == nDemoID || nPropID == nSavedGameID || nPropID == nHighScoreId) {
 		pStorage = m_pSaveStorage;
 		CDbBase::DirtySave();
 	} else if (nPropID == nMessageID || nPropID == nMessageTextID) {
@@ -315,6 +317,7 @@ c4_ViewRef CDbBase::GetPlayerDataView(const VIEWTYPE vType, const char* viewName
 			return m_pPlayerStorage->View(viewName);
 		case V_Demos:
 		case V_SavedGames:
+		case V_LocalHighScores:
 			return m_pSaveStorage->View(viewName);
 		case V_SavedGameMoves:
 			return m_pSaveMoveStorage->View(viewName);
@@ -633,6 +636,7 @@ bool CDbBase::CreateDatabase(const WSTRING& wstrFilepath, int initIncrementedIDs
 	c4_View SavedGames = newStorage.GetAs(SAVEDGAMES_VIEWDEF);
 	c4_View SavedGameMoves = newStorage.GetAs(SAVEDGAMEMOVES_VIEWDEF);
 	c4_View Speech = newStorage.GetAs(SPEECH_VIEWDEF);
+	c4_View LocalHighScores = newStorage.GetAs(LOCALHIGHSCORES_VIEWDEF);
 
 	if (initIncrementedIDs >= 0)
 	{
@@ -646,7 +650,8 @@ bool CDbBase::CreateDatabase(const WSTRING& wstrFilepath, int initIncrementedIDs
 			p_PlayerID[      initIncrementedIDs ] +
 			p_RoomID[        initIncrementedIDs ] +
 			p_SavedGameID[   initIncrementedIDs ] +
-			p_SpeechID[      initIncrementedIDs ]);
+			p_SpeechID[      initIncrementedIDs ] +
+			p_HighScoreID[   initIncrementedIDs ]);
 	}
 
 	newStorage.Commit();
@@ -673,6 +678,7 @@ c4_Storage* storage) //(in) metakit storage object for dat file
 	storage->GetAs(SAVEDGAMES_VIEWDEF);
 	storage->GetAs(SAVEDGAMEMOVES_VIEWDEF);
 	storage->GetAs(SPEECH_VIEWDEF);
+	storage->GetAs(LOCALHIGHSCORES_VIEWDEF);
 
 	//Now commit the changes
 	storage->Commit();

--- a/drodrpg/DRODLib/DbHolds.cpp
+++ b/drodrpg/DRODLib/DbHolds.cpp
@@ -144,6 +144,14 @@ void CDbHolds::Delete(
 			DeleteMessage(static_cast<MESSAGE_ID>(descriptionMID));
 	}
 
+	//Delete all local high scores for the hold
+	db.HighScores.FilterByHold(dwHoldID);
+	db.HighScores.FilterByPlayer(0);
+	CIDSet scoreIDs = db.HighScores.GetIDs();
+	for (iter = scoreIDs.begin(); iter != scoreIDs.end(); ++iter) {
+		db.HighScores.Delete(*iter);
+	}
+
 	//Delete the hold.
 	CDb::deleteHold(dwHoldID); //call first
 	HoldsView.RemoveAt(dwHoldRowI);

--- a/drodrpg/DRODLib/DbLocalHighScores.cpp
+++ b/drodrpg/DRODLib/DbLocalHighScores.cpp
@@ -1,0 +1,479 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#include "DbLocalHighScores.h"
+#include "Db.h"
+
+#include <BackEndLib/Base64.h>
+
+//*****************************************************************************
+CDbLocalHighScore::CDbLocalHighScore()
+{
+	Clear();
+}
+
+//*****************************************************************************
+bool CDbLocalHighScore::Load(
+//Loads a high score from database into this object.
+//
+//Params:
+	const UINT dwLocalHighScoreID, //(in) ID of the high score to load
+	const bool bQuick //(in)  [default=false] load only quick data members
+)
+{
+	Clear();
+
+	c4_View LocalHighScoresView;
+	const UINT dwLocalHighScoreI = LookupRowByPrimaryKey(dwLocalHighScoreID,
+		V_LocalHighScores, LocalHighScoresView);
+	if (dwLocalHighScoreI == ROW_NO_MATCH)
+		return false;
+	c4_RowRef row = LocalHighScoresView[dwLocalHighScoreI];
+
+	//Load in props from db record.
+	dwHighScoreID = p_HighScoreID(row);
+	dwHoldID = p_HoldID(row);
+	dwPlayerID = p_PlayerID(row);
+	score = p_Score(row);
+	this->stats = p_Stats(row);
+
+	c4_Bytes scorepointNameBytes = p_ScorepointName(row);
+	GetWString(this->scorepointName, scorepointNameBytes);
+
+	return true;
+}
+
+//*****************************************************************************
+MESSAGE_ID CDbLocalHighScore::SetProperty(
+//Used during XML data import.
+//According to pType, convert string to proper datatype and member
+//
+//Returns: whether operation was successful
+//
+//Params:
+	const PROPTYPE pType,   //(in) property (data member) to set
+	char* const str,        //(in) string representation of value
+	CImportInfo& info,      //(in/out) Import info
+	bool& bSaveRecord       //(out) whether record should be saved
+)
+{
+	static PrimaryKeyMap::iterator localID;
+	switch (pType) {
+		case P_HighScoreID:
+		{
+			this->dwHighScoreID = convertToUINT(str);
+			if (!this->dwHighScoreID)
+				return MID_FileCorrupted;
+
+			//Look up local ID.
+			localID = info.HighScoreIDMap.find(this->dwHoldID);
+			if (localID != info.HighScoreIDMap.end())
+				//Error - this high score should not have been imported already.
+				return MID_FileCorrupted;
+
+			if (bSaveRecord) {
+				const UINT dwLocalHighScoreID = GetLocalID();
+				if (!dwLocalHighScoreID) {
+					//Import this high score into the DB.
+					const UINT dwOldLocalID = this->dwHighScoreID;
+					this->dwHighScoreID = 0L;
+					Update();
+					info.HoldIDMap[dwOldLocalID] = this->dwHighScoreID;
+				} else {
+					c4_View LocalHighScoresView;
+					const UINT dwLocalHighScoreI = LookupRowByPrimaryKey(dwLocalHighScoreID,
+						V_LocalHighScores, LocalHighScoresView);
+					if (dwLocalHighScoreI == ROW_NO_MATCH) return MID_FileCorrupted;
+					const int dbScore = p_Score(LocalHighScoresView[dwLocalHighScoreI]);
+					if (this->score > dbScore) {
+						//Overwrite existing lesser score with this one
+						Update();
+					}
+				}
+			} else {
+				//This high score is being ignored
+				info.HighScoreIDMap[this->dwHighScoreID] = 0;
+			}
+		}
+		break;
+		case P_HoldID:
+		{
+			this->dwHoldID = convertToUINT(str);
+			//Set to local ID.
+			localID = info.HoldIDMap.find(this->dwHoldID);
+			if (localID == info.HoldIDMap.end())
+				return MID_HoldNotFound;   //record should have been loaded already
+			this->dwHoldID = (*localID).second;
+			if (!this->dwHoldID)
+			{
+				//Records for this hold are being ignored. Don't save this high score.
+				bSaveRecord = false;
+			}
+		}
+		break;
+		case P_PlayerID:
+		{
+			this->dwPlayerID = convertToUINT(str);
+			//Set to local ID.
+			localID = info.PlayerIDMap.find(this->dwPlayerID);
+			if (localID == info.PlayerIDMap.end())
+				return MID_FileCorrupted;  //record should exist now
+			this->dwPlayerID = localID->second;
+		}
+		break;
+		case P_Score:
+		{
+			this->score = convertToInt(str);
+		}
+		break;
+		case P_ScorepointName:
+		{
+			this->scorepointName = UTF8ToUnicode(str);
+		}
+		break;
+		case P_Stats:
+		{
+			BYTE* data;
+			Base64::decode(str, data);
+			this->stats = (const BYTE*)data;
+			delete[] data;
+		}
+		break;
+	}
+
+	return MID_ImportSuccessful;
+}
+
+//*****************************************************************************
+bool CDbLocalHighScore::Update()
+//Update database with high score, and return if it was successful.
+{
+	bool bSuccess = true;
+
+	g_pTheDB->HighScores.ResetMembership();
+
+	if (this->bPartialLoad)
+	{
+		ASSERT(!"CDbLocalHighScore: partial load update");
+		return false;
+	}
+
+	if (this->dwHighScoreID == 0)
+	{
+		//Insert a new level.
+		bSuccess = UpdateNew();
+	}
+	else
+	{
+		//Update existing level.
+		bSuccess = UpdateExisting();
+	}
+
+	return bSuccess;
+}
+
+//*****************************************************************************
+void CDbLocalHighScore::Clear()
+//Frees resources associated with this object and resets member vars.
+{
+	this->dwHighScoreID = this->dwHoldID = 
+		this->dwPlayerID = this->score = 0;
+	this->scorepointName.clear();
+	this->stats.Clear();
+}
+
+//*****************************************************************************
+UINT CDbLocalHighScore::GetLocalID() const
+//Use the hold and player ID, along with the scorepoint name to find the main ID
+//from DB records
+//
+//Returns: local ID if a record in the DB matches this object's identifiers, else 0
+{
+	ASSERT(IsOpen());
+	ASSERT(this->dwHoldID);
+	ASSERT(this->dwPlayerID);
+	ASSERT(!this->scorepointName.empty());
+	const UINT dwHighScoreCount = GetViewSize(V_LocalHighScores);
+
+	//Each iteration checks the hold and player id, then the scorepoint name
+	//All three need to match for the high score to be a match.
+	for (UINT dwHighScoreI = 0; dwHighScoreI < dwHighScoreCount; ++dwHighScoreI)
+	{
+		c4_RowRef row = GetRowRef(V_LocalHighScores, dwHighScoreI);
+		if (!(this->dwHoldID == p_HoldID(row) && this->dwPlayerID == p_PlayerID(row))) {
+			//Not a match
+			continue;
+		}
+
+		//Now get and check the scorepoint name
+		WSTRING name;
+		GetWString(name, p_ScorepointName(row));
+		if (this->scorepointName == name) {
+			return (UINT)p_HighScoreID(row);
+		}
+	}
+
+	return 0;
+}
+
+//*****************************************************************************
+void CDbLocalHighScore::SetMembers(const CDbLocalHighScore& src)
+//For copy constructor and assignment operator.
+{
+	this->dwHighScoreID = src.dwHighScoreID;
+	this->dwHoldID = src.dwHoldID;
+	this->dwPlayerID = src.dwPlayerID;
+	this->score = src.score;
+	this->scorepointName = src.scorepointName;
+	this->stats = src.stats;
+}
+
+//*****************************************************************************
+bool CDbLocalHighScore::UpdateExisting()
+//Update an existing high score record in database.
+{
+	LOGCONTEXT("CDbLocalHighScore::UpdateExisting");
+	ASSERT(this->dwHighScoreID != 0);
+	ASSERT(IsOpen());
+
+	c4_View LocalHighScoresView;
+	const UINT dwLocalHighScoreI = LookupRowByPrimaryKey(this->dwHighScoreID,
+		V_LocalHighScores, LocalHighScoresView);
+
+	if (dwLocalHighScoreI == ROW_NO_MATCH) {
+		ASSERT(!"Bad local high score ID.");
+		return false;
+	}
+
+	//Get stats into a buffer that can be written to db.
+	UINT dwStatsSize;
+	BYTE* pbytStatsBytes = this->stats.GetPackedBuffer(dwStatsSize);
+	if (!pbytStatsBytes) return false;
+	c4_Bytes StatsBytes(pbytStatsBytes, dwStatsSize);
+
+	c4_RowRef row = LocalHighScoresView[dwLocalHighScoreI];
+
+	p_HighScoreID(row) = this->dwHighScoreID;
+	p_HoldID(row) = this->dwHoldID;
+	p_PlayerID(row) = this->dwPlayerID;
+	p_Score(row) = this->score;
+	p_ScorepointName(row) = PutWString(this->scorepointName);
+	p_Stats(row) = StatsBytes;
+
+	CDbBase::DirtySave();
+	return true;
+}
+
+//*****************************************************************************
+bool CDbLocalHighScore::UpdateNew()
+//Add new high score record to database.
+{
+	LOGCONTEXT("CDbLocalHighScore::UpdateNew");
+	ASSERT(this->dwHighScoreID == 0);
+	ASSERT(IsOpen());
+
+	//Get stats into a buffer that can be written to db.
+	UINT dwStatsSize;
+	BYTE* pbytStatsBytes = this->stats.GetPackedBuffer(dwStatsSize);
+	if (!pbytStatsBytes) return false;
+	c4_Bytes StatsBytes(pbytStatsBytes, dwStatsSize);
+
+	this->dwHighScoreID = GetIncrementedID(p_HighScoreID);
+
+	c4_RowRef row = g_pTheDB->HighScores.GetNewRow();
+	p_HighScoreID(row) = this->dwHighScoreID;
+	p_HoldID(row) = this->dwHoldID;
+	p_PlayerID(row) = this->dwPlayerID;
+	p_Score(row) = this->score;
+	p_ScorepointName(row) = PutWString(this->scorepointName);
+	p_Stats(row) = StatsBytes;
+
+	return true;
+}
+
+//*****************************************************************************
+void CDbLocalHighScores::Delete(UINT dwLocalHighScoreID)
+//Deletes records of high score with the given id
+{
+	ASSERT(dwLocalHighScoreID);
+
+	c4_View LocalHighScoresView;
+	const UINT dwLocalHighScoreI = LookupRowByPrimaryKey(dwLocalHighScoreID,
+		V_LocalHighScores, LocalHighScoresView);
+
+	if (dwLocalHighScoreI == ROW_NO_MATCH) {
+		ASSERT(!"Bad local high score ID.");
+		return;
+	}
+
+	//Delete the score
+	LocalHighScoresView.RemoveAt(dwLocalHighScoreI);
+	this->bIsMembershipLoaded = false;
+	CDbBase::DirtySave();
+}
+
+//*****************************************************************************
+#define STARTTAG(vType,pType) "<"; str += ViewTypeStr(vType); str += " "; str += PropTypeStr(pType); str += "='"
+#define PROPTAG(pType) "' "; str += PropTypeStr(pType); str += "='"
+#define CLOSETAG "'/>" NEWLINE
+#define INT32TOSTR(val) writeInt32(dummy, sizeof(dummy), (val))
+
+//*****************************************************************************
+void CDbLocalHighScores::ExportXML(
+//Returns: string containing XML text describing this high score
+//
+//Params:
+	const UINT dwLocalHighScoreID, //(in)
+	CDbRefs& dbRefs,               //(in/out)
+	string& str,                   //(in/out)
+	const bool bRef)               //(in) Only export GUID reference (default = false)
+{
+	if (dbRefs.IsSet(V_LocalHighScores, dwLocalHighScoreID))
+		return;
+
+	dbRefs.Set(V_LocalHighScores, dwLocalHighScoreID);
+
+	//Prepare data.
+	CDbLocalHighScore* pHighScore = GetByID(dwLocalHighScoreID);
+	ASSERT(pHighScore);
+	if (!pHighScore)
+		return; //shouldn't happen -- but this is more robust
+
+	//Include corresponding hold and player refs.
+	g_pTheDB->Players.ExportXML(pHighScore->dwPlayerID, dbRefs, str, true);
+	g_pTheDB->Holds.ExportXML(pHighScore->dwHoldID, dbRefs, str, true);
+
+	char dummy[32];
+
+	str += STARTTAG(V_LocalHighScores, P_HoldID);
+	str += INT32TOSTR(pHighScore->dwHoldID);
+	str += PROPTAG(P_PlayerID);
+	str += INT32TOSTR(pHighScore->dwPlayerID);
+	str += PROPTAG(P_ScorepointName);
+	str += Base64::encode(pHighScore->scorepointName);
+	str += PROPTAG(P_Score);
+	str += INT32TOSTR(pHighScore->score);
+
+	UINT dwBufSize;
+	BYTE* const pStats = pHighScore->stats.GetPackedBuffer(dwBufSize);
+
+	if (dwBufSize > sizeof(BYTE)) {
+		str += PROPTAG(P_Stats);
+		str += Base64::encode(pStats, dwBufSize - sizeof(BYTE));   //strip null BYTE
+	}
+	delete[] pStats;
+
+	str += PROPTAG(P_HighScoreID);
+	str += INT32TOSTR(pHighScore->dwHighScoreID);
+	str += CLOSETAG;
+
+	delete pHighScore;
+}
+
+#undef STARTTAG
+#undef PROPTAG
+#undef CLOSETAG
+#undef INT32TOSTR
+
+//*****************************************************************************
+void CDbLocalHighScores::FilterByHold(UINT dwFilterByHoldID)
+{
+	if (this->bIsMembershipLoaded && dwFilterByHoldID != this->dwFilterByHoldID) {
+		//Membership is invalid.
+		this->bIsMembershipLoaded = false;
+	}
+
+	this->dwFilterByHoldID = dwFilterByHoldID;
+}
+
+//*****************************************************************************
+void CDbLocalHighScores::FilterByPlayer(UINT dwFilterByPlayerID)
+{
+	if (this->bIsMembershipLoaded && dwFilterByPlayerID != this->dwFilterByPlayerID) {
+		//Membership is invalid.
+		this->bIsMembershipLoaded = false;
+	}
+
+	this->dwFilterByPlayerID = dwFilterByPlayerID;
+}
+
+//*****************************************************************************
+UINT CDbLocalHighScores::GetIDForScorepoint(WSTRING scorepointName)
+//Returns the ID of the record for the given scorepoint, or zero if the record
+//couldn't be found.
+//Precondition: Hold and player filters have been set.
+{
+	if (!(this->dwFilterByHoldID && this->dwFilterByPlayerID)) {
+		ASSERT(!"CDbLocalHighScores::GetIDForScorepoint is only for filtered records");
+		return 0;
+	}
+
+	if (!this->bIsMembershipLoaded) LoadMembership();
+
+	multimap<WSTRING, UINT>::const_iterator it = scorepointNameToID.find(scorepointName);
+	if (it == scorepointNameToID.end()) {
+		return 0;
+	}
+
+	return it->second;
+}
+
+//*****************************************************************************
+bool CDbLocalHighScores::HasScorepoint(WSTRING scorepointName)
+//Returns if a scorepoint with the give name exists in the filtered set of records
+{
+	if (!this->bIsMembershipLoaded) LoadMembership();
+
+	return scorepointNameToID.count(scorepointName) > 0;
+}
+
+//*****************************************************************************
+void CDbLocalHighScores::LoadMembership()
+//Load the membership list with all high score IDs.
+{
+	ASSERT(IsOpen());
+	const UINT dwLocalHighScoreCount = GetViewSize();
+
+	//Each iteration gets a high score ID and puts in membership list.
+	this->MembershipIDs.clear();
+	this->scorepointNameToID.clear();
+	for (UINT dwHighScoreI = 0; dwHighScoreI < dwLocalHighScoreCount; ++dwHighScoreI)
+	{
+		c4_RowRef row = GetRowRef(V_LocalHighScores, dwHighScoreI);
+		const UINT dwHoldID = p_HoldID(row);
+		const UINT dwPlayerID = p_PlayerID(row);
+		if ((!this->dwFilterByHoldID || dwHoldID == this->dwFilterByHoldID) &&
+			(!this->dwFilterByPlayerID || dwPlayerID == this->dwFilterByPlayerID)) {
+			UINT id = p_HighScoreID(row);
+			this->MembershipIDs += id;
+
+			WSTRING name;
+			GetWString(name, p_ScorepointName(row));
+			scorepointNameToID.insert({ name, id });
+		}
+	}
+
+	this->currentRow = this->MembershipIDs.begin();
+	this->bIsMembershipLoaded = true;
+}

--- a/drodrpg/DRODLib/DbLocalHighScores.h
+++ b/drodrpg/DRODLib/DbLocalHighScores.h
@@ -1,0 +1,101 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+//DbLocalHighScores.h
+//Declarations for DbLocalHighScores and DbLocalHighScore.
+//Classes for accessing local highscore data from database.
+
+#ifndef DB_LOCALHIGHSCORES
+#define DB_LOCALHIGHSCORES
+
+#include "DbVDInterface.h"
+#include "ImportInfo.h"
+
+//*****************************************************************************
+class CDbLocalHighScore : public CDbBase {
+protected:
+	friend class CDbVDInterface<CDbLocalHighScore>;
+	CDbLocalHighScore();
+
+public:
+	CDbLocalHighScore(CDbLocalHighScore& Src) : CDbBase() { SetMembers(Src); }
+	CDbLocalHighScore& operator= (const CDbLocalHighScore& Src) {
+		SetMembers(Src);
+		return *this;
+	}
+
+	bool Load(const UINT dwLocalHighScoreID, const bool bQuick = false);
+	virtual MESSAGE_ID SetProperty(const PROPTYPE pType, char* const str,
+		CImportInfo& info, bool& bSaveRecord);
+
+	virtual bool Update();
+
+	UINT dwHighScoreID;
+	UINT dwHoldID;
+	UINT dwPlayerID;
+	int  score;
+	WSTRING scorepointName;
+	CDbPackedVars stats;
+
+private:
+	void Clear();
+
+	UINT GetLocalID() const;
+
+	void SetMembers(const CDbLocalHighScore& src);
+
+	bool UpdateExisting();
+	bool UpdateNew();
+};
+
+//*****************************************************************************
+class CDbLocalHighScores : public CDbVDInterface<CDbLocalHighScore> {
+protected:
+	friend class CDb;
+	CDbLocalHighScores()
+		: CDbVDInterface<CDbLocalHighScore>(V_LocalHighScores, p_HighScoreID),
+		dwFilterByHoldID(0), dwFilterByPlayerID(0)
+	{}
+
+public:
+
+	virtual void Delete(UINT dwLocalHighScoreID);
+
+	virtual void ExportXML(
+		const UINT dwLocalHighScoreID,CDbRefs& dbRefs, string& str, const bool bRef = false);
+	void FilterByHold(UINT dwFilterByHoldID);
+	void FilterByPlayer(UINT dwFilterByPlayerID);
+	UINT GetIDForScorepoint(WSTRING scorepointName);
+	bool HasScorepoint(WSTRING scorepointName);
+
+private:
+	virtual void LoadMembership();
+
+	UINT dwFilterByHoldID;
+	UINT dwFilterByPlayerID;
+
+	std::multimap<WSTRING, UINT> scorepointNameToID;
+};
+
+#endif // #ifndef DB_LOCALHIGHSCORES

--- a/drodrpg/DRODLib/DbPlayers.cpp
+++ b/drodrpg/DRODLib/DbPlayers.cpp
@@ -115,6 +115,13 @@ void CDbPlayers::Delete(
 	for (iter = SavedGameIDs.begin(); iter != SavedGameIDs.end(); ++iter)
 		db.SavedGames.Delete(*iter);
 
+	db.HighScores.FilterByHold(0);
+	db.HighScores.FilterByPlayer(dwPlayerID);
+	CIDSet highScoreIDs = db.HighScores.GetIDs();
+	for (iter = highScoreIDs.begin(); iter != highScoreIDs.end(); ++iter) {
+		db.HighScores.Delete(*iter);
+	}
+
 	CDbBase::DirtyPlayer();
 	if (!bRetainRef)
 	{
@@ -324,6 +331,21 @@ void CDbPlayers::ExportXML(
 				if (str.size() > str.capacity()*0.98)
 					str.reserve(str.capacity() * 2);
 				db.SavedGames.ExportXML(*iter, dbRefs, str);
+			}
+
+			CDbXML::PerformCallbackf(0.01f);
+			db.HighScores.FilterByPlayer(dwPlayerID);
+			CIDSet HighScoreIDs = db.HighScores.GetIDs();
+			const float fNumHighScores = (float)SavedGameIDs.size();
+			str.reserve(static_cast<UINT>(str.capacity() + fNumHighScores * 500)); //large speed optimization
+
+			for (iter = HighScoreIDs.begin(), wCount = 0; iter != HighScoreIDs.end(); ++iter) {
+				CDbXML::PerformCallbackf(++wCount / fNumHighScores);
+				if (str.size() > str.capacity() * 0.98) {
+					str.reserve(str.capacity() * 2);
+				}
+
+				db.HighScores.ExportXML(*iter, dbRefs, str);
 			}
 		}
 

--- a/drodrpg/DRODLib/DbProps.h
+++ b/drodrpg/DRODLib/DbProps.h
@@ -74,6 +74,7 @@ DEFPROP(c4_IntProp,     GID_LevelIndex);
 DEFPROP(c4_IntProp,     GID_NewLevelIndex);
 DEFPROP(c4_IntProp,     GID_OriginalNameMessageID);
 DEFPROP(c4_IntProp,     GID_PlayerID);
+DEFPROP(c4_IntProp,     HighScoreID);
 DEFPROP(c4_IntProp,     HoldID);
 DEFPROP(c4_IntProp,     ImageStartX);
 DEFPROP(c4_IntProp,     ImageStartY);
@@ -112,6 +113,8 @@ DEFPROP(c4_IntProp,     RoomRows);
 DEFPROP(c4_IntProp,     RoomX);
 DEFPROP(c4_IntProp,     RoomY);
 DEFPROP(c4_IntProp,     SavedGameID);
+DEFPROP(c4_IntProp,     Score);
+DEFPROP(c4_BytesProp,   ScorepointName);
 DEFPROP(c4_IntProp,     ScriptID);
 DEFPROP(c4_BytesProp,   Settings);
 DEFPROP(c4_IntProp,     ShowDescription);
@@ -168,7 +171,8 @@ DEFTDEF(INCREMENTEDIDS_VIEWDEF,
 			"PlayerID:I,"
 			"RoomID:I,"
 			"SavedGameID:I,"
-			"SpeechID:I"
+			"SpeechID:I,"
+			"HighScoreID:I"
 		"]");
 
 #define MONSTERS_VIEWPROPDEF  \
@@ -421,6 +425,17 @@ DEFTDEF(SAVEDGAMEMOVES_VIEWDEF,
 			"Commands:B"     //packed movement commands
 		"]");
 
+DEFTDEF(LOCALHIGHSCORES_VIEWDEF,
+		"LocalHighScores"
+		"["
+				"HighScoreID:I,"
+				"Score:I,"
+				"PlayerID:I,"
+				"HoldID:I,"
+				"ScorepointName:B,"
+				"Stats:B"
+		"]");
+
 #undef DEFPROP
 #undef DEFTDEF
 
@@ -444,6 +459,7 @@ enum VIEWTYPE
 	V_SavedGameMoves,
 	V_SavedGames,
 	V_Speech,
+	V_LocalHighScores,
 	V_Count,
 	V_Invalid
 };
@@ -507,6 +523,7 @@ enum PROPTYPE
 	P_GID_NewLevelIndex,
 	P_GID_OriginalNameMessage, //not ID
 	P_GID_PlayerID,
+	P_HighScoreID,
 	P_HoldID,
 	P_ImageStartX,
 	P_ImageStartY,
@@ -547,6 +564,8 @@ enum PROPTYPE
 	P_RoomX,
 	P_RoomY,
 	P_SavedGameID,
+	P_Score,
+	P_ScorepointName,
 	P_ScriptID,
 	P_Settings,
 	P_ShowDescription,
@@ -577,11 +596,11 @@ enum PROPTYPE
 };
 
 //*****************************************************************************
-extern const char viewTypeStr[V_Count][15]
+extern const char viewTypeStr[V_Count][16]
 #ifdef INCLUDED_FROM_DBBASE_CPP
 = {
 	"Data", "Demos", "Holds", "Levels", "MessageTexts", "Players",
-	"Rooms", "SavedGameMoves", "SavedGames", "Speech"
+	"Rooms", "SavedGameMoves", "SavedGames", "Speech", "LocalHighScores"
 }
 #endif
 ;
@@ -610,7 +629,7 @@ extern const char propTypeStr[P_Count][26]
 	"EditingPrivileges", "EMailMessage", "EndHoldMessage", "EndTurnNo",
 	"EntranceID", "EntrancesExplored", "ExtraVars", "Flags", "GID_Created",
 	"GID_LevelIndex", "GID_NewLevelIndex", "GID_OriginalNameMessage",
-	"GID_PlayerID", "HoldID", "ImageStartX", "ImageStartY",
+	"GID_PlayerID", "HighScoreID", "HoldID", "ImageStartX", "ImageStartY",
 //	"IsFirstTurn",
 	"IsHidden", "IsLocal", "IsMainEntrance",
 	"IsSecret",
@@ -623,7 +642,7 @@ extern const char propTypeStr[P_Count][26]
 	"PlayerID",
 //	"ProcessSequence",
 	"RawData", "Right", "RoomID", "RoomCols",
-	"RoomRows", "RoomX", "RoomY", "SavedGameID", "ScriptID",
+	"RoomRows", "RoomX", "RoomY", "SavedGameID", "Score", "ScorepointName", "ScriptID",
 	"Settings", "ShowDescription", "ShowSequenceNo", "SpeechID", "Squares",
 	"StartRoomAppearance",
 	"StartRoomO", "StartRoomSwordOff", "StartRoomX", "StartRoomY", "Stats",

--- a/drodrpg/DRODLib/DbRefs.cpp
+++ b/drodrpg/DRODLib/DbRefs.cpp
@@ -67,6 +67,8 @@ const
 			return this->SavedGames.has(dwID);
 		case V_Speech:
 			return this->Speech.has(dwID);
+		case V_LocalHighScores:
+			return this->HighScores.has(dwID);
 		default:
 			ASSERTP(false, "CDbRefs::IsSet() Unexpected view type.");
 			return false;
@@ -107,6 +109,9 @@ void CDbRefs::Set(
 			break;
 		case V_Speech:
 			this->Speech += dwID;
+			break;
+		case V_LocalHighScores:
+			this->HighScores += dwID;
 			break;
 		default:
 			ASSERTP(false, "CDbRefs::Set() Unexpected view type.");

--- a/drodrpg/DRODLib/DbRefs.h
+++ b/drodrpg/DRODLib/DbRefs.h
@@ -64,6 +64,7 @@ private:
 	CIDSet Rooms;       //maybe ref
 	CIDSet SavedGames;  //maybe ref
 	CIDSet Speech;      //never a ref
+	CIDSet HighScores;  //never a ref
 };
 
 #endif //...#ifndef DBREFS_H

--- a/drodrpg/DRODLib/DbXML.cpp
+++ b/drodrpg/DRODLib/DbXML.cpp
@@ -114,6 +114,7 @@ void CDbXML::AddRowsForPendingRecords()
 	g_pTheDB->Demos.EnsureEmptyRows(CDbXML::info.nDemos);
 	g_pTheDB->Players.EnsureEmptyRows(CDbXML::info.nPlayers);
 	g_pTheDB->SavedGames.EnsureEmptyRows(CDbXML::info.nSavedGames);
+	g_pTheDB->HighScores.EnsureEmptyRows(CDbXML::info.nHighScore);
 
 	CDbXML::info.bPreparsed = true;
 }
@@ -150,6 +151,8 @@ CDbBase* CDbXML::GetNewRecord(
 			return g_pTheDB->SavedGameMoves.GetNew();
 		case V_Speech:
 			return g_pTheDB->Speech.GetNew();
+		case V_LocalHighScores:
+			return g_pTheDB->HighScores.GetNew();
 
 		default:
 			ASSERT(!"Unexpected view type.");
@@ -262,6 +265,7 @@ void CDbXML::TallyElement(
 		case V_Rooms: ++CDbXML::info.nRooms; break;
 		case V_SavedGames: ++CDbXML::info.nSavedGames; break;
 		case V_Speech: ++CDbXML::info.nSpeech; break;
+		case V_LocalHighScores: ++CDbXML::info.nHighScore; break;
 		default: break;
 	}
 }

--- a/drodrpg/DRODLib/ImportInfo.h
+++ b/drodrpg/DRODLib/ImportInfo.h
@@ -83,9 +83,10 @@ public:
 	PrimaryKeyMap RoomIDMap;
 	PrimaryKeyMap SavedGameIDMap;
 	PrimaryKeyMap SpeechIDMap;
+	PrimaryKeyMap HighScoreIDMap;
 
 	bool bPreparsed;
-	UINT  nData, nDemos, nHolds, nLevels, nPlayers, nRooms, nSavedGames, nSpeech;
+	UINT  nData, nDemos, nHolds, nLevels, nPlayers, nRooms, nSavedGames, nSpeech, nHighScore;
 
 	bool  bReplaceOldPlayers;
 	bool  bReplaceOldHolds;     //confirm upgrading saved games in hold

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -358,4 +358,4 @@ New personal best!
 
 [MID_PercentOptimal]
 [eng]
-%s% optimal
+%s% of personal best

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -351,3 +351,11 @@ Blue Keys
 [MID_SKEYStatFull]
 [eng]
 Skeleton Keys
+
+[MID_NewLocalHighScore]
+[eng]
+New personal best!
+
+[MID_PercentOptimal]
+[eng]
+%s% optimal

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -606,6 +606,8 @@ enum MID_CONSTANT {
   MID_GKEYStatFull = 1825,
   MID_BKEYStatFull = 1826,
   MID_SKEYStatFull = 1827,
+  MID_NewLocalHighScore = 1987,
+  MID_PercentOptimal = 1989,
 
   //Messages from General.uni:
   MID_SDLInitFailed = 464,


### PR DESCRIPTION
Adds support for storing a user's best score for a score point locally. These records are stored in new database view, with new management objects `CDbLocalHighScore` and `CDbLocalHighScores`. Each record corresponds to a specific player's score for a specific scorepoint in a specific hold. Along with the raw score value, the player's stats are also recorded (but the stats are currently not used for anything). This view is stored as part of the saved games data file.

When a scorepoint command is executed, the game will now create a new high score record if none exists, or update the existing one if the player's score is greater than the current recorded score. If online score submission is disabled, a message will also be shown.

The scorepoints dialog now uses high score records to determine if a scorepoint should be shown, and will append the player's score for that scorepoint.

Scores are exported and imported as part of a player. When imported, an existing record will be overwritten if the incoming record is better than the existing record.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46165