### PR TITLE
Add togglable movement order hint effects

### DIFF
--- a/DROD/DROD.2019.vcxproj
+++ b/DROD/DROD.2019.vcxproj
@@ -663,6 +663,7 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="MapWidget.cpp" />
     <ClCompile Include="ModScreen.cpp" />
+    <ClCompile Include="MovementOrderHintEffect.cpp" />
     <ClCompile Include="NewPlayerScreen.cpp" />
     <ClCompile Include="NoticeEffect.cpp" />
     <ClCompile Include="ParticleExplosionEffect.cpp" />
@@ -754,6 +755,7 @@
     <ClInclude Include="DottedLineEffect.h" />
     <ClInclude Include="MapWidget.h" />
     <ClInclude Include="ModScreen.h" />
+    <ClInclude Include="MovementOrderHintEffect.h" />
     <ClInclude Include="NeatherStrikesOrbEffect.h" />
     <ClInclude Include="NewPlayerScreen.h" />
     <ClInclude Include="NoticeEffect.h" />

--- a/DROD/DROD.2019.vcxproj.filters
+++ b/DROD/DROD.2019.vcxproj.filters
@@ -268,6 +268,9 @@
     <ClCompile Include="DottedLineEffect.cpp">
       <Filter>Effects</Filter>
     </ClCompile>
+    <ClCompile Include="MovementOrderHintEffect.cpp">
+      <Filter>Effects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AumtlichGazeEffect.h">
@@ -547,6 +550,9 @@
       <Filter>Effects</Filter>
     </ClInclude>
     <ClInclude Include="DottedLineEffect.h">
+      <Filter>Effects</Filter>
+    </ClInclude>
+    <ClInclude Include="MovementOrderHintEffect.h">
       <Filter>Effects</Filter>
     </ClInclude>
   </ItemGroup>

--- a/DROD/DrodEffect.h
+++ b/DROD/DrodEffect.h
@@ -75,6 +75,7 @@ enum EffectType
 	ECNETNOTICE,      //caravelnet notice
 	EROOMDRAWSTATS,
 	ETILESWIRL,       //tile swirl effect
+	EMOVEORDERHINT    //movement order preview
 };
 
 //*****************************************************************************

--- a/DROD/DrodFontManager.cpp
+++ b/DROD/DrodFontManager.cpp
@@ -530,19 +530,19 @@ bool CDrodFontManager::LoadFonts()
 	this->LoadedFonts[F_ExpandText].OutlineColor = Black;
 	this->LoadedFonts[F_ExpandText].wOutlineWidth = 2;	
 
-	//Load damage preview font.
+	//Load movement order hint font.
 	pFont = GetFont(wstrFont2Filepath, 14);
 	if (!pFont) return false;
-	this->LoadedFonts[F_MovementOrderPreview].pTTFFont = pFont;
-	this->LoadedFonts[F_MovementOrderPreview].wLineSkipHeight = GetFontHeight(F_MovementOrderPreview);
-	this->LoadedFonts[F_MovementOrderPreview].ForeColor = White;
-	this->LoadedFonts[F_MovementOrderPreview].BackColor = Black;
-	this->LoadedFonts[F_MovementOrderPreview].bAntiAlias = true;
-	this->LoadedFonts[F_MovementOrderPreview].bOutline = true;
-	this->LoadedFonts[F_MovementOrderPreview].OutlineColor = Black;
-	this->LoadedFonts[F_MovementOrderPreview].wOutlineWidth = 1;
-	GetWordWidth(F_MovementOrderPreview, wszSpace, wSpaceWidth);
-	this->LoadedFonts[F_MovementOrderPreview].wSpaceWidth = wSpaceWidth;
+	this->LoadedFonts[F_MovementOrderHint].pTTFFont = pFont;
+	this->LoadedFonts[F_MovementOrderHint].wLineSkipHeight = GetFontHeight(F_MovementOrderHint);
+	this->LoadedFonts[F_MovementOrderHint].ForeColor = White;
+	this->LoadedFonts[F_MovementOrderHint].BackColor = Black;
+	this->LoadedFonts[F_MovementOrderHint].bAntiAlias = true;
+	this->LoadedFonts[F_MovementOrderHint].bOutline = true;
+	this->LoadedFonts[F_MovementOrderHint].OutlineColor = Black;
+	this->LoadedFonts[F_MovementOrderHint].wOutlineWidth = 1;
+	GetWordWidth(F_MovementOrderHint, wszSpace, wSpaceWidth);
+	this->LoadedFonts[F_MovementOrderHint].wSpaceWidth = wSpaceWidth;
 
 	//Make sure all fonts were loaded.
 #ifdef _DEBUG

