### PR TITLE
Fix initial populating of default scripts

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -3278,6 +3278,7 @@ void CCharacterDialogWidget::EditDefaultScriptForCustomNPC()
 		}
 		this->bEditingDefaultScript = true;
 		this->defaultScriptCustomCharID = pChar->dwCharID;
+		PopulateCommandDescriptions(this->pDefaultScriptCommandsListBox, *pChar->pCommands);
 	}
 
 	//Different commands/fields are available in default scripts.


### PR DESCRIPTION
I accidentally broke default script editing in #726, making it so the fix script edited would always be shown. This PR fixes the fix.