### PR TITLE
RPG: Fix issues with map icons

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1820,7 +1820,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pMapIconListBox->AddItem(ScriptVars::MI_Gear, g_pTheDB->GetMessageText(MID_Gear));
 	this->pMapIconListBox->AddItem(ScriptVars::MI_MoneyBag, g_pTheDB->GetMessageText(MID_MoneyBag));
 	this->pMapIconListBox->AddItem(ScriptVars::MI_KeyBlue, g_pTheDB->GetMessageText(MID_BlueKey));
-	this->pMapIconListBox->AddItem(ScriptVars::MI_KeyWhite, g_pTheDB->GetMessageText(MID_WhiteKey));
+	this->pMapIconListBox->AddItem(ScriptVars::MI_KeyWhite, g_pTheDB->GetMessageText(MID_SkeletonKey));
 	this->pMapIconListBox->AddItem(ScriptVars::MI_StairsUp, g_pTheDB->GetMessageText(MID_StairsUp));
 	this->pMapIconListBox->AddItem(ScriptVars::MI_StairsDown, g_pTheDB->GetMessageText(MID_StairsDown));
 	this->pMapIconListBox->AddItem(ScriptVars::MI_NorthArrow, g_pTheDB->GetMessageText(MID_NorthArrow));

--- a/drodrpg/DROD/DROD.2019.vcxproj
+++ b/drodrpg/DROD/DROD.2019.vcxproj
@@ -635,6 +635,7 @@
     <ClInclude Include="EditRoomScreen.h" />
     <ClInclude Include="EditRoomWidget.h" />
     <ClInclude Include="EditSelectScreen.h" />
+    <ClInclude Include="EffectChangeHistory.h" />
     <ClInclude Include="EntranceSelectDialogWidget.h" />
     <ClInclude Include="EquipmentDescription.h" />
     <ClInclude Include="ExplosionEffect.h" />

--- a/drodrpg/DROD/EffectChangeHistory.h
+++ b/drodrpg/DROD/EffectChangeHistory.h
@@ -1,0 +1,71 @@
+// $Id: EffectChangeHistory.h $
+
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2007, 2023
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+#ifndef EFFECT_CHANGE_HISTORY_H
+#define EFFECT_CHANGE_HISTORY_H
+
+#include <BackEndLib/Types.h>
+#include <vector>
+
+//******************************************************************************
+//Class to record when changes to effects that require specific refreshing are made.
+//When the game goes "back in time", these effects can then be downdated.
+//It is assumed that adding a record means that any records in its future are now invalid
+class EffectChangeHistory {
+public:
+	EffectChangeHistory() = default;
+	~EffectChangeHistory() = default;
+
+	bool isAfterLatest(UINT turn) {
+		return turn > changeTurns.back();
+	}
+
+	//Remove all records after a given turn.
+	void removeAfter(UINT turn) {
+		while (!empty() && changeTurns.back() >= turn) {
+			changeTurns.pop_back();
+		}
+	}
+
+	//Add a new record. Any records from later turns are removed.
+	void add(UINT turn) {
+		removeAfter(turn);
+		changeTurns.push_back(turn);
+	}
+
+	void reset() {
+		changeTurns.clear();
+		changeTurns.push_back(0);
+	}
+
+	bool empty() {
+		return changeTurns.empty();
+	}
+
+private:
+	std::vector<UINT> changeTurns;
+};
+#endif // !EFFECT_CHANGE_HISTORY_H

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -5694,6 +5694,12 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		}
 	}
 
+	if (CueEvents.HasOccurred(CID_MapIcon))
+	{
+		this->pMapWidget->UpdateFromCurrentGame();
+		this->pMapWidget->RequestPaint();
+	}
+
 	if (CueEvents.HasOccurred(CID_MoneyDoorOpened) || CueEvents.HasOccurred(CID_MoneyDoorLocked))
 		g_pTheSound->PlaySoundEffect(SEID_ORBHIT); //!!new sound
 	if (CueEvents.HasOccurred(CID_KnockOpenedDoor) || CueEvents.HasOccurred(CID_DoorLocked))

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -28,6 +28,7 @@
 #ifndef GAMESCREEN_H
 #define GAMESCREEN_H
 
