### PR TITLE
Fix issues with body attack immune player behavior

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -6597,7 +6597,7 @@ const
 
 			//Can this kill the monster it's stepping to?
 			//Humans need dagger to do this.
-			bool bKill = pMonster->IsAttackableTarget() &&
+			bool bKill = pMonster->IsAttackableTarget() && pMonster->IsVulnerableToBodyAttack() &&
 				(!bIsHuman(GetResolvedIdentity()) || CanDaggerStep(pMonster));
 
 			if (!bKill && !bPush) {

--- a/DRODLib/Clone.cpp
+++ b/DRODLib/Clone.cpp
@@ -182,6 +182,15 @@ bool CClone::IsVulnerableToExplosion() const
 }
 
 //*****************************************************************************
+bool CClone::IsVulnerableToPlayerBodyAttack() const
+{
+	if (!this->pCurrentGame)
+		return false;
+
+	return this->pCurrentGame->swordsman.IsCloneVulnerableToThisBodyAttack();
+}
+
+//*****************************************************************************
 bool CClone::IsVulnerableToWeapon(WeaponType weaponType) const
 {
 	if (!this->pCurrentGame)

--- a/DRODLib/Clone.h
+++ b/DRODLib/Clone.h
@@ -53,6 +53,7 @@ public:
 	virtual bool IsHiding() const;
 	virtual bool IsVulnerableToAdder() const;
 	virtual bool IsVulnerableToExplosion() const;
+	virtual bool IsVulnerableToPlayerBodyAttack() const;
 	virtual bool IsVulnerableToWeapon(WeaponType weaponType) const;
   bool KillIfOnDeadlyTile(CCueEvents& CueEvents);
   virtual bool OnStabbed(CCueEvents &CueEvents, const UINT wX = (UINT)-1, const UINT wY = (UINT)-1,

--- a/DRODLib/Construct.cpp
+++ b/DRODLib/Construct.cpp
@@ -104,7 +104,8 @@ const
 
 	//Can only move onto attackable monsters.
 	CMonster *pMonster = room.GetMonsterAtSquare(wCol, wRow);
-	if (pMonster && !pMonster->IsAttackableTarget() && pMonster->wType != M_FLUFFBABY){
+	if (pMonster && (!pMonster->IsAttackableTarget() || !pMonster->IsVulnerableToBodyAttack())
+		&& pMonster->wType != M_FLUFFBABY){
 		const int dx = (int)wCol - (int)this->wX;
 		const int dy = (int)wRow - (int)this->wY;
 		if (!pMonster->IsPushableByBody() || !room.CanPushMonster(pMonster, wCol, wRow, wCol + dx, wRow + dy)){

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2766,10 +2766,6 @@ const
 
 			//These monsters can't be stepped on
 			UINT monsterType = pMonster->wType;
-			if (monsterType == M_TEMPORALCLONE || monsterType == M_CLONE) {
-				const CPlayerDouble *pDouble = DYN_CAST(const CPlayerDouble*, const CMonster*, pMonster);
-				monsterType = pDouble->GetIdentity();
-			}
 			switch (monsterType)
 			{
 				case M_WUBBA:
@@ -2777,6 +2773,12 @@ const
 				case M_FEGUNDO:
 					bObstacle = bMonsterObstacle = true;
 					break;
+				case M_CLONE: case M_TEMPORALCLONE:
+				{
+					const CPlayerDouble* pDouble = DYN_CAST(const CPlayerDouble*, const CMonster*, pMonster);
+					bObstacle = bMonsterObstacle = !pDouble->IsVulnerableToPlayerBodyAttack();
+				}
+				break;
 				case M_CHARACTER:
 				{
 					const CCharacter *pCharacter = DYN_CAST(const CCharacter*, const CMonster*, pMonster);

--- a/DRODLib/Mimic.cpp
+++ b/DRODLib/Mimic.cpp
@@ -62,7 +62,7 @@ bool CMimic::CanBumpActivateOrb() const
 bool CMimic::CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const
 {
 	if (bStepAttack)
-		return true;
+		return player.IsVulnerableToDoubleBodyAttack(true);
 
 	if (!(HasSword() && GetWeaponType() == WT_Dagger))
 		return false;

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -574,7 +574,7 @@ CheckMonster:
 			pMonster->wType != M_FLUFFBABY // Fluff babies can be stepped on regardless of anything
 			&& !this->CanDaggerStep(pMonster, false)
 			// Even when attackable, body-attack-invulnerable targets just can't be killed by a body-attack
-			&& (!pMonster->IsAttackableTarget() || !bIsVulnerableToBodyAttack(pMonster->GetIdentity()))
+			&& (!pMonster->IsAttackableTarget() || !pMonster->IsVulnerableToBodyAttack())
 			&& ( // If object is pushable AND cannot be pushed
 				!this->CanPushObjects()
 				|| !pMonster->IsPushableByBody()
@@ -1979,6 +1979,12 @@ const
 bool CMonster::IsVulnerableToAdder() const
 {
 	return !(IsLongMonster() || IsPiece());
+}
+
+//*****************************************************************************
+bool CMonster::IsVulnerableToBodyAttack() const
+{
+	return bIsVulnerableToBodyAttack(this->GetIdentity());
 }
 
 //*****************************************************************************

--- a/DRODLib/Monster.h
+++ b/DRODLib/Monster.h
@@ -326,6 +326,7 @@ public:
 	virtual bool  IsHiding() const {return false;}
 	virtual bool  IsVisible() const {return true;}
 	virtual bool  IsVulnerableToAdder() const;
+	virtual bool  IsVulnerableToBodyAttack() const;
 	virtual bool  IsVulnerableToExplosion() const;
 	virtual bool  IsWading() const;
 	bool          IsStunned() const { return this->stunned != 0; }

--- a/DRODLib/PlayerDouble.h
+++ b/DRODLib/PlayerDouble.h
@@ -88,6 +88,7 @@ public:
 	virtual bool BrainAffects() const {return false;}
 	virtual bool IsAggressive() const {return false;}
 	virtual bool IsFriendly() const {return true;}
+	virtual bool IsVulnerableToPlayerBodyAttack() const { return true; }
 	virtual bool IsVulnerableToWeapon(WeaponType weaponType) const {return true;}
 };
 

--- a/DRODLib/Swordsman.cpp
+++ b/DRODLib/Swordsman.cpp
@@ -497,6 +497,21 @@ bool CSwordsman::IsAt(UINT wX, UINT wY) const
 }
 
 //*****************************************************************************
+bool CSwordsman::IsCloneVulnerableToThisBodyAttack() const
+//Returns if a clone of the player can be body attacked by the player.
+{
+	bool active;
+	if (HasBehavior(PB_BodyAttackImmune, active)) {
+		return !active; //No immunity = can be attacked
+	}
+
+	//Slightly differet roles are safe from being attacked by players than by
+	//monsters.
+	return !(this->wAppearance == M_ROCKGOLEM || this->wAppearance == M_WUBBA ||
+		this->wAppearance == M_FEGUNDO || this->wAppearance == M_CONSTRUCT);
+}
+
+//*****************************************************************************
 bool CSwordsman::IsInRoom() const
 //Returns: whether player is controlling a character in the game room
 {
@@ -595,6 +610,21 @@ bool CSwordsman::IsVulnerableToBodyAttack() const
 	}
 
 	return bIsVulnerableToBodyAttack(this->wAppearance);
+}
+
+//*****************************************************************************
+bool CSwordsman::IsVulnerableToDoubleBodyAttack(bool bStepAttack) const
+//Return whether the player can be stepped on by player doubles
+{
+	bool active;
+	if (HasBehavior(PB_BodyAttackImmune, active)) {
+		return !active; //No immunity = can be attacked
+	}
+
+	if (wAppearance == M_CITIZEN || wAppearance == M_ARCHITECT)
+		return !bStepAttack;
+
+	return !(wAppearance == M_WUBBA || wAppearance == M_FEGUNDO);
 }
 
 //*****************************************************************************

--- a/DRODLib/Swordsman.h
+++ b/DRODLib/Swordsman.h
@@ -139,6 +139,7 @@ public:
 	UINT GetWaterTraversalState(UINT wRole = M_NONE) const;
 	MovementType GetMovementType() const;
 	bool IsAt(UINT wX, UINT wY) const;
+	bool IsCloneVulnerableToThisBodyAttack() const;
 	bool IsInRoom() const;
 	bool IsStabbable() const;
 	bool IsVulnerableToAdder() const;
@@ -147,6 +148,7 @@ public:
 	bool IsVulnerableToHeat() const;
 	bool IsVulnerableToWeapon(const WeaponType weaponType) const;
 	bool IsVulnerableToBodyAttack() const;
+	bool IsVulnerableToDoubleBodyAttack(bool bStepAttack) const;
 	bool IsTarget() const;
 	bool IsWeaponAt(UINT wX, UINT wY) const;
 	bool IsVisible() const { return !(this->bIsInvisible || this->bIsHiding); }

--- a/DRODLib/TemporalClone.cpp
+++ b/DRODLib/TemporalClone.cpp
@@ -172,20 +172,6 @@ bool CTemporalClone::CanPushOntoOTile(const UINT wTile) const
 	return false;
 }
 
-//*****************************************************************************************
-//Can this projection step onto (and thus kill) the player?
-bool CTemporalClone::CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const
-{
-	if (bStepAttack)
-		return true;
-
-	if (!(HasSword() && GetWeaponType() == WT_Dagger))
-		return false;
-
-	//Check if player is invulnerable to "dagger stepping".
-	return player.IsVulnerableToWeapon(WT_Dagger);
-}
-
 //*****************************************************************************
 bool CTemporalClone::FacesMovementDirection() const
 {
@@ -362,6 +348,21 @@ bool CTemporalClone::IsVulnerableToExplosion() const
 	bool active;
 	HasBehavior(PB_ExplosionImmune, active);
 	return !active; //No immunity = it hurts
+}
+
+//*****************************************************************************
+bool CTemporalClone::IsVulnerableToPlayerBodyAttack() const
+//Returns: If a body attack from the player can kill this.
+{
+	bool active;
+	if (HasBehavior(PB_BodyAttackImmune, active)) {
+		return !active; //No immunity = can be attacked
+	}
+
+	//Slightly differet roles are safe from being attacked by players than by
+	//monsters.
+	return !(this->wAppearance == M_ROCKGOLEM || this->wAppearance == M_WUBBA ||
+		this->wAppearance == M_FEGUNDO || this->wAppearance == M_CONSTRUCT);
 }
 
 //*****************************************************************************

--- a/DRODLib/TemporalClone.h
+++ b/DRODLib/TemporalClone.h
@@ -47,7 +47,7 @@ public:
 	virtual bool CanPushMonsters() const;
 	virtual bool CanPushObjects() const;
 	virtual bool CanPushOntoOTile(const UINT wTile) const;
-	virtual bool CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const;
+	//virtual bool CanStepAttackPlayer(const CSwordsman& player, const bool bStepAttack) const;
 	virtual bool FacesMovementDirection() const;
 	virtual UINT GetIdentity() const;
 	virtual bool IsAttackableTarget() const;
@@ -56,8 +56,9 @@ public:
 	virtual bool IsMonsterTarget() const;
 	virtual bool IsTarget() const;
 	virtual bool IsVulnerableToAdder() const;
-	bool         IsVulnerableToBodyAttack() const;
+	virtual bool IsVulnerableToBodyAttack() const;
 	virtual bool IsVulnerableToExplosion() const;
+	virtual bool IsVulnerableToPlayerBodyAttack() const;
 	virtual bool IsVulnerableToWeapon(const WeaponType weaponType) const;
 	virtual bool HasStepAttack() const;
 	bool         KillIfOnDeadlyTile(CCueEvents &CueEvents);


### PR DESCRIPTION
The implementation of this behavior turned out to be pretty naive. Mainly because the three things it effects (swordsman, clones, timeclones) are all slightly inconsistent in what can step on them. This should hopefully iron things out so that they can be mangled by the correct things when the behavior override isn't active.