### PR TITLE
RPG: Fix up keybinding work mistakes

### DIFF
--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -3280,6 +3280,17 @@ void CEditRoomScreen::OnKeyDown(
 	//Check for other keys.
 	switch (Key.keysym.sym)
 	{
+		case SDLK_F4:
+		{
+			const bool bAltCtrl = (Key.keysym.mod & (KMOD_ALT | KMOD_CTRL)) != 0;
+			if (bAltCtrl)
+			{
+				//Save on ALT-F4 exit.
+				SaveRoom();
+			}
+		}
+		break;
+
 		//Exit screen.
 		case SDLK_ESCAPE:
 			//Handle some cleanup on screen exit.

--- a/drodrpg/Texts/SettingsScreen.uni
+++ b/drodrpg/Texts/SettingsScreen.uni
@@ -610,7 +610,7 @@ Go to Prev Level
 [eng]
 Go to Next Level
 
-[MID_Command_Editor_NextLevel]
+[MID_Command_Editor_LogVarRefs]
 [eng]
 Log Var References
 


### PR DESCRIPTION
I zapped the safety case for saving a room in the editor when using ALT-F4 becasue I didn't understand what I was looking at. Also, I gave one the messages the wrong id in `SettingsScreen.uni`. Fixing them up here.