+#include "EffectChangeHistory.h"
 #include "RoomScreen.h"
 
 #include "../DRODLib/CurrentGame.h"
@@ -44,6 +45,7 @@ class CClockWidget;
 class CFiredCharacterCommand;
 class CEntranceSelectDialogWidget;
 class CSubtitleEffect;
+class EffectChangeHistory;
 struct VisualEffectInfo;
 class CGameScreen : public CRoomScreen
 {
@@ -273,6 +275,8 @@ private:
 	UINT        wUndoToTurn; //undo moves back to this turn at once
 //	bool			bHoldConquered; //whether player has conquered hold being played
 //	CIDSet		roomsPreviouslyConquered; //rooms player has conquered previously in hold being played
+
+	EffectChangeHistory mapIconChanges;
 
 	float *fPos;   //position vector
 

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -33,6 +33,7 @@
 
 #include "DrodBitmapManager.h"
 #include "DrodEffect.h"
+#include "EffectChangeHistory.h"
 #include "FaceWidget.h"
 #include "Light.h"
 #include "TileImageCalcs.h"
@@ -194,46 +195,6 @@ struct TileImageBlitParams {
 };
 
 typedef map<ROOMCOORD, vector<TweeningTileMask> > t_PitMasks;
-
-//******************************************************************************
-//Class to record when changes to effects that require specific refreshing are made.
-//When the room goes "back in time", these effects can then be downdated.
-//It is assumed that adding a record means that any records in its future are now invalid
-class EffectChangeHistory {
-public:
-	EffectChangeHistory() = default;
-	~EffectChangeHistory() = default;
-
-	bool isAfterLatest(UINT turn) {
-		return turn > changeTurns.back();
-	}
-
-	//Remove all records after a given turn.
-	void removeAfter(UINT turn) {
-		while (!empty() && changeTurns.back() >= turn) {
-			changeTurns.pop_back();
-		}
-	}
-
-	//Add a new record. Any records from later turns are removed.
-	void add(UINT turn) {
-		removeAfter(turn);
-		changeTurns.push_back(turn);
-	}
-
-	void reset() {
-		changeTurns.clear();
-		changeTurns.push_back(0);
-	}
-
-	bool empty() {
-		return changeTurns.empty();
-	}
-
-private:
-	std::vector<UINT> changeTurns;
-};
-
 //******************************************************************************
 class CCurrentGame;
 class CRoomEffectList;

--- a/drodrpg/DROD/drod.2019.vcxproj.filters
+++ b/drodrpg/DROD/drod.2019.vcxproj.filters
@@ -474,6 +474,9 @@
     <ClInclude Include="PuffExplosionEffect.h">
       <Filter>Effects</Filter>
     </ClInclude>
+    <ClInclude Include="EffectChangeHistory.h">
+      <Filter>General</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="Res\DROD.ico">

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3940,7 +3940,7 @@ void CCharacter::SetMapIcon(
 	pExpRoom->mapIconState = iconState;
 
 	if (pExpRoom->mapState != MapState::Invisible) {
-		CueEvents.Add(CID_LevelMap, new CAttachableWrapper<UINT>(T_MAP));
+		CueEvents.Add(CID_MapIcon);
 	}
 }
 

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -710,6 +710,11 @@ enum CUEEVENT_ID
 	//Private data: NONE
 	CID_LightTilesChanged,
 
+	//An icon was changed on a visible room
+	//
+	//Private data: NONE
+	CID_MapIcon,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -7539,6 +7539,18 @@ void CCurrentGame::SetPlayerToRoomStart()
 	RemoveMappedRoomsNotIn(this->roomsExploredAtRoomStart, this->roomsMappedAtRoomStart,
 			this->PreviouslyExploredRooms);
 
+	for (vector<ExploredRoom*>::const_iterator roomIter = this->ExploredRooms.begin();
+		roomIter != this->ExploredRooms.end(); ++roomIter)
+	{
+		ExploredRoom* pExpRoom = *roomIter;
+		map<UINT, pair<ScriptVars::MapIcon, ScriptVars::MapIconState>>::const_iterator finder =
+			this->mapIconsAtRoomStart.find(pExpRoom->roomID);
+		if (finder != this->mapIconsAtRoomStart.end()) {
+			pExpRoom->mapIcon = finder->second.first;
+			pExpRoom->mapIconState = finder->second.second;
+		}
+	}
+
 	//Prepare vars for recording saved games.
 	this->bIsGameActive = true;
 	this->wTurnNo = 0;
@@ -7602,6 +7614,13 @@ void CCurrentGame::SetRoomStartToPlayer()
 	this->roomsExploredAtRoomStart = GetExploredRooms();
 	this->roomsMappedAtRoomStart = GetMappedRooms();
 	this->roomsMappedAtRoomStart += GetInvisibleRooms();
+
+	this->mapIconsAtRoomStart.clear();
+	for (vector<ExploredRoom*>::const_iterator room = this->ExploredRooms.begin();
+		room != this->ExploredRooms.end(); ++room) {
+			ExploredRoom* pExpRoom = *room;
+			this->mapIconsAtRoomStart[pExpRoom->roomID] = { pExpRoom->mapIcon, pExpRoom->mapIconState };
+	}
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -413,6 +413,7 @@ public:
 	CDbPackedVars statsAtRoomStart; //stats when room was begun
 	map<UINT, map<int, int>> scriptArraysAtRoomStart;
 	CIDSet   roomsExploredAtRoomStart, roomsMappedAtRoomStart;
+	map <UINT, pair<ScriptVars::MapIcon, ScriptVars::MapIconState>> mapIconsAtRoomStart;
 	vector<CMoveCoordEx> ambientSounds;  //ambient sounds playing now
 	vector<SpeechLog> roomSpeech; //speech played up to this moment in the current room
 //	bool     bRoomExitLocked; //safety to prevent player from exiting room when set

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -963,9 +963,9 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_Chest: strText = "Chest"; break;
 		case MID_Gear: strText = "Gear"; break;
 		case MID_MoneyBag: strText = "Money bag"; break;
-		case MID_WhiteKey: strText = "White key"; break;
 		case MID_QuestionMark: strText = "Question mark"; break;
 		case MID_MapIconAlpha: strText = "Map icon alpha"; break;
+		case MID_WhiteKey: strText = "White key"; break;
 		case MID_White: strText = "White"; break;
 		case MID_Red: strText = "Red"; break;
 		case MID_Green: strText = "Green"; break;

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1233,7 +1233,7 @@ enum MID_CONSTANT {
   MID_NewGames = 1841,
   MID_ConfirmNewGame = 1842,
   MID_AutoPreviewCharacters = 1850,
-  MID_MapIconAlpha = 2007,
+  MID_MapIconAlpha = 2006,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,
@@ -1666,8 +1666,8 @@ enum MID_CONSTANT {
   MID_Chest = 2002,
   MID_Gear = 2003,
   MID_MoneyBag = 2004,
-  MID_WhiteKey = 2005,
-  MID_QuestionMark = 2006,
+  MID_QuestionMark = 2005,
+  MID_WhiteKey = 2007,
   MID_SetDarkness = 2024,
   MID_SetCeilingLight = 2025,
   MID_SetWallLight = 2026,


### PR DESCRIPTION
A few tweaks and fixes to improve map icons:

1. "White key" is now named "Skeleton key" on the interface. This leaves a spare string rattling around. For the moment I've shuffled some message ids around, and I have a thing in the pipeline that happens to need a single string, so I'll fully replace it at that point.
2. Adding icons to the map now has its own cue event instead of using the map room reveal event.
3. Icons are now tracked so that they can be properly updated during room resets.
4. Some tracking has been added to `CGameScreen` to make sure the map widget redraws correctly when undoing or restarting. `EffectChangeHistory` is no longer just for lighting. (It also now lives in its own file.)