### PR TITLE
Add option to describe citizen groups with colors

### DIFF
--- a/DROD/DemoScreen.cpp
+++ b/DROD/DemoScreen.cpp
@@ -155,6 +155,8 @@ bool CDemoScreen::SetForActivate()
 	if (this->pRoomWidget->IsShowingPuzzleMode() !=
 			settings.GetVar(Settings::PuzzleMode, false))
 		this->pRoomWidget->TogglePuzzleMode();
+	this->pRoomWidget->DescribeCitizenColor(
+		settings.GetVar(Settings::DescribeCitizenColor, false));
 
 	SetShowVoicedSubtitle(settings.GetVar(Settings::ShowSubtitlesWithVoices, true));
 

--- a/DROD/EditRoomScreen.cpp
+++ b/DROD/EditRoomScreen.cpp
@@ -2093,6 +2093,10 @@ void CEditRoomScreen::ApplyPlayerSettings()
 	//Set room editing options.
 	this->bAutoSave = pCurrentPlayer->Settings.GetVar(Settings::AutoSave, true);
 
+	//Set if citizen groups are subtitled as numbers or colors
+	this->pRoomWidget->DescribeCitizenColor(
+		pCurrentPlayer->Settings.GetVar(Settings::DescribeCitizenColor, false));
+
 	COptionButtonWidget *pOptionButton = static_cast<COptionButtonWidget *>(
 			GetWidget(TAG_SHOWERRORS));
 	this->bShowErrors = pCurrentPlayer->Settings.GetVar(Settings::ShowErrors, true);

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -2069,6 +2069,10 @@ void CGameScreen::ApplyPlayerSettings()
 		settings.GetVar(Settings::MovementOrderHint, false))
 		this->pRoomWidget->ToggleMovementOrderHint();
 
+	//Set if citizen groups are subtitled as numbers or colors
+	this->pRoomWidget->DescribeCitizenColor(
+		settings.GetVar(Settings::DescribeCitizenColor, false));
+
 	this->bAutoUndoOnDeath = settings.GetVar(Settings::AutoUndoOnDeath, false);
 
 	//Move repeat rate.

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1574,9 +1574,16 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 			const int stationType = pCitizen->StationType();
 			if (stationType >= 0)
 			{
-				wstr += wszSpace;
-				wstr += wszPoundSign;
-				wstr += _itoW(stationType, temp, 10);
+				if (bDescribeCitizenColor) {
+					wstr += wszSpace;
+					wstr += wszHyphen;
+					wstr += wszSpace;
+					wstr += DescribeStationColor(stationType);
+				} else {
+					wstr += wszSpace;
+					wstr += wszPoundSign;
+					wstr += _itoW(stationType, temp, 10);
+				}
 			}
 		}
 
@@ -1636,11 +1643,19 @@ SkipDescribingMonster:
 		//Indicate station color.
 		if (tTile == T_STATION)
 		{
-			wstr += wszSpace;
-			wstr += wszLeftParen;
-			wstr += wszPoundSign;
-			wstr += _itoW(this->pRoom->GetTParam(wX, wY), temp, 10);
-			wstr += wszRightParen;
+			int stationType = (int)(this->pRoom->GetTParam(wX, wY));
+			if (bDescribeCitizenColor) {
+				wstr += wszSpace;
+				wstr += wszHyphen;
+				wstr += wszSpace;
+				wstr += DescribeStationColor(stationType);
+			} else {
+				wstr += wszSpace;
+				wstr += wszLeftParen;
+				wstr += wszPoundSign;
+				wstr += _itoW(stationType, temp, 10);
+				wstr += wszRightParen;
+			}
 		}
 	}
 
@@ -5802,6 +5817,33 @@ void CRoomWidget::DeleteArrays()
 	this->pTileImages = NULL;
 
 	this->lightMaps.clear();
