### PR TITLE
Fix inconsistency with rewind limit logic

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -221,7 +221,7 @@ bool CGameScreen::LoadSavedGame(
 		return false;
 
 	this->bPlayTesting = false;
-	this->undo.setRewindLimit(this->pCurrentGame->wTurnNo);
+	this->undo.setRewindLimit(this->pCurrentGame->wPlayerTurn);
 	this->bRoomClearedOnce = this->pCurrentGame->IsCurrentRoomPendingExit();
 
 	SetSignTextToCurrentRoom();
@@ -5380,7 +5380,7 @@ void CGameScreen::RestartRoom(int nCommand, CCueEvents& CueEvents)
 	this->bRoomClearedOnce = this->pCurrentGame->IsCurrentRoomPendingExit();
 
 	if (!this->bPlayTesting)
-		this->undo.setRewindLimit(this->pCurrentGame->wTurnNo); //can't undo past restart point
+		this->undo.setRewindLimit(this->pCurrentGame->wPlayerTurn); //can't undo past restart point
 
 	ClearEventsThatOnlyShowOnInitialRoomEntrance(CueEvents);
 


### PR DESCRIPTION
After a restart, the rewind limit turn is set to the current turn number. However, the check for the rewind limit uses the player turn number, meaning the amount of undos is reduced if "turnless" actions have been performed. The limit should always be set using the player turn.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46519