### PR TITLE
Fix how default behaviors are set for characters

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -6857,11 +6857,9 @@ void CCharacter::SetCurrentGame(
 			default: break;
 		}
 
+		SetDefaultBehaviors();
+		SetDefaultMovementType();
 	}
-
-	// Always set default behaviors and movement types
-	SetDefaultBehaviors();
-	SetDefaultMovementType();
 
 	//If this NPC is a custom character with no script,
 	//then use the default script for this custom character type.

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -240,6 +240,8 @@ public:
 	void           ResolveLogicalIdentity(CDbHold *pHold);
 	virtual void   SetCurrentGame(const CCurrentGame *pSetCurrentGame);
 	virtual void   SetCustomSpeechColor(const UINT color) { this->customSpeechColor = color; }
+	void           SetDefaultBehaviors();
+	void           SetDefaultMovementType();
 	void   SetImperative(const ScriptFlag::Imperative eVal) {this->eImperative = eVal;}
 	virtual void   SetExtraVarsFromMembers(const bool bHoldChar=false);
 	void           SetExtraVarsFromMembersWithoutScript(const bool bHoldChar=false);
@@ -308,8 +310,6 @@ private:
 	void TurnIntoMonster(CCueEvents& CueEvents, const bool bSpecial=false);
 	bool TurnsSlowly() const;
 
-	void SetDefaultBehaviors();
-	void SetDefaultMovementType();
 	void setPredefinedVarInt(UINT varIndex, const UINT val, CCueEvents& CueEvents);
 	void setPredefinedVarString(UINT varIndex, const WSTRING val, CCueEvents& CueEvents);
 	void SetVariable(const CCharacterCommand& command, CCurrentGame *pGame, CCueEvents& CueEvents);

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -263,6 +263,8 @@ CMonster* CCurrentGame::AddNewEntity(
 	CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pNew);
 	pCharacter->wLogicalIdentity = identity;
 	pCharacter->SetCurrentGame(this); //will assign the default script for custom NPCs
+	pCharacter->SetDefaultBehaviors();
+	pCharacter->SetDefaultMovementType();
 	pCharacter->dwScriptID = this->pHold->GetNewScriptID();
 	pCharacter->bNewEntity = true;
 


### PR DESCRIPTION
At some point I changed how character's default behaviors (and movement types) were set so that they would be set on non-zero turns, to fix a problem with generated characters. This broke game snapshots in a subtle way.

The fix to the fix is to make the defaulting turn zero only, and to manually call those functions on generated characters.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46201