### PR TITLE
RPG: Fix wrong overload in CCurrentGame::getTextForInputCommandKey

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1159,7 +1159,7 @@ WSTRING CCurrentGame::getTextForInputCommandKey(InputCommands::DCMD id) const
 	const CDbPackedVars settings = g_pTheDB->GetCurrentPlayerSettings();
 	const InputCommands::KeyDefinition* keyDefinition = InputCommands::GetKeyDefinition(id);
 
-	const InputKey inputKey = settings.GetVar(keyDefinition->settingName, 0);
+	const InputKey inputKey = settings.GetVar(keyDefinition->settingName, InputKey(0));
 
 	return I18N::DescribeInputKey(inputKey);
 }


### PR DESCRIPTION
Due to C++ being how it is, the wrong version of `DbPackedVars::GetVar` ends up being used. This causes an assert because the int version of the function doesn't like how the var has the size of a int64.