--- a/DROD/DrodFontManager.cpp
+++ b/DROD/DrodFontManager.cpp
@@ -530,6 +530,20 @@ bool CDrodFontManager::LoadFonts()
 	this->LoadedFonts[F_ExpandText].OutlineColor = Black;
 	this->LoadedFonts[F_ExpandText].wOutlineWidth = 2;	
 
+	//Load damage preview font.
+	pFont = GetFont(wstrFont2Filepath, 14);
+	if (!pFont) return false;
+	this->LoadedFonts[F_MovementOrderPreview].pTTFFont = pFont;
+	this->LoadedFonts[F_MovementOrderPreview].wLineSkipHeight = GetFontHeight(F_MovementOrderPreview);
+	this->LoadedFonts[F_MovementOrderPreview].ForeColor = White;
+	this->LoadedFonts[F_MovementOrderPreview].BackColor = Black;
+	this->LoadedFonts[F_MovementOrderPreview].bAntiAlias = true;
+	this->LoadedFonts[F_MovementOrderPreview].bOutline = true;
+	this->LoadedFonts[F_MovementOrderPreview].OutlineColor = Black;
+	this->LoadedFonts[F_MovementOrderPreview].wOutlineWidth = 1;
+	GetWordWidth(F_MovementOrderPreview, wszSpace, wSpaceWidth);
+	this->LoadedFonts[F_MovementOrderPreview].wSpaceWidth = wSpaceWidth;
+
 	//Make sure all fonts were loaded.
 #ifdef _DEBUG
 	for (UINT wFontI = 0; wFontI < F_Last; ++wFontI)

--- a/DROD/DrodFontManager.h
+++ b/DROD/DrodFontManager.h
@@ -77,7 +77,7 @@ enum FONTTYPE
 	F_ExpandText,
 	F_WorldMapLevel,
 	F_SettingsKeymaps,
-	F_MovementOrderPreview,
+	F_MovementOrderHint,
 
 	F_Last
 };

--- a/DROD/DrodFontManager.h
+++ b/DROD/DrodFontManager.h
@@ -77,6 +77,7 @@ enum FONTTYPE
 	F_ExpandText,
 	F_WorldMapLevel,
 	F_SettingsKeymaps,
+	F_MovementOrderPreview,
 
 	F_Last
 };

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -1425,6 +1425,7 @@ void CGameScreen::OnDeactivate()
 		vars.SetVar(Settings::EnableChatInGame, this->bEnableChat);
 		vars.SetVar(Settings::ReceiveWhispersOnlyInGame, this->bReceiveWhispersOnly);
 		vars.SetVar(Settings::MoveCounter, this->pRoomWidget->IsShowingMoveCount());
+		vars.SetVar(Settings::MovementOrderHint, this->pRoomWidget->IsShowingMovementOrder());
 		vars.SetVar(Settings::PuzzleMode, this->pRoomWidget->IsShowingPuzzleMode());
 
 		pCurrentPlayer->Update();
