### PR TITLE
Fix regression allowing player to non-lethally step on clones

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -2776,7 +2776,8 @@ const
 				case M_CLONE: case M_TEMPORALCLONE:
 				{
 					const CPlayerDouble* pDouble = DYN_CAST(const CPlayerDouble*, const CMonster*, pMonster);
-					bObstacle = bMonsterObstacle = !pDouble->IsVulnerableToPlayerBodyAttack();
+					if (!pDouble->IsVulnerableToPlayerBodyAttack())
+						bObstacle = bMonsterObstacle = true;
 				}
 				break;
 				case M_CHARACTER:


### PR DESCRIPTION
Accidentally introduced a new bug in #805. This unbreaks it, preventing the player from stepping on clones or projections if they don't have a body attack.