### PR TITLE
RPG: Make Removes Sword behaviour only apply on weapons

### DIFF
--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -245,7 +245,7 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 		text += g_pTheDB->GetMessageText(MID_AttackLast);
 		needSeparator = true;
 	}
-	if (pCharacter->RemovesSword())
+	if (pCharacter->RemovesSword() && equipType == ScriptFlag::Weapon)
 	{
 		if (needSeparator)
 			text += separator;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3623,16 +3623,6 @@ bool CCurrentGame::IsPlayerSwordRemoved() const
 		if (pCharacter && pCharacter->RemovesSword())
 			return true;
 	}
-	if (!IsPlayerShieldDisabled()) {
-		pCharacter = getCustomEquipment(ScriptFlag::Armor);
-		if (pCharacter && pCharacter->RemovesSword())
-			return true;
-	}
-	if (!IsPlayerAccessoryDisabled()) {
-		pCharacter = getCustomEquipment(ScriptFlag::Accessory);
-		if (pCharacter && pCharacter->RemovesSword())
-			return true;
-	}
 
 	return false;
 }

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -803,7 +803,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_CustomType: strText = "%s type"; break;
 		case MID_StrongAgainstType: strText = "Strong against %s"; break;
 		case MID_ShowScore: strText = "Show score"; break;
-		case MID_RemovesSword: strText = "Removes sword"; break;
+		case MID_RemovesSword: strText = "Small weapon"; break;
 		case MID_VarLevelMultiplier: strText = "_LevelMultiplier"; break;
 		case MID_VarRoomX: strText = "_RoomX"; break;
 		case MID_VarRoomY: strText = "_RoomY"; break;

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1422,7 +1422,7 @@ Strong against %s
 
 [MID_RemovesSword]
 [eng]
-Removes sword
+Small weapon
 
 [MID_ExplosiveSafe]
 [eng]


### PR DESCRIPTION
Requested change, along with a rename. It makes sense, as applying it to other equipment can lead to strange situations when equipment is disabled.