+}
+
+//*****************************************************************************
+WSTRING CRoomWidget::DescribeStationColor(const int& stationType) const
+//Returns a string describing the color of the given station type
+{
+	UINT mid;
+	switch (stationType) {
+		default: case 0: mid = MID_White; break;
+		case 1: mid = MID_Red; break;
+		case 2: mid = MID_Green; break;
+		case 3: mid = MID_Blue; break;
+		case 4: mid = MID_PaleRed; break;
+		case 5: mid = MID_PaleGreen; break;
+		case 6: mid = MID_PaleBlue; break;
+		case 7: mid = MID_Yellow; break;
+		case 8: mid = MID_Cyan; break;
+		case 9: mid = MID_Mauve; break;
+		case 10: mid = MID_Orange; break;
+		case 11: mid = MID_Pink; break;
+		case 12: mid = MID_Lime; break;
+		case 13: mid = MID_Turquoise; break;
+		case 14: mid = MID_Violet; break;
+		case 15: mid = MID_Azure; break;
+	}
+
+	return g_pTheDB->GetMessageText(mid);
 }
 
 //*****************************************************************************

--- a/DROD/RoomWidget.h
+++ b/DROD/RoomWidget.h
@@ -304,6 +304,7 @@ public:
 	bool           AreCheckpointsVisible() const {return this->bShowCheckpoints;}
 	void           ClearEffects(const bool bKeepFrameRate = true);
 	void           CountDirtyTiles(UINT& damaged, UINT& dirty, UINT& monster) const;
+	void           DescribeCitizenColor(bool desribeAsColor) { bDescribeCitizenColor = desribeAsColor; }
 	void           DirtyRoom() {this->bAllDirty = true;}
 	void           DisplayPersistingImageOverlays(CCueEvents& CueEvents);
 	void           DisplayRoomCoordSubtitle(const int nMouseX, const int nMouseY);
@@ -462,6 +463,7 @@ protected:
 			int wWidth=CDrodBitmapManager::DISPLAY_COLS,
 			int wHeight=CDrodBitmapManager::DISPLAY_ROWS);
 	void           DeleteArrays();
+	WSTRING        DescribeStationColor(const int& stationType) const;
 	void           DirtyTileRect(const int x1, const int y1,
 			const int x2, const int y2);
 	void           DirtyTilesForSpriteAt(UINT pixel_x, UINT pixel_y, UINT w, UINT h);
@@ -717,6 +719,7 @@ private:
 	Uint32            time_of_last_sky_move;
 
 	bool              bShowMovementOrderHints;
+	bool              bDescribeCitizenColor;
 
 	multimap<EffectType, int> queued_layer_effect_type_removal;
 };

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -114,6 +114,7 @@ const UINT TAG_GROUPEDITORMENUITEMS = 1072;
 
 const UINT TAG_UNDOLEVEL_NUM_LABEL = 1073;
 const UINT TAG_AUTOUNDOONDEATH = 1074;
+const UINT TAG_CITIZEN_DESCRIBE_COLOR = 1075;
 
 const UINT TAG_CANCEL = 1091;
 const UINT TAG_HELP = 1092;
@@ -332,8 +333,12 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 	static const int Y_AUTOUNDOONDEATH = Y_SAVEONDIE + CY_SAVEONDIE;
 	static const UINT CX_AUTOUNDOONDEATH = CX_SHOWCHECKPOINTS;
 	static const UINT CY_AUTOUNDOONDEATH = CY_STANDARD_OPTIONBUTTON;
+	static const int X_DESCRIBE_CITIZEN_COLOR = X_AUTOUNDOONDEATH;
+	static const int Y_DESCRIBE_CITIZEN_COLOR = Y_AUTOUNDOONDEATH + CY_AUTOUNDOONDEATH;
+	static const UINT CX_DESCRIBE_CITIZEN_COLOR = CX_AUTOUNDOONDEATH;
+	static const UINT CY_DESCRIBE_CITIZEN_COLOR = CY_AUTOUNDOONDEATH;
 
-	static const UINT CY_SPECIAL_FRAME = Y_AUTOUNDOONDEATH + CY_AUTOUNDOONDEATH + CY_SPACE;
+	static const UINT CY_SPECIAL_FRAME = Y_DESCRIBE_CITIZEN_COLOR + CY_DESCRIBE_CITIZEN_COLOR + CY_SPACE;
 
 	//Demo frame and children
 	static const UINT X_DEMO_FRAME = X_EDITOR_FRAME;