@@ -1656,6 +1657,9 @@ void CGameScreen::OnKeyDown(
 			g_pTheSound->PlaySoundEffect(SEID_CHECKPOINT);
 			this->pRoomWidget->TogglePuzzleMode();
 			this->pRoomWidget->DirtyRoom();
+		break;
+		case CMD_EXTRA_TOGGLE_MOVE_ORDER_HINT:
+			this->pRoomWidget->ToggleMovementOrderHint();
 		break;
 		case CMD_EXTRA_SKIP_SPEECH:
 			if (this->pCurrentGame && this->pCurrentGame->IsCutScenePlaying()) {
@@ -2055,6 +2059,11 @@ void CGameScreen::ApplyPlayerSettings()
 	if (this->pRoomWidget->IsShowingPuzzleMode() !=
 			settings.GetVar(Settings::PuzzleMode, false))
 		this->pRoomWidget->TogglePuzzleMode();
+
+	//Enable/disable movement order effect
+	if (this->pRoomWidget->IsShowingMovementOrder() !=
+		settings.GetVar(Settings::MovementOrderHint, false))
+		this->pRoomWidget->ToggleMovementOrderHint();
 
 	this->bAutoUndoOnDeath = settings.GetVar(Settings::AutoUndoOnDeath, false);
 

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -45,6 +45,7 @@
 #include "FiretrapEffect.h"
 #include "IceMeltEffect.h"
 #include "ImageOverlayEffect.h"
+#include "MovementOrderHintEffect.h"
 #include "PuffExplosionEffect.h"
 #include "SparkEffect.h"
 #include "SpikeEffect.h"
@@ -1477,6 +1478,9 @@ void CGameScreen::OnDeactivate()
 		}
 
 		delete pCurrentPlayer;
+
+		//Don't retain this cache while not playing.
+		CMovementOrderHintEffect::ClearSurfaceCache();
 
 		//Ensure all internet upload requests have been sent.
 		WaitToUploadDemos();

--- a/DROD/MovementOrderHintEffect.cpp
+++ b/DROD/MovementOrderHintEffect.cpp
@@ -1,0 +1,132 @@
+// $Id: MovementOrderHintEffect.h $
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#include "MovementOrderHintEffect.h"
+#include "RoomWidget.h"
+#include "DrodFontManager.h"
+#include "../DRODLib/CurrentGame.h"
+#include "../DRODLib/GameConstants.h"
+#include <BackEndLib/Assert.h>
+#include <FrontEndLib/Screen.h>
+
+//********************************************************************************
+CMovementOrderHintEffect::CMovementOrderHintEffect(
+	CWidget* pSetWidget, const CMonster* pMonster, int moveOrder)
+	: CEffect(pSetWidget, (UINT)-1, EMOVEORDERHINT)
+	, pMonster(const_cast<CMonster*>(pMonster))  //Though non-const, everything in this effect should leave monster state as-is
+	, wMoveOrder(moveOrder)
+	, pTextSurface(NULL)
+{
+	ASSERT(pSetWidget);
+	ASSERT(pSetWidget->GetType() == WT_Room);
+	ASSERT(pMonster);
+
+	this->pRoomWidget = DYN_CAST(CRoomWidget*, CWidget*, pSetWidget);
+	CDbRoom *pRoom = this->pRoomWidget->GetRoom();
+	ASSERT(pRoom);
+	if (pRoom) {
+		CCurrentGame* pGame = pRoom->GetCurrentGame();
+		ASSERT(pGame);
+		this->wValidTurn = pGame->wTurnNo;
+
+		//Prepare effect.
+		PrepWidget();
+	} else {
+		this->wValidTurn = 0;
+	}
+}
+
+//********************************************************************************
+CMovementOrderHintEffect::~CMovementOrderHintEffect()
+{
+	if (this->pTextSurface)
+		SDL_FreeSurface(this->pTextSurface);
+}
+
+//********************************************************************************
+bool CMovementOrderHintEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
+{
+	const UINT wTurnNow = this->pRoomWidget->GetRoom()->GetCurrentGame()->wTurnNo;
+	if (wTurnNow != this->wValidTurn)
+		return false;
+
+	if (!this->pMonster->IsAlive())
+		return false;
+
+	return true;
+}
+
+//********************************************************************************
+void CMovementOrderHintEffect::Draw(SDL_Surface& destSurface)
+{
+	//Clip screen surface to widget to prevent overrun.
+	SDL_Rect OwnerRect;
+	this->pOwnerWidget->GetRect(OwnerRect);
+	SDL_SetClipRect(&destSurface, &OwnerRect);
+
+	ASSERT(this->pMonster);
+
+	CCueEvents Ignored;
+	int destX = this->pRoomWidget->GetX() + this->pMonster->wX * CBitmapManager::CX_TILE;
+	int destY = this->pRoomWidget->GetY() + this->pMonster->wY * CBitmapManager::CY_TILE;
+
+	this->dirtyRects[0].x = destX;
+	this->dirtyRects[0].y = destY;
+
+	SDL_Rect SrcRect = MAKE_SDL_RECT(0, 0, this->dirtyRects[0].w, this->dirtyRects[0].h);
+	SDL_Rect ScreenRect = MAKE_SDL_RECT(destX, destY, this->dirtyRects[0].w, this->dirtyRects[0].h);
+	SDL_BlitSurface(this->pTextSurface, &SrcRect, &destSurface, &ScreenRect);
+
+	//Unclip screen surface.
+	SDL_SetClipRect(&destSurface, NULL);
+}
+
+//********************************************************************************
+void CMovementOrderHintEffect::PrepWidget()
+{
+	WSTRING wstr = std::to_wstring(wMoveOrder);
+	static const UINT eFontType = F_MovementOrderPreview;
+	UINT wLineW, wLineH;
+	g_pTheFM->GetTextRectHeight(eFontType, wstr.c_str(),
+		CBitmapManager::CX_TILE * 2, wLineW, wLineH);
+
+	//Render text to internal surface to avoid re-rendering each frame.
+	if (this->pTextSurface)
+		SDL_FreeSurface(this->pTextSurface);
+	this->pTextSurface = CBitmapManager::ConvertSurface(
+		SDL_CreateRGBSurface(SDL_SWSURFACE, wLineW, wLineH, g_pTheBM->BITS_PER_PIXEL, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000));
+	ASSERT(this->pTextSurface);
+
+	const Uint32 bg_color = SDL_MapRGBA(this->pTextSurface->format, 0, 0, 0, SDL_ALPHA_TRANSPARENT);
+	SDL_FillRect(this->pTextSurface, NULL, bg_color);
+
+	//Draw text (outlined, w/ anti-aliasing).
+	g_pTheFM->DrawTextToRect(eFontType, wstr.c_str(),
+		0, 0, wLineW, wLineH, this->pTextSurface);
+
+	SDL_Rect Dest = MAKE_SDL_RECT(0, 0, wLineW, wLineH);
+	this->dirtyRects.push_back(Dest);
+}

--- a/DROD/MovementOrderHintEffect.cpp
+++ b/DROD/MovementOrderHintEffect.cpp
@@ -134,13 +134,22 @@ SDL_Surface* CMovementOrderHintEffect::GetSurfaceForOrder(int order)
 //Since rendering text is relatively expensive, surfaces are cached to reduce the
 //amount of renders required.
 {
+	//At some point, these hints aren't useful
+	if (order > 1000)
+		order = 1000;
+
 	//Try getting from the cache first
 	map<int, SDL_Surface*>::iterator finder = s_surfaceCache.find(order);
 	if (finder != s_surfaceCache.end()) {
 		return finder->second;
 	}
 
-	WSTRING wstr = std::to_wstring(order);
+	WSTRING wstr; 
+	if (order == 1000) {
+		wstr = L">999";
+	} else {
+		wstr = std::to_wstring(order);
+	}
 	static const UINT eFontType = F_MovementOrderHint;
 	UINT wLineW, wLineH;
 	g_pTheFM->GetTextRectHeight(eFontType, wstr.c_str(),

--- a/DROD/MovementOrderHintEffect.cpp
+++ b/DROD/MovementOrderHintEffect.cpp
@@ -69,6 +69,9 @@ CMovementOrderHintEffect::~CMovementOrderHintEffect()
 //********************************************************************************
 bool CMovementOrderHintEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 {
+	ASSERT(this->pRoomWidget->GetRoom());
+	ASSERT(this->pRoomWidget->GetRoom()->GetCurrentGame());
+
 	const UINT wTurnNow = this->pRoomWidget->GetRoom()->GetCurrentGame()->wTurnNo;
 	if (wTurnNow != this->wValidTurn)
 		return false;
@@ -108,7 +111,7 @@ void CMovementOrderHintEffect::Draw(SDL_Surface& destSurface)
 void CMovementOrderHintEffect::PrepWidget()
 {
 	WSTRING wstr = std::to_wstring(wMoveOrder);
-	static const UINT eFontType = F_MovementOrderPreview;
+	static const UINT eFontType = F_MovementOrderHint;
 	UINT wLineW, wLineH;
 	g_pTheFM->GetTextRectHeight(eFontType, wstr.c_str(),
 		CBitmapManager::CX_TILE * 2, wLineW, wLineH);

--- a/DROD/MovementOrderHintEffect.h
+++ b/DROD/MovementOrderHintEffect.h
@@ -39,6 +39,8 @@ public:
 	CMovementOrderHintEffect(CWidget* pSetWidget, const CMonster* pMonster, int moveOrder);
 	~CMovementOrderHintEffect();
 
+	static void ClearSurfaceCache();
+
 protected:
 	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
 	virtual void Draw(SDL_Surface& destSurface);
@@ -50,6 +52,8 @@ protected:
 
 private:
 	void PrepWidget();
+
+	SDL_Surface* GetSurfaceForOrder(int order);
 
 	CMonster* pMonster;
 

--- a/DROD/MovementOrderHintEffect.h
+++ b/DROD/MovementOrderHintEffect.h
@@ -29,9 +29,6 @@
 
 #include <FrontEndLib/Effect.h>
 #include <BackEndLib/Types.h>
-#include <BackEndLib/Coord.h>
-
-#include <vector>
 
  //****************************************************************************************
 class CMonster;

--- a/DROD/MovementOrderHintEffect.h
+++ b/DROD/MovementOrderHintEffect.h
@@ -1,0 +1,62 @@
+// $Id: MovementOrderHintEffect.h $
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#ifndef MOVEMENTORDERHINTEFFECT_H
+#define MOVEMENTORDERHINTEFFECT_H
+
+#include <FrontEndLib/Effect.h>
+#include <BackEndLib/Types.h>
+#include <BackEndLib/Coord.h>
+
+#include <vector>
+
+ //****************************************************************************************
+class CMonster;
+class CRoomWidget;
+class CMovementOrderHintEffect : public CEffect
+{
+public:
+	CMovementOrderHintEffect(CWidget* pSetWidget, const CMonster* pMonster, int moveOrder);
+	~CMovementOrderHintEffect();
+
+protected:
+	virtual bool Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed);
+	virtual void Draw(SDL_Surface& destSurface);
+
+	UINT        wValidTurn;   //game turn this display is valid for
+	UINT        wMoveOrder;   //movement order value to display
+
+	CRoomWidget* pRoomWidget;
+
+private:
+	void PrepWidget();
+
+	CMonster* pMonster;
+
+	SDL_Surface* pTextSurface;
+};
+
+#endif //...#ifndef MOVEMENTORDERHINTEFFECT_H

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -6572,10 +6572,9 @@ void CRoomWidget::AddMovementOrderHints()
 		const CCharacter* pCharacter = dynamic_cast<const CCharacter*>(pMonster);
 
 		if (!pMonster->IsVisible()) {
-			if (!pCharacter)
-				continue;
+			if (pCharacter && pCharacter->IsInvisibleCountMoveOrder())
+				++index; //count but don't show to avoid potential overlaps
 
-			if (!pCharacter->IsInvisibleCountMoveOrder())
 				continue;
 		}
 

--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -340,6 +340,7 @@ public:
 	virtual bool   IsPlayerLightRendered() const;
 	bool           IsPlayerLightShowing() const;
 	bool           IsShowingMoveCount() const {return this->bShowMoveCount;}
+	bool           IsShowingMovementOrder() const {return this->bShowMovementOrderHints;}
 	bool           IsShowingPuzzleMode() const {return this->bShowPuzzleMode;}
 	bool           IsTemporalCloneAnimated() const { return this->temporalCloneEffectHeight >= 0; }
 	bool           IsWeatherRendered() const;
@@ -393,6 +394,7 @@ public:
 	virtual void   SetPlot(const UINT /*wCol*/, const UINT /*wRow*/) {}
 	void           SetPuzzleModeOptions(const PuzzleModeOptions &puzzleModeOptions);
 	void           ShowCheckpoints(const bool bVal=true) {this->bShowCheckpoints = bVal;}
+	void           ShowMovementOrderHints(const bool bVal = true) { this->bShowMovementOrderHints = bVal; }
 	void           ShowRoomTransition(const UINT wExitOrientation, CCueEvents& CueEvents);
 	void           ShowPlayer(const bool bFlag=true) {this->bShowingPlayer = bFlag;}
 	void           ShowPuzzleMode(const bool bVal);
@@ -403,6 +405,7 @@ public:
 	void           SyncWeather(CCueEvents& CueEvents);
 	void           ToggleFrameRate();
 	void           ToggleMoveCount();
+	void           ToggleMovementOrderHint();
 	void           TogglePuzzleMode();
 	void           ToggleVarDisplay();
 	static void    TranslateMonsterColor(const int nColor, float& fR, float& fG, float& fB);
@@ -649,6 +652,7 @@ protected:
 	int               CX_TILE, CY_TILE;
 
 private:
+	void           AddMovementOrderHints();
 	void           AddPlatformPitMasks(const TileImageBlitParams& blit, t_PitMasks& pitMasks);
 	void           AddTemporalCloneNextMoveEffect(const CTemporalClone *pTC, const UINT frame);
 	inline void    ApplyDisplayFilter(int displayFilter, SDL_Surface* pDestSurface, UINT wX, UINT wY);
@@ -711,6 +715,8 @@ private:
 	bool              need_to_update_room_weather;
 
 	Uint32            time_of_last_sky_move;
+
+	bool              bShowMovementOrderHints;
 
 	multimap<EffectType, int> queued_layer_effect_type_removal;
 };

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -920,7 +920,7 @@ void CSettingsScreen::SetupKeymap2Tab(CTabbedMenuWidget* pTabbedMenu)
 	static const int COMMAND_COLUMN_OFFSETS [BUTTON_COLUMNS] = {0, 6, 13};
 	static const int COMMAND_COLUMNS[BUTTON_COLUMNS][13] = {
 		{
-			DCMD_LockRoom, DCMD_SkipSpeech, DCMD_TogglePuzzleMode,
+			DCMD_LockRoom, DCMD_SkipSpeech, DCMD_TogglePuzzleMode, DCMD_ToggleMovementOrderHint,
 			DCMD_ToggleFullScreen, DCMD_Screenshot, DCMD_SaveRoomImage,
 			NO_COMMAND,
 		},

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -2797,6 +2797,14 @@ void CCharacter::Process(
 						this->bInvisibleInspectable = false;
 						bChangeImperative = false;
 						break;
+					case ScriptFlag::InvisibleCountMoveOrder:
+						this->bInvisibleCountsMoveOrder = true;
+						bChangeImperative = false;
+					break;
+					case ScriptFlag::InvisibleNotCountMoveOrder:
+						this->bInvisibleCountsMoveOrder = false;
+						bChangeImperative = false;
+					break;
 					case ScriptFlag::NotPushable:
 						this->bNotPushable = true;
 						this->bPushableByBody = false;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1029,6 +1029,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_CountArrayEntries: strText = "Count array entries"; break;
 	case MID_GetMapRoom: strText = "(Selecting Room)"; break;
 	case MID_AddRoomToMap: strText = "Add room to map"; break;
+	case MID_Command_ToggleMovementOrderHint: strText = "Toggle Ordering Hint"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/GameConstants.cpp
+++ b/DRODLib/GameConstants.cpp
@@ -91,6 +91,7 @@ namespace InputCommands
 		keyDefinitions[DCMD_Stats] = new KeyDefinition(CMD_EXTRA_STATS, "Key_Stats", MID_Command_Stats, SDLK_RETURN);
 		keyDefinitions[DCMD_ChatHistory] = new KeyDefinition(CMD_EXTRA_CHAT_HISTORY, "Key_ChatHistory", MID_Command_ChatHistory, BuildInputKey(SDLK_RETURN, false, false, true));
 		keyDefinitions[DCMD_PuzzleModeOptions] = new KeyDefinition(CMD_EXTRA_PUZZLE_MODE_OPTIONS, "Key_PuzzleModeOptions", MID_Command_PuzzleModeOptions, BuildInputKey(SDLK_F3, false, true, false));
+		keyDefinitions[DCMD_ToggleMovementOrderHint] = new KeyDefinition(CMD_EXTRA_TOGGLE_MOVE_ORDER_HINT, "Key_ToggleMovementOrderHint", MID_Command_ToggleMovementOrderHint, BuildInputKey(SDLK_F3, false, false, true));
 		keyDefinitions[DCMD_ToggleTurnCount] = new KeyDefinition(CMD_EXTRA_TOGGLE_TURN_COUNT, "Key_ToggleTurnCount", MID_Command_ToggleTurnCount, SDLK_F7);
 		keyDefinitions[DCMD_ToggleHoldVars] = new KeyDefinition(CMD_EXTRA_TOGGLE_HOLD_VARS, "Key_ToggleHoldVars", MID_Command_ToggleHoldVars, BuildInputKey(SDLK_F7, false, false, true));
 		keyDefinitions[DCMD_ToggleFrameRate] = new KeyDefinition(CMD_EXTRA_TOGGLE_FRAME_RATE, "Key_ToggleFrameRate", MID_Command_ToggleFrameRate, BuildInputKey(SDLK_F7, false, true, false));

--- a/DRODLib/GameConstants.h
+++ b/DRODLib/GameConstants.h
@@ -122,7 +122,8 @@ extern const WCHAR wszVersionReleaseNumber[];
 #define CMD_EXTRA_SHOW_HELP (COMMAND_COUNT+37)
 #define CMD_EXTRA_TOGGLE_HOLD_VARS (COMMAND_COUNT+38)
 #define CMD_EXTRA_TOGGLE_FRAME_RATE (COMMAND_COUNT+39)
-#define EXTRA_COMMAND_COUNT (COMMAND_COUNT+40)
+#define CMD_EXTRA_TOGGLE_MOVE_ORDER_HINT (COMMAND_COUNT+40)
+#define EXTRA_COMMAND_COUNT (COMMAND_COUNT+41)
 
 // Hardcoded commands used by DemoScreen that cannot be remapped
 #define CMD_DEMO_SEEK_010 (EXTRA_COMMAND_COUNT + 1)
@@ -231,6 +232,7 @@ namespace InputCommands
 		DCMD_ToggleTurnCount,
 		DCMD_ToggleHoldVars,
 		DCMD_ToggleFrameRate,
+		DCMD_ToggleMovementOrderHint,
 		DCMD_QuickDemoRecord,
 		DCMD_ToggleDemoRecord,
 		DCMD_WatchDemos,

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -63,6 +63,7 @@ namespace Settings
 	DEF(Language);
 	DEF(LastNotice);
 	DEF(MoveCounter);
+	DEF(MovementOrderHint);
 	DEF(Music);
 	DEF(MusicVolume);
 	DEF(NoFocusPlaysMusic);

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -63,6 +63,7 @@ namespace Settings
 	DEF(Language);
 	DEF(LastNotice);
 	DEF(MoveCounter);
+	DEF(MovementOrderHint);
 	DEF(Music);
 	DEF(MusicVolume);
 	DEF(NoFocusPlaysMusic);

--- a/Data/Help/1/keyboard.html
+++ b/Data/Help/1/keyboard.html
@@ -118,6 +118,9 @@ accidentally exiting a room)</td>
       <td><b>Alt+F3</b> - open <a name="puzzlemode">Puzzle Mode</a> options dialog</td>
     </tr>
     <tr>
+      <td><b>Ctrl+F3</b> - toggle movement order hint display</td>
+    </tr>
+    <tr>
       <td><a name="demos"><b>F4</b></a> - <a href="demos.html">quick demo record</a> </td>
     </tr>
     <tr>

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1406,6 +1406,7 @@ enum MID_CONSTANT {
   MID_DateFormatMDY = 2126,
   MID_DateFormatDMY = 2127,
   MID_DateFormatYMD = 2128,
+  MID_Command_ToggleMovementOrderHint = 2144,
   
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/Texts/SettingsScreen.uni
+++ b/Texts/SettingsScreen.uni
@@ -705,3 +705,7 @@ DD/MM/YY
 [MID_DateFormatYMD]
 [eng]
 YYYY-MM-DD
+
+[MID_Command_ToggleMovementOrderHint]
+[eng]
+Toggle Ordering Hint


### PR DESCRIPTION
Based on the damage and item preview effects for RPG, movement order can now be displayed directly on monsters. It's a key-togglable effect, since it's not information that's always relevant.

Monster remains don't show order, but do get counted (which is needed to match with the order shown when right-clicking). Maybe order should be shown for construct remains, since that can matter. Fegundo ashes do get the effect, since they're counted as alive.

The performance gets a little bad once the monster counter gets high enough, probably due to how many surfaces are getting created. Not sure if that can be streamlined.