### PR TITLE
Fix slayer incorrectly discarding path to orb

### DIFF
--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -999,10 +999,11 @@ void CSlayer::MoveToOpenDoor(CCueEvents &CueEvents)     //(in/out)
 		if (!plates.empty())
 		{
 			CCoordStack orbPath = this->pathToDest;
-			bPathFound |= FindOptimalPathTo(this->wX, this->wY, plates, false);
+			bool bPlatePathFound = FindOptimalPathTo(this->wX, this->wY, plates, false);
+			bPathFound = bOrbPathFound || bPlatePathFound;
 
 			//Choose shorter path.  With a tie, paths to orbs take preference.
-			if (bOrbPathFound && this->pathToDest.GetSize() >= orbPath.GetSize())
+			if (!bPlatePathFound || (bOrbPathFound && this->pathToDest.GetSize() >= orbPath.GetSize()))
 				this->pathToDest = orbPath;
 		}
 		if (!bPathFound)


### PR DESCRIPTION
A weird oversight: If a slayer wants to open an a door, finds a path to an orb, then fails to find a path to a plate, it gets stuck. This is because if it fails to find a path to a plate, `pathToDest` will have a size of zero, which is always less than any valid orb path.

A small change is needed to actually verify that a path a plate was found, and if not, the orb path should be used if it exists.