@@ -431,6 +436,12 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 	pOptionButton = new COptionButtonWidget(TAG_AUTOUNDOONDEATH, X_AUTOUNDOONDEATH,
 		Y_AUTOUNDOONDEATH, CX_AUTOUNDOONDEATH, CY_AUTOUNDOONDEATH,
 		g_pTheDB->GetMessageText(MID_AutoUndoOnDeath),
+		false);
+	pSpecialFrame->AddWidget(pOptionButton);
+
+	pOptionButton = new COptionButtonWidget(TAG_CITIZEN_DESCRIBE_COLOR, X_DESCRIBE_CITIZEN_COLOR,
+		Y_DESCRIBE_CITIZEN_COLOR, CX_DESCRIBE_CITIZEN_COLOR, CY_DESCRIBE_CITIZEN_COLOR,
+		g_pTheDB->GetMessageText(MID_DescribeCitizenColor),
 		false);
 	pSpecialFrame->AddWidget(pOptionButton);
 
@@ -1663,6 +1674,10 @@ void CSettingsScreen::UpdateWidgetsFromPlayerData(
 			GetWidget(TAG_AUTOUNDOONDEATH));
 	pOptionButton->SetChecked(settings.GetVar(Settings::AutoUndoOnDeath, false));
 
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_CITIZEN_DESCRIBE_COLOR));
+	pOptionButton->SetChecked(settings.GetVar(Settings::DescribeCitizenColor, false));
+
 	//Editor settings.
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_AUTOSAVE));
@@ -1818,6 +1833,10 @@ void CSettingsScreen::UpdatePlayerDataFromWidgets(
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_AUTOUNDOONDEATH));
 	settings.SetVar(Settings::AutoUndoOnDeath, pOptionButton->IsChecked());
+
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_CITIZEN_DESCRIBE_COLOR));
+	settings.SetVar(Settings::DescribeCitizenColor, pOptionButton->IsChecked());
 
 	//Editor settings.
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1030,6 +1030,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_GetMapRoom: strText = "(Selecting Room)"; break;
 	case MID_AddRoomToMap: strText = "Add room to map"; break;
 	case MID_Command_ToggleMovementOrderHint: strText = "Toggle Ordering Hint"; break;
+	case MID_DescribeCitizenColor: strText = "Describe citizen groups as color"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -49,6 +49,7 @@ namespace Settings
 	DEF(CNetProgressIsOld);
 	DEF(ConnectToInternet);
 	DEF(DemoDateFormat);
+	DEF(DescribeCitizenColor);
 	DEF(DisplayCombos);
 	DEF(EnableChatInGame);
 	DEF(ExportPath);

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -49,6 +49,7 @@ namespace Settings
 	DEF(CNetProgressIsOld);
 	DEF(ConnectToInternet);
 	DEF(DemoDateFormat);
+	DEF(DescribeCitizenColor);
 	DEF(DisplayCombos);
 	DEF(EnableChatInGame);
 	DEF(ExportPath);

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1407,6 +1407,7 @@ enum MID_CONSTANT {
   MID_DateFormatDMY = 2127,
   MID_DateFormatYMD = 2128,
   MID_Command_ToggleMovementOrderHint = 2144,
+  MID_DescribeCitizenColor = 2145,
   
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/Texts/SettingsScreen.uni
+++ b/Texts/SettingsScreen.uni
@@ -709,3 +709,7 @@ YYYY-MM-DD
 [MID_Command_ToggleMovementOrderHint]
 [eng]
 Toggle Ordering Hint
+
+[MID_DescribeCitizenColor]
+[eng]
+Describe citizen groups as color


### PR DESCRIPTION
It's been remarked that way citizens are described in the tile tooltip can be confusing, since the group number looks like a movement order number. Since we now have color strings, we can reuse them for the purpose of describing citizens and relay stations.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46525