### PR TITLE
RPG: Add item groups for keys and collectables

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4733,8 +4733,10 @@ void CCharacterDialogWidget::PopulateItemGroupListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(ScriptFlag::IG_AttackUp, g_pTheDB->GetMessageText(MID_AttackUpGroup));
 	pListBox->AddItem(ScriptFlag::IG_DefenseUp, g_pTheDB->GetMessageText(MID_DefenseUpGroup));
 	pListBox->AddItem(ScriptFlag::IG_Powerup, g_pTheDB->GetMessageText(MID_PowerupGroup));
+	pListBox->AddItem(ScriptFlag::IG_Keys, g_pTheDB->GetMessageText(MID_Keys));
 	pListBox->AddItem(ScriptFlag::IG_Shovels, g_pTheDB->GetMessageText(MID_Shovel1));
 	pListBox->AddItem(ScriptFlag::IG_Map, g_pTheDB->GetMessageText(MID_LevelMap));
+	pListBox->AddItem(ScriptFlag::IG_Collectable, g_pTheDB->GetMessageText(MID_CollectableGroup));
 	pListBox->AddItem(ScriptFlag::IG_Equipment, g_pTheDB->GetMessageText(MID_EquipmentGroup));
 }
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4328,6 +4328,8 @@ TileCheckFunc getItemGroupFunction(ScriptFlag::ItemGroup group)
 	case ScriptFlag::IG_Shovels: return bIsShovel;
 	case ScriptFlag::IG_Map: return bIsMap;
 	case ScriptFlag::IG_Equipment: return bIsEquipment;
+	case ScriptFlag::IG_Keys: return bIsKey;
+	case ScriptFlag::IG_Collectable: return bIsCollectable;
 	default: return bIsPlainFloor;
 	}
 }
@@ -4374,6 +4376,8 @@ UINT getItemGroupLayer(ScriptFlag::ItemGroup group)
 	case ScriptFlag::IG_Shovels: return LAYER_TRANSPARENT;
 	case ScriptFlag::IG_Map: return LAYER_TRANSPARENT;
 	case ScriptFlag::IG_Equipment: return LAYER_TRANSPARENT;
+	case ScriptFlag::IG_Keys: return LAYER_TRANSPARENT;
+	case ScriptFlag::IG_Collectable: return LAYER_TRANSPARENT;
 	default: return LAYER_OPAQUE;
 	}
 }

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -230,6 +230,8 @@ namespace ScriptFlag
 		IG_Shovels = 33, //All sizes of shovel
 		IG_Map = 34, //Map and detailed map
 		IG_Equipment = 35, //Any equipment slot
+		IG_Keys = 36, //Any key
+		IG_Collectable = 37, //Any item the player can pick up
 		ItemGroupCount //Total number of defined groups
 	};
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -1034,6 +1034,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_Command_Script_SelectAll: strText = "Select All"; break;
 		case MID_Command_Script_ToText: strText = "Export Script Commands"; break;
 		case MID_Command_Script_FromText: strText = "Import Script Commands"; break;
+		case MID_CollectableGroup: strText = "Collectable items"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -302,6 +302,12 @@ static inline bool bIsDEFUp(const UINT t) { return t == T_DEF_UP || t == T_DEF_U
 
 static inline bool bIsShovel(const UINT t) { return t == T_SHOVEL1 || t == T_SHOVEL3 || t == T_SHOVEL10; }
 
+static inline bool bIsKey(const UINT t) { return t == T_KEY; }
+
+static inline bool bIsCollectable(const UINT t) {
+	return bIsPowerUp(t) || bIsShovel(t) || bIsMap(t) || bIsKey(t);
+}
+
 static inline bool bIsTLayerCoveringItem(const UINT t) { return t == T_MIRROR || t == T_CRATE || t == T_POWDER_KEG; }
 
 static inline bool bIsFuseConnected(const UINT t) { return t == T_FUSE || t == T_BOMB; }

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1719,6 +1719,7 @@ enum MID_CONSTANT {
   MID_SetMapIcon = 2027,
   MID_AttackTile = 2028,
   MID_Roachie = 2029,
+  MID_CollectableGroup = 2075,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1747,3 +1747,7 @@ Attack tile
 [MID_Roachie]
 [eng]
 Roachie
+
+[MID_CollectableGroup]
+[eng]
+Collectable items


### PR DESCRIPTION
While keys are technically one item, from a user-facing perspective having them as an item group is nicer.