### PR TITLE
Add support for building platforms via scripting

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5218,8 +5218,6 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget *pListBox,
 		pListBox->AddItem(T_PLATE_MULTI, g_pTheDB->GetMessageText(MID_PressurePlate));
 		pListBox->AddItem(T_PLATE_ON_OFF, g_pTheDB->GetMessageText(MID_PressurePlateToggle));
 		pListBox->AddItem(T_PLATE_ONEUSE, g_pTheDB->GetMessageText(MID_PressurePlateOneUse));
-		pListBox->AddItem(T_PLATFORM_P, g_pTheDB->GetMessageText(MID_PlatformPit));
-		pListBox->AddItem(T_PLATFORM_W, g_pTheDB->GetMessageText(MID_PlatformWater));
 		pListBox->AddItem(T_LIGHT_CEILING, g_pTheDB->GetMessageText(MID_LightCeiling));
 		pListBox->AddItem(T_SCROLL, g_pTheDB->GetMessageText(MID_Scroll));
 		pListBox->AddItem(T_STAIRS, g_pTheDB->GetMessageText(MID_Stairs));
@@ -5290,6 +5288,8 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget *pListBox,
 	pListBox->AddItem(T_OVERHEAD_IMAGE, g_pTheDB->GetMessageText(MID_OverheadImage));
 	pListBox->AddItem(T_PIT, g_pTheDB->GetMessageText(MID_Pit));
 	pListBox->AddItem(T_PIT_IMAGE, g_pTheDB->GetMessageText(MID_PitImage));
+	pListBox->AddItem(T_PLATFORM_P, g_pTheDB->GetMessageText(MID_PlatformPit));
+	pListBox->AddItem(T_PLATFORM_W, g_pTheDB->GetMessageText(MID_PlatformWater));
 	pListBox->AddItem(T_POTION_C, g_pTheDB->GetMessageText(MID_ClonePotion));
 	pListBox->AddItem(T_POTION_D, g_pTheDB->GetMessageText(MID_DecoyPotion));
 	pListBox->AddItem(T_POTION_I, g_pTheDB->GetMessageText(MID_InvisPotion));

--- a/DRODLib/BuildUtil.cpp
+++ b/DRODLib/BuildUtil.cpp
@@ -48,8 +48,6 @@ bool BuildUtil::bIsValidBuildTile(const UINT wTileNo)
 	case T_SNK_SW:
 	case T_CHECKPOINT:
 	case T_LIGHT_CEILING:
-	case T_PLATFORM_W:
-	case T_PLATFORM_P:
 	case T_WALL_M:
 	case T_STAIRS_UP:
 	case T_STAIRS:
@@ -282,6 +280,13 @@ bool BuildUtil::BuildAnyTile(CDbRoom& room, const UINT baseTile, const UINT tile
 				return true;
 			}
 		return false;
+		case T_PLATFORM_W:
+		case T_PLATFORM_P:
+			if (BuildNormalTile(room, baseTile, tile, x, y, false, CueEvents)) {
+				room.PlotPlatform(x, y, tile);
+				return true;
+			}
+		return false;
 		default:
 			return BuildNormalTile(room, baseTile, tile, x, y, bAllowSame, CueEvents);
 	}
@@ -382,7 +387,9 @@ bool BuildUtil::BuildNormalTile(CDbRoom& room, const UINT baseTile, const UINT t
 		|| bIsThinIce(baseTile)
 		|| bIsThinIce(wOldOTile)
 		|| bIsDoor(wOldOTile)
-		|| bIsDoor(baseTile))
+		|| bIsDoor(baseTile)
+		|| baseTile == T_PLATFORM_W
+		|| wOldOTile == T_PLATFORM_W)
 	{
 		CCoordSet plots;
 		for (int nJ = -1; nJ <= 1; ++nJ){

--- a/DRODLib/DbRooms.h
+++ b/DRODLib/DbRooms.h
@@ -410,6 +410,7 @@ public:
 			CMonster *pMonster=NULL, bool bUnderObject=false);
 	void           Plot(const CCoordSet& plots, const bool bChangesRoomGeometry=false);
 	void           PlotMonster(UINT wX, UINT wY, UINT wTileNo, CMonster *pMonster);
+	void           PlotPlatform(UINT wX, UINT wY, UINT wTileNo);
 	void           PreprocessMonsters(CCueEvents& CueEvents);
 	static bool    PressurePlateIsDepressedBy(const UINT item);
 	void           ProcessTurn(CCueEvents &CueEvents, const bool bFullMove);

--- a/DRODLib/Platform.cpp
+++ b/DRODLib/Platform.cpp
@@ -66,6 +66,23 @@ bool CPlatform::IsAt(const UINT wX, const UINT wY) const
 }
 
 //*****************************************************************************
+void CPlatform::Merge(CPlatform* other)
+//Merge two platforms by adding all the other platform's blocks to this plaform,
+//then clear the other platform.
+{
+	this->blocks += other->blocks;
+	other->blocks.Clear();
+	PrepareEdgeSet();
+}
+
+//*****************************************************************************
+void CPlatform::AddTile(const UINT wX, const UINT wY)
+{
+	this->blocks.Push(wX, wY);
+	PrepareEdgeSet();
+}
+
+//*****************************************************************************
 bool CPlatform::CanMove(const UINT wO)
 //Returns: whether platform can be moved in specified direction
 {

--- a/DRODLib/Platform.h
+++ b/DRODLib/Platform.h
@@ -44,10 +44,12 @@ public:
 	static void clearFallTiles() {CPlatform::fallTiles.clear();}
 	static bool fallTilesPending() {return !CPlatform::fallTiles.empty();}
 
+	void AddTile(const UINT wX, const UINT wY);
 	bool CanMove(const UINT wO);
 	void GetTiles(CCoordSet& tiles) const;
 	CIDSet GetTypes() const;
 	bool IsAt(const UINT wX, const UINT wY) const;
+	void Merge(CPlatform* other);
 	void Move(const UINT wO);
 	void Move(CDbRoom& room, const int nOX, const int nOY, const bool bPlotToRoom);
 	void RemoveTile(const UINT wX, const UINT wY);


### PR DESCRIPTION
New platforms of both types can now be constructed in rooms, either directly with the Build command, or via build markers. Constructed platforms will merge with existing platform, and this can allow multiple platforms to merge into a single platform.

A minor technical note is that merging platforms can leave behind empty platforms. This isn't entire ideal, but the same thing can happen when building over platforms, so it doesn't appear to have any detrimental effects.