### PR TITLE
Make Seep killable by Puffs

### DIFF
--- a/DRODLib/MonsterType.h
+++ b/DRODLib/MonsterType.h
@@ -311,7 +311,7 @@ static inline bool bIsVulnerableToBodyAttack(const UINT mt) {
 static inline bool bCanFluffKill(const UINT mt) {
 	switch(mt) {
 		case M_ROCKGOLEM: case M_ROCKGIANT: case M_CONSTRUCT:
-		case M_GENTRYII: case M_FLUFFBABY: case M_SEEP:
+		case M_GENTRYII: case M_FLUFFBABY:
 			return false;
 		default:
 			return true;


### PR DESCRIPTION
An interaction some people find weird. I'm not sure how strongly intentioned it is, although puff-safety is something that has to be specifically given to a monster type.

It might not affect published rooms to change this.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=45458