### PR TITLE
Add commands to query entire array variables

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -126,6 +126,24 @@ inline bool bCommandHasData(const UINT eCommand)
 	}
 }
 
+std::function<bool(int, int)> getComparator(ScriptVars::Comp comparison) {
+	switch (comparison) {
+		case ScriptVars::Equals:
+		default:
+			return [](int lhs, int rhs) { return lhs == rhs; };
+		case ScriptVars::Greater:
+			return [](int lhs, int rhs) { return lhs > rhs; };
+		case ScriptVars::Less:
+			return [](int lhs, int rhs) { return lhs < rhs; };
+		case ScriptVars::GreaterThanOrEqual:
+			return [](int lhs, int rhs) { return lhs >= rhs; };
+		case ScriptVars::LessThanOrEqual:
+			return [](int lhs, int rhs) { return lhs <= rhs; };
+		case ScriptVars::Inequal:
+			return [](int lhs, int rhs) { return lhs != rhs; };
+	}
+}
+
 //
 //Public methods.
 //
@@ -279,6 +297,8 @@ void CCharacter::ChangeHoldForCommands(
 				case CCharacterCommand::CC_ArrayVarSet:
 				case CCharacterCommand::CC_ArrayVarSetAt:
 				case CCharacterCommand::CC_ClearArrayVar:
+				case CCharacterCommand::CC_WaitForArrayEntry:
+				case CCharacterCommand::CC_CountArrayEntries:
 				{
 					//Update var refs.
 					UINT wRef = c.getVarID();
@@ -3159,6 +3179,20 @@ void CCharacter::Process(
 				bProcessNextCommand = true;
 			}
 			break;
+			case CCharacterCommand::CC_WaitForArrayEntry:
+			{
+				if (!DoesArrayVarSatisfy(command, pGame))
+					STOP_COMMAND;
+				bProcessNextCommand = true;
+			}
+			break;
+			case CCharacterCommand::CC_CountArrayEntries:
+			{
+				int count = CountArrayVarEntries(command, pGame);
+				pGame->ProcessCommandSetVar(ScriptVars::P_RETURN_X, count);
+				bProcessNextCommand = true;
+			}
+			break;
 
 			case CCharacterCommand::CC_SetPlayerAppearance:
 			{
@@ -5380,6 +5414,76 @@ bool CCharacter::DoesVarSatisfy(const CCharacterCommand& command, CCurrentGame *
 }
 
 //*****************************************************************************
+bool CCharacter::DoesArrayVarSatisfy(const CCharacterCommand& command, CCurrentGame* pGame)
+{
+	const UINT varId = command.x;
+	if (pGame->pHold && !pGame->pHold->IsArrayVar(varId))
+		return false; //Only for array vars
+
+	ScriptArrayMap& scriptArrays = pGame->pHold->IsLocalVar(varId) ? this->localScriptArrays : pGame->scriptArrays;
+	ScriptArrayMap::const_iterator finder = scriptArrays.find(varId);
+
+	if (finder == scriptArrays.end()) {
+		return false; //Array hasn't been initialized yet, so it can't contain the target value
+	}
+
+	const map<int, int>& array = finder->second;
+
+	int operand = int(command.w); //expect an integer value by default
+	if (!operand && !command.label.empty())
+	{
+		//Operand is not just an integer, but a text expression.
+		UINT index = 0;
+		operand = parseExpression(command.label.c_str(), index, pGame, this);
+	}
+
+	std::function<bool(int, int)> comparator = getComparator((ScriptVars::Comp)command.y);
+	for (map<int, int>::const_iterator it = array.cbegin(); it != array.cend(); ++it) {
+		if (comparator(it->second, operand)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//*****************************************************************************
+int CCharacter::CountArrayVarEntries(const CCharacterCommand& command, CCurrentGame* pGame)
+{
+	const UINT varId = command.x;
+	if (pGame->pHold && !pGame->pHold->IsArrayVar(varId))
+		return 0; //Only for array vars
+
+	ScriptArrayMap& scriptArrays = pGame->pHold->IsLocalVar(varId) ? this->localScriptArrays : pGame->scriptArrays;
+	ScriptArrayMap::const_iterator finder = scriptArrays.find(varId);
+
+	if (finder == scriptArrays.end()) {
+		return 0; //Array hasn't been initialized yet, so must have zero of anything
+	}
+
+	const map<int, int>& array = finder->second;
+
+	int operand = int(command.w); //expect an integer value by default
+	if (!operand && !command.label.empty())
+	{
+		//Operand is not just an integer, but a text expression.
+		UINT index = 0;
+		operand = parseExpression(command.label.c_str(), index, pGame, this);
+	}
+
+	std::function<bool(int, int)> comparator = getComparator((ScriptVars::Comp)command.y);
+	int count = 0;
+
+	for (map<int, int>::const_iterator it = array.cbegin(); it != array.cend(); ++it) {
+		if (comparator(it->second, operand)) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+//*****************************************************************************
 bool CCharacter::IsExpressionSatisfied(const CCharacterCommand& command, CCurrentGame* pGame)
 {
 	int constant = (int)command.x;
@@ -5778,6 +5882,11 @@ bool CCharacter::EvaluateConditionalCommand(
 		case CCharacterCommand::CC_WaitForBrainSense:
 		{
 			return pGame->bBrainSensesSwordsman;
+		}
+		break;
+		case CCharacterCommand::CC_WaitForArrayEntry:
+		{
+			return DoesArrayVarSatisfy(command, pGame);
 		}
 		break;
 		default:

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -284,8 +284,10 @@ private:
 	void BuildTiles(const CCharacterCommand& command, CCueEvents& CueEvents);
 	bool CanEnterTunnelInDirection(const int dx, const int dy) const;
 	bool ConfirmPathWithNextMoveOpen();
+	int CountArrayVarEntries(const CCharacterCommand& command, CCurrentGame* pGame);
 	void Disappear();
 	bool DoesVarSatisfy(const CCharacterCommand& command, CCurrentGame *pGame);
+	bool DoesArrayVarSatisfy(const CCharacterCommand& command, CCurrentGame *pGame);
 
 	bool EvaluateConditionalCommand(
 		const CCharacterCommand& command, CCurrentGame* pGame, const int nLastCommand, CCueEvents& CueEvents);

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -90,6 +90,7 @@ bool CCharacterCommand::IsLogicalWaitCondition() const {
 		case CC_WaitForNotItemGroup:
 		case CC_WaitForPlayerState:
 		case CC_WaitForBrainSense:
+		case CC_WaitForArrayEntry:
 			return true;
 		default:
 			return false;
@@ -102,6 +103,8 @@ UINT CCharacterCommand::getVarID() const
 		case CC_VarSet:
 		case CC_WaitForVar:
 		case CC_ClearArrayVar:
+		case CC_WaitForArrayEntry:
+		case CC_CountArrayEntries:
 			return x;
 		case CC_VarSetAt:
 		case CC_ArrayVarSet:
@@ -118,6 +121,8 @@ void CCharacterCommand::setVarID(const UINT varID)
 		case CC_VarSet:
 		case CC_WaitForVar:
 		case CC_ClearArrayVar:
+		case CC_WaitForArrayEntry:
+		case CC_CountArrayEntries:
 			x = varID;
 		break;
 		case CC_VarSetAt:

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -441,6 +441,8 @@ public:
 		CC_SetPlayerState,      //Change player state (Y) to on or off (x).
 		CC_SelectSquare,        //Prompt the player to select a position in the room.
 		CC_WaitForBrainSense,   //Wait until a brain senses the player.
+		CC_WaitForArrayEntry,   //Wait until array X has entry satisfying comparison Y expression.
+		CC_CountArrayEntries,   //Count number of entries in array X satisfying comparison Y expression.
 
 		CC_Count
 	};

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1025,6 +1025,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_DeactivateCloudSyncPrompt: strText = "Deactivate cloud sync for this profile? This will only affect the local profile."; break;
 	case MID_ReactivateCloudSyncPrompt: strText = "A cloud player profile was already set for this CaravelNet account, which matches the local profile. Reactivate cloud sync?"; break;
 	case MID_DottedLineEffect: strText = "Dotted line"; break;
+	case MID_WaitForArrayEntry: strText = "Wait for array entry"; break;
+	case MID_CountArrayEntries: strText = "Count array entries"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/DbHolds.cpp
+++ b/DRODLib/DbHolds.cpp
@@ -1502,6 +1502,8 @@ void CDbHolds::CheckForVarRefs(
 		case CCharacterCommand::CC_ArrayVarSet:
 		case CCharacterCommand::CC_ArrayVarSetAt:
 		case CCharacterCommand::CC_ClearArrayVar:
+		case CCharacterCommand::CC_WaitForArrayEntry:
+		case CCharacterCommand::CC_CountArrayEntries:
 		{
 			if (bChallenges)
 				break;

--- a/Data/Help/1/scriptarray.html
+++ b/Data/Help/1/scriptarray.html
@@ -24,6 +24,16 @@
     The one difference is that the variable name must be followed by a pair of square brackets ([]) containing an index value. This can be a numeric value or an expression that resolves to such a value. 
     If an index that has not been set is accessed, a default value of 0 is returned.</p>
 
+    <p><u>Querying full arrays</u></p>
+    <p>Two commands operate over an entire array, to provide a concise way to determine its state:
+    <ul>
+        <li><a name="wait-for-entry"><b>Wait for array entry</b></a> - Waits until the given array contains a value that satisfies the given comparison to a given value.
+        As with other variable commands, an expression can be used in place of a constant value.</li>
+        <li><a name="count-entries"><b>Count array entries</b></a> - Counts the number of values in the array that satisfies the given comparison to a given value.
+        The result is stored in <b>_ReturnX</b>.</li>
+    </ul>
+    </p>
+
     <p><u>Examples of valid array expressions</u></p>
     <ul>
         <li>#Array[2]</li>

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1908,6 +1908,8 @@ enum MID_CONSTANT {
   MID_SelectSquare = 2132,
   MID_Restricted = 2133,
   MID_WaitForBrainSense = 2136,
+  MID_WaitForArrayEntry = 2140,
+  MID_CountArrayEntries = 2141,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3507,3 +3507,11 @@ Restricted
 [MID_WaitForBrainSense]
 [eng]
 Wait for brain sensing player
+
+[MID_WaitForArrayEntry]
+[eng]
+Wait for array entry
+
+[MID_CountArrayEntries]
+[eng]
+Count array entries


### PR DESCRIPTION
Due to how arrays work, it is difficult to search them. Two new commands `Wait for array entry` and `Count array entries` allow all values that have been set in an array to be checked against a condition.

`DoesArrayVarSatisfy` and `CountArrayVarEntries` have been implemented using lambdas and `std::function`. It's possible to do this without them, but it's look messier and is harder to read. (I did restrain myself slightly and didn't start using `auto` whenever a variable declaration started getting too long for my liking)