### PR TITLE
Fix out of bounds error in BuildUtil::BuildTilesAt

### DIFF
--- a/DRODLib/BuildUtil.cpp
+++ b/DRODLib/BuildUtil.cpp
@@ -97,6 +97,9 @@ UINT BuildUtil::BuildTilesAt(
 			if (BuildUtil::BuildAnyTile(room, baseTile, tile, x, y, bAllowSame, CueEvents))
 				++builtTiles;
 
+	if (baseTile >= TOTAL_EDIT_TILE_COUNT)
+		return builtTiles;
+
 	if (TILE_LAYER[baseTile] == LAYER_OPAQUE) {
 		for (UINT y = py; y <= endY; ++y)
 			for (UINT x = px; x <= endX; ++x) {


### PR DESCRIPTION
An oversight with tile numbers meant a bad index could be used for the `TILE_LAYER` array. Some platforms are polite enough to crash instead of allow more worrisome possibilities. This is the root cause of some reported crashes.

Thread 1: https://forum.caravelgames.com/viewtopic.php?TopicID=46270
Thread 2: https://forum.caravelgames.com/viewtopic.php?TopicID=46273