### PR TITLE
Add "Add room to map" command

### DIFF
--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -79,6 +79,8 @@ public:
 	bool RenameCharacter();
 	bool RenameVar(const bool bIsArrayVar = false);
 
+	UINT mapQueryX, mapQueryY; //for querying the user for map position
+
 	static const UINT INDENT_PREFIX_SIZE;
 	static const UINT INDENT_TAB_SIZE;
 	static const UINT INDENT_IF_CONDITION_SIZE;
@@ -149,6 +151,7 @@ private:
 
 	void  prepareForwardReferences(const COMMANDPTR_VECTOR& newCommands);
 
+	void  QueryMapRoom();
 	void  QueryRect();
 	void  QueryXY();
 	void  QueryXYWH();

--- a/DROD/EditRoomWidget.h
+++ b/DROD/EditRoomWidget.h
@@ -45,7 +45,8 @@ enum EditState
 	ES_GETRECT,    //query for a room rectangle
 	ES_PASTING,    //next click pastes a copied room region
 	ES_GETSQUARES1,//query for first of two room squares
-	ES_GETSQUARES2 //query for second of two room squares
+	ES_GETSQUARES2,//query for second of two room squares
+	ES_GETMAPROOM  //query for a room from the minimap
 };
 
 //Plotting a long monster segment in the editor.

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3821,7 +3821,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 	if (CueEvents.HasOccurred(CID_GentryiiPulledTaut))
 		PlaySoundEffect(SEID_CHAIN_PULL);
 
-	if (CueEvents.HasOccurred(CID_CompleteLevel))
+	if (CueEvents.HasOccurred(CID_CompleteLevel) || CueEvents.HasOccurred(CID_AddedRoomToMap))
 	{
 		this->pMapWidget->UpdateFromCurrentGame();
 		this->pMapWidget->RequestPaint();

--- a/DROD/MapWidget.h
+++ b/DROD/MapWidget.h
@@ -58,6 +58,7 @@ public:
 	virtual void   Resize(const UINT wSetW, const UINT wSetH);
 	void           SelectRoom(const UINT dwRoomX, const UINT dwRoomY);
 	void           SelectRoomAtCoords(const int nX, const int nY);
+	bool           SelectRoomIfValid(const UINT dwRoomX, const UINT dwRoomY);
 	void           SetDarkenedRooms(CIDSet &RoomIDs);
 	void           SetDestSurface(SDL_Surface *pNewSurface);
 	void           UpdateFromCurrentGame();
@@ -89,7 +90,6 @@ private:
 	bool           IsAdjacentToValidRoom(const UINT dwRoomX, const UINT dwRoomY);
 	inline void       LockMapSurface();
 	void           MarkEntrancesAsNotMain(CDbHold *pHold, CIDSet &entranceIDs) const;
-	bool           SelectRoomIfValid(const UINT dwRoomX, const UINT dwRoomY);
 	inline void       UnlockMapSurface();
 	void           UpdateMapSurface(const bool bRefreshSelectedRoom = false);
 

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3820,6 +3820,21 @@ void CCharacter::Process(
 			}
 			break;
 
+			case CCharacterCommand::CC_AddRoomToMap:
+			{
+				//Add room at (x,y) to player's mapped rooms.
+				const UINT roomID = pGame->pLevel->GetRoomIDAtCoords(
+					command.x, pGame->pLevel->dwLevelID * 100 + command.y);
+				if (roomID)
+				{
+					pGame->ExploredRooms += roomID;
+					CueEvents.Add(CID_AddedRoomToMap);
+				}
+
+				bProcessNextCommand = true;
+			}
+			break;
+
 			case CCharacterCommand::CC_SetDarkness:
 			{
 				getCommandParams(command, px, py, pw, ph, pflags);

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -443,6 +443,7 @@ public:
 		CC_WaitForBrainSense,   //Wait until a brain senses the player.
 		CC_WaitForArrayEntry,   //Wait until array X has entry satisfying comparison Y expression.
 		CC_CountArrayEntries,   //Count number of entries in array X satisfying comparison Y expression.
+		CC_AddRoomToMap,        //Add room at (x,y) to player's mapped rooms.
 
 		CC_Count
 	};

--- a/DRODLib/CueEvents.h
+++ b/DRODLib/CueEvents.h
@@ -853,6 +853,11 @@ enum CUEEVENT_ID
 	//Private data: CCoord *pSquare
 	CID_PlatformBlocked,
 
+	//Script added a room to the explored rooms list
+	//
+	//Private data: NONE
+	CID_AddedRoomToMap,
+
 #ifdef TEST_SPIDER
 	//Custom CueEvent to cause failure in test spider
 	//Make sure this is always the last CueEvent defined

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1027,6 +1027,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_DottedLineEffect: strText = "Dotted line"; break;
 	case MID_WaitForArrayEntry: strText = "Wait for array entry"; break;
 	case MID_CountArrayEntries: strText = "Count array entries"; break;
+	case MID_GetMapRoom: strText = "(Selecting Room)"; break;
+	case MID_AddRoomToMap: strText = "Add room to map"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -122,6 +122,9 @@ designate.  There are four general classes of script commands, as follows:</p>
 <p><a name="interaction"><b>3.&nbsp;&nbsp;Interaction</b></a> - How the NPC
 interacts with its environment.</p>
 <ol>
+  <li><a name="addtomap"><b>Add room to map</b></a> - Adds the chosen room to the
+      player's map, as if they had explored. This exploration is not removed by undoing
+      moves or restarting the room.</li>
   <li><a name="activateat"><b>Activate item at</b></a> - Activates the item at
       the room square you select. Items that can be activated are: orbs,
       pressure plates, lights and wall lights. Nothing will happen this turn if

--- a/Texts/EditScreens.uni
+++ b/Texts/EditScreens.uni
@@ -2082,3 +2082,7 @@ Undelete
 Undelete!!translate
 [fra]
 Undelete!!translate
+
+[MID_GetMapRoom]
+[eng]
+(Selecting Room)

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -628,6 +628,7 @@ enum MID_CONSTANT {
   MID_ReplaceFileButton = 2002,
   MID_FilePendingDeletionSuffix = 2003,
   MID_Undelete = 2004,
+  MID_GetMapRoom = 2142,
 
   //Messages from EndOfGame.uni:
   MID_YouConquered = 406,
@@ -1910,6 +1911,7 @@ enum MID_CONSTANT {
   MID_WaitForBrainSense = 2136,
   MID_WaitForArrayEntry = 2140,
   MID_CountArrayEntries = 2141,
+  MID_AddRoomToMap = 2143,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3515,3 +3515,7 @@ Wait for array entry
 [MID_CountArrayEntries]
 [eng]
 Count array entries
+
+[MID_AddRoomToMap]
+[eng]
+Add room to map


### PR DESCRIPTION
Allows rooms to be explored without sending the player to them. This action isn't reversed by undoing a move or restarting a room, because the infrastructure to support undoing adding explored rooms is definitely not worth the effort.

Thread: http://forum.caravelgames.com/viewtopic.php?TopicID=41625