### PR TITLE
RPG: Add Attack tile command

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -166,6 +166,7 @@ const UINT TAG_ITEM_GROUP_LISTBOX = 884;
 const UINT TAG_MAP_ICON_STATE_LISTBOX = 883;
 const UINT TAG_MAP_ICON_LISTBOX = 882;
 const UINT TAG_COLOR_LISTBOX = 881;
+const UINT TAG_NO_DEF_LABEL = 880;
 
 const UINT MAX_TEXT_LABEL_SIZE = 100;
 
@@ -1861,6 +1862,11 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pColorListBox->AddItem(ScriptFlag::LC_Turquoise, g_pTheDB->GetMessageText(MID_Turquoise));
 	this->pColorListBox->AddItem(ScriptFlag::LC_Violet, g_pTheDB->GetMessageText(MID_Violet));
 	this->pColorListBox->AddItem(ScriptFlag::LC_Azure, g_pTheDB->GetMessageText(MID_Azure));
+
+	//Attack tile no enemy defense label.
+	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_NO_DEF_LABEL, X_SINGLESTEPLABEL,
+		Y_SINGLESTEPLABEL, CX_SINGLESTEPLABEL, CY_SINGLESTEPLABEL, F_Small,
+		g_pTheDB->GetMessageText(MID_NoEnemyDefense)));
 
 	//OK/cancel buttons.
 	CButtonWidget *pOKButton = new CButtonWidget(
@@ -3902,6 +3908,24 @@ const
 		}
 		break;
 
+		case CCharacterCommand::CC_AttackTile:
+			wstr += _itoW(command.w, temp, 10);
+			wstr += wszSpace;
+			wstr += g_pTheDB->GetMessageText(MID_ATKStat);
+			wstr += wszSpace;
+			wstr += g_pTheDB->GetMessageText(MID_At);
+			wstr += wszSpace;
+			wstr += wszLeftParen;
+			wstr += _itoW(command.x, temp, 10);
+			wstr += wszComma;
+			wstr += _itoW(command.y, temp, 10);
+			wstr += wszRightParen;
+			if (command.h) {
+				wstr += wszSpace;
+				wstr += g_pTheDB->GetMessageText(MID_NoEnemyDefense);
+			}
+		break;
+
 		case CCharacterCommand::CC_SetMovementType:
 			wstr += this->pMovementTypeListBox->GetTextForKey(command.x);
 		break;
@@ -4117,6 +4141,7 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		case CCharacterCommand::CC_SetDarkness:
 		case CCharacterCommand::CC_SetCeilingLight:
 		case CCharacterCommand::CC_SetWallLight:
+		case CCharacterCommand::CC_AttackTile:
 			if (bLastWasIfCondition || wLogicNestDepth)
 				wstr += wszQuestionMark;	//questionable If condition
 		break;
@@ -4276,6 +4301,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_AnswerOption, g_pTheDB->GetMessageText(MID_AnswerOption));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Appear, g_pTheDB->GetMessageText(MID_Appear));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_AppearAt, g_pTheDB->GetMessageText(MID_AppearAt));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_AttackTile, g_pTheDB->GetMessageText(MID_AttackTile));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Autosave, g_pTheDB->GetMessageText(MID_Autosave));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Behavior, g_pTheDB->GetMessageText(MID_Behavior));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_BuildTile, g_pTheDB->GetMessageText(MID_BuildMarker));
@@ -4311,7 +4337,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Return, g_pTheDB->GetMessageText(MID_ReturnCommand));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_RoomLocationText, g_pTheDB->GetMessageText(MID_RoomLocationText));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ScoreCheckpoint, g_pTheDB->GetMessageText(MID_ScoreCheckpoint));
-	this->pActionListBox->AddItem(CCharacterCommand::CC_SetMapIcon, L"Set map icon");
+	this->pActionListBox->AddItem(CCharacterCommand::CC_SetMapIcon, g_pTheDB->GetMessageText(MID_SetMapIcon));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetMovementType, g_pTheDB->GetMessageText(MID_SetMovementType));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetMonsterVar, g_pTheDB->GetMessageText(MID_SetMonsterVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetNPCAppearance, g_pTheDB->GetMessageText(MID_SetNPCAppearance));
@@ -5245,6 +5271,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT MAPICON[] = { TAG_MAP_ICON_STATE_LISTBOX, TAG_MAP_ICON_LISTBOX, 0 };
 	static const UINT CEILINGLIGHT[] = { TAG_COLOR_LISTBOX, 0 };
 	static const UINT WALLLIGHT[] = { TAG_WAIT, TAG_COLOR_LISTBOX, 0 };
+	static const UINT ATTACKTILE[] = { TAG_WAIT, TAG_ONOFFLISTBOX2, 0 };
 
 	static const UINT* activeWidgets[CCharacterCommand::CC_Count] = {
 		NO_WIDGETS,
@@ -5337,10 +5364,11 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		MAPICON,            //CC_SetMinimapIcon
 		WAIT,               //CC_SetDarkness
 		CEILINGLIGHT,       //CC_SetCeilingLight
-		WALLLIGHT           //CC_SetWallLight
+		WALLLIGHT,          //CC_SetWallLight
+		ATTACKTILE          //CC_AttackTile
 	};
 
-	static const UINT NUM_LABELS = 31;
+	static const UINT NUM_LABELS = 32;
 	static const UINT labelTag[NUM_LABELS] = {
 		TAG_EVENTLABEL, TAG_WAITLABEL, TAG_DELAYLABEL, TAG_SPEAKERLABEL,
 		TAG_MOODLABEL, TAG_TEXTLABEL, TAG_DIRECTIONLABEL, TAG_SOUNDNAME_LABEL,
@@ -5349,7 +5377,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_MOVERELXLABEL, TAG_MOVERELYLABEL, TAG_LOOPSOUND, TAG_WAITABSLABEL,
 		TAG_SKIPENTRANCELABEL, TAG_DIRECTIONLABEL2, TAG_SOUNDEFFECTLABEL, TAG_ROOMREVEALLABEL,
 		TAG_COLOR_LABEL, TAG_VALUE_OR_EXPRESSION, TAG_IMAGEOVERLAY_LABEL, TAG_ARRAYINDEX_LABEL,
-		TAG_ARRAYVAR_TEXTLABEL, TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL
+		TAG_ARRAYVAR_TEXTLABEL, TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, TAG_NO_DEF_LABEL
 	};
 
 	static const UINT NO_LABELS[NUM_LABELS] =      {0};
@@ -5378,7 +5406,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT EXPRESSION_L[NUM_LABELS] =   { TAG_VARVALUELABEL, 0 };
 	static const UINT IMAGE_OVERLAY_L[NUM_LABELS] = { TAG_IMAGEOVERLAY_LABEL, 0 };
 	static const UINT ARRAYSET_L[] =               { TAG_ARRAYINDEX_LABEL, TAG_ARRAYVAR_TEXTLABEL, 0 };
-	static const UINT OPENTILE_L[] =                { TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, 0 };
+	static const UINT OPENTILE_L[] =               { TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, 0 };
+	static const UINT ATTACKTILE_L[] =             { TAG_NO_DEF_LABEL, 0 };
 
 	static const UINT* activeLabels[CCharacterCommand::CC_Count] = {
 		NO_LABELS,
@@ -5472,6 +5501,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_SetDarkness
 		NO_LABELS,          //CC_SetCeilingLight
 		NO_LABELS,          //CC_SetWallLight
+		ATTACKTILE_L,       //CC_AttackTile
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -6380,6 +6410,16 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		}
 		break;
 
+		case CCharacterCommand::CC_AttackTile:
+		{
+			CTextBoxWidget* pDamage = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_WAIT));
+			this->pCommand->w = pDamage->GetNumber();
+			this->pCommand->h = this->pOnOffListBox2->GetSelectedItem();
+			QueryXY();
+		}
+		break;
+
 		case CCharacterCommand::CC_SetMovementType:
 			this->pCommand->x = this->pMovementTypeListBox->GetSelectedItem();
 			AddCommand();
@@ -6853,6 +6893,16 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 				this->pSpeechText->SetText(this->pCommand->label.c_str());
 			else
 				this->pSpeechText->SetText(_itoW(this->pCommand->h, temp, 10));
+		}
+		break;
+
+		case CCharacterCommand::CC_AttackTile:
+		{
+			CTextBoxWidget* pDamage = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_WAIT));
+			ASSERT(pDamage);
+			pDamage->SetText(_itoW(this->pCommand->w, temp, 10));
+			this->pOnOffListBox2->SelectItem(this->pCommand->h);
 		}
 		break;
 
@@ -7570,6 +7620,13 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 			pCommand->label = pText + pos; //get text expression
 	break;
 
+	case CCharacterCommand::CC_AttackTile:
+		parseNumber(pCommand->x); skipComma; skipComma;
+		parseNumber(pCommand->y); skipComma; skipComma;
+		parseNumber(pCommand->w); skipComma; skipComma;
+		parseNumber(pCommand->h); skipComma; skipComma;
+	break;
+
 	case CCharacterCommand::CC_SetMovementType:
 		parseMandatoryOption(pCommand->x, this->pMovementTypeListBox, bFound);
 	break;
@@ -8251,6 +8308,13 @@ WSTRING CCharacterDialogWidget::toText(
 		else
 			concatNum(c.h);
 	}
+	break;
+
+	case CCharacterCommand::CC_AttackTile:
+		concatNumWithComma(c.x);
+		concatNumWithComma(c.y);
+		concatNumWithComma(c.w);
+		concatNumWithComma(c.h);
 	break;
 
 	case CCharacterCommand::CC_SetMovementType:

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3089,9 +3089,9 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_AttackTile:
 			{
 				getCommandRect(command, px, py, pw, ph);
-				int damage;
+				int damage = 0;
 				CMonster* pMonster = room.GetMonsterAtSquare(px, py);
-				CMonster* pTarget;
+				CMonster* pTarget = NULL;
 				if (pMonster && pMonster->getHP() > 0) {
 					//Attack monster
 					pTarget = pMonster;
@@ -3108,7 +3108,7 @@ void CCharacter::Process(
 					player.Damage(CueEvents, -damage, CID_MonsterKilledPlayer); //-ve for flat damage
 				}
 
-				if (damage == 0) {
+				if (damage == 0 && pTarget) {
 					CueEvents.Add(CID_EntityAffected, new CCombatEffect(pTarget, CET_NODAMAGE), true);
 				}
 

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -364,6 +364,7 @@ public:
 		CC_SetDarkness,         //Set darkness level in rect (x,y,w,h) to value in flags. Zero value removes darkness
 		CC_SetCeilingLight,     //Set ceiling light value in rect (x,y,w,h) to value in flags. Zero value removes light
 		CC_SetWallLight,        //Set wall light value at (x,y) to intensity (w) with value in flags. Zero intensity or value removes light
+		CC_AttackTile,          //Attack the entity at (x,y) with a power of (w) ATK. Ignores DEF is (h) is set
 		CC_Count
 	};
 

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -364,7 +364,7 @@ public:
 		CC_SetDarkness,         //Set darkness level in rect (x,y,w,h) to value in flags. Zero value removes darkness
 		CC_SetCeilingLight,     //Set ceiling light value in rect (x,y,w,h) to value in flags. Zero value removes light
 		CC_SetWallLight,        //Set wall light value at (x,y) to intensity (w) with value in flags. Zero intensity or value removes light
-		CC_AttackTile,          //Attack the entity at (x,y) with a power of (w) ATK. Ignores DEF is (h) is set
+		CC_AttackTile,          //Attack the entity at (x,y) with a power of (w) ATK. Ignores DEF if (h) is set
 		CC_Count
 	};
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -985,6 +985,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_SetDarkness: strText = "Set ceiling darkness"; break;
 		case MID_SetCeilingLight: strText = "Set ceiling light"; break;
 		case MID_SetWallLight: strText = "Set wall light"; break;
+		case MID_SetMapIcon: strText = "Set map icon"; break;
+		case MID_AttackTile: strText = "Attack tile"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -124,8 +124,8 @@ interacts with its environment.</p>
       next to the orb when struck, it will appear that Beethro is using his
       portable orb.</li>
   <li><a name="attack-tile"><b>Attack tile</b></a> - Damages the player or monster
-      at the room square you select, with the specified amount of damage. The command
-      can be configured to ignore the target's DEF value.</li>
+      at the room square you select, with the specified amount of ATK power. The
+      command can be configured to ignore the target's DEF value.</li>
   <li><a name="speech"><b>Speech</b></a> - Causes someone in the room to say
       something.<br />
       <a name="dialogtext"><u>Dialog text</u></a>: Type the words that are said.
@@ -315,8 +315,8 @@ interacts with its environment.</p>
 	  explored it.  If the indicated room has already been explored
 	  by the player, this command does nothing.</li>
   <li><a name="set-map-icon"><b>Set map icon</b></a> - Adds an icon for the selected
-      room on the player's map. Icons are only shown for rooms that have been revealed
-      to the player, but can be added to unrevealed rooms. Setting the icon to "none"
+      room on the player's map. Icons can be added to unrevealed rooms but are only displayed
+      on rooms that have been revealed to the player. Setting the icon to "none"
       will remove any icon from that room. In addition to normal display, icons can be
       shown in grayscale, negative color, and sepia.</li>
   <li><a name="autosave"><b>Autosave</b></a> - Automatically saves the player's

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -123,6 +123,9 @@ interacts with its environment.</p>
       to orbs before striking them for more intuitive behavior.  If no one is
       next to the orb when struck, it will appear that Beethro is using his
       portable orb.</li>
+  <li><a name="attack-tile"><b>Attack tile</b></a> - Damages the player or monster
+      at the room square you select, with the specified amount of damage. The command
+      can be configured to ignore the target's DEF value.</li>
   <li><a name="speech"><b>Speech</b></a> - Causes someone in the room to say
       something.<br />
       <a name="dialogtext"><u>Dialog text</u></a>: Type the words that are said.
@@ -311,6 +314,11 @@ interacts with its environment.</p>
 	  then it will show the room on the minimap as if the player has already
 	  explored it.  If the indicated room has already been explored
 	  by the player, this command does nothing.</li>
+  <li><a name="set-map-icon"><b>Set map icon</b></a> - Adds an icon for the selected
+      room on the player's map. Icons are only shown for rooms that have been revealed
+      to the player, but can be added to unrevealed rooms. Setting the icon to "none"
+      will remove any icon from that room. In addition to normal display, icons can be
+      shown in grayscale, negative color, and sepia.</li>
   <li><a name="autosave"><b>Autosave</b></a> - Automatically saves the player's
       game in an "Autosave" slot under the name you provide.
 	  Whenever this command is executed, any previous

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1671,6 +1671,8 @@ enum MID_CONSTANT {
   MID_SetDarkness = 2024,
   MID_SetCeilingLight = 2025,
   MID_SetWallLight = 2026,
+  MID_SetMapIcon = 2027,
+  MID_AttackTile = 2028,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1735,3 +1735,11 @@ Set ceiling light
 [MID_SetWallLight]
 [eng]
 Set wall light
+
+[MID_SetMapIcon]
+[eng]
+Set map icon
+
+[MID_AttackTile]
+[eng]
+Attack tile


### PR DESCRIPTION
The much desired command to hurt things. It can even be configured to consider or ignore the target's defense value. Percentage damage isn't directly supported, but should be easily achieved with _MyScript overrides. Part of the reason this command is helpful is because #717 means that using `Set monster var` now has side-effects when used on serpents.

(There are also a few things missed from the map icon work in here)