### PR TITLE
RPG: Add color-changing predefined vars

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4953,6 +4953,8 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_GOLD, g_pTheDB->GetMessageText(MID_VarMonsterGold));
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_XP, g_pTheDB->GetMessageText(MID_VarMonsterXP));
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_COLOR, g_pTheDB->GetMessageText(MID_VarMonsterColor));
+	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_HUE, g_pTheDB->GetMessageText(MID_VarMonsterHue));
+	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_SATURATION, g_pTheDB->GetMessageText(MID_VarMonsterSaturation));
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_SWORD, g_pTheDB->GetMessageText(MID_VarMonsterSword));
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_X, g_pTheDB->GetMessageText(MID_VarMonsterX));
 	this->pVarListBox->AddItem(ScriptVars::P_MONSTER_Y, g_pTheDB->GetMessageText(MID_VarMonsterY));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -2111,6 +2111,8 @@ void CCharacterDialogWidget::OnClick(
 			if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
 				this->pCharacter->wProcessSequence = this->pCharOptionsDialog->GetProcessSequence();
 				this->pCharacter->SetColor(this->pCharOptionsDialog->GetColor());
+				this->pCharacter->SetHue(this->pCharOptionsDialog->GetHue());
+				this->pCharacter->SetSaturation(this->pCharOptionsDialog->GetSaturation());
 				this->pCharacter->SetCustomSpeechColor(this->pCharOptionsDialog->GetSpeechColor());
 				this->pCharacter->SetGhostImage(this->pCharOptionsDialog->GetGhostDisplay());
 				this->pCharacter->SetMinimapTreasure(this->pCharOptionsDialog->GetMinimapTreasure());
@@ -3093,6 +3095,8 @@ void CCharacterDialogWidget::EditDefaultScriptForCustomNPC()
 				if (dwTagNo == CCharacterOptionsDialog::TAG_SAVE) {
 					pChar->ExtraVars.SetVar(ParamProcessSequenceStr, this->pCharOptionsDialog->GetProcessSequence());
 					pChar->ExtraVars.SetVar(ColorStr, this->pCharOptionsDialog->GetColor());
+					pChar->ExtraVars.SetVar(HueStr, this->pCharOptionsDialog->GetHue());
+					pChar->ExtraVars.SetVar(SaturationStr, this->pCharOptionsDialog->GetSaturation());
 					pChar->ExtraVars.SetVar(ParamSpeechColorStr, this->pCharOptionsDialog->GetSpeechColor());
 					pChar->ExtraVars.SetVar(GhostImageStr, this->pCharOptionsDialog->GetGhostDisplay());
 					pChar->ExtraVars.SetVar(MinimapTreasureStr, this->pCharOptionsDialog->GetMinimapTreasure());

--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -49,6 +49,20 @@ CCharacterOptionsDialog::CCharacterOptionsDialog(
 	AddWidget(new CLabelWidget(0L, TITLE_X, TITLE_Y,
 		TITLE_CX, TITLE_CY, F_Header, g_pTheDB->GetMessageText(MID_CharOptionsTitle)));
 
+	AddWidget(new CLabelWidget(0L, HUELABEL_X, HUELABEL_Y,
+		LABEL_CX, LABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_VarMonsterHue)));
+
+	this->pHueTextBox = new CTextBoxWidget(0L, HUETEXT_X, HUETEXT_Y,
+		TEXT_CX, TEXT_CY, COLOR_MAX_LENGTH, TAG_OK);
+	AddWidget(pHueTextBox);
+
+	AddWidget(new CLabelWidget(0L, SATURATIONLABEL_X, SATURATIONLABEL_Y,
+		LABEL_CX, LABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_VarMonsterSaturation)));
+
+	this->pSaturationTextBox = new CTextBoxWidget(0L, SATURATIONTEXT_X, SATURATIONTEXT_Y,
+		TEXT_CX, TEXT_CY, COLOR_MAX_LENGTH, TAG_OK);
+	AddWidget(pSaturationTextBox);
+
 	AddWidget(new CLabelWidget(0L, COLORLABEL_X, COLORLABEL_Y,
 		LABEL_CX, LABEL_CY, F_Small, g_pTheDB->GetMessageText(MID_VarMonsterColor)));
 
@@ -119,6 +133,12 @@ void CCharacterOptionsDialog::SetCharacter(
 	_itoW(pCharacter->getColor(), temp, 10, bufferLength);
 	this->pColorTextBox->SetText(temp);
 
+	_itoW(pCharacter->getHue(), temp, 10, bufferLength);
+	this->pHueTextBox->SetText(temp);
+
+	_itoW(pCharacter->getSaturation(), temp, 10, bufferLength);
+	this->pSaturationTextBox->SetText(temp);
+
 	SetSpeechColorTexts(pCharacter->GetCustomSpeechColor());
 
 	this->pGhostDisplayCheckbox->SetChecked(pCharacter->IsGhostImage());
@@ -137,6 +157,12 @@ void CCharacterOptionsDialog::SetCharacter(
 
 	_itoW(pCharacter->ExtraVars.GetVar(ColorStr, 0), temp, 10, bufferLength);
 	this->pColorTextBox->SetText(temp);
+
+	_itoW(pCharacter->ExtraVars.GetVar(HueStr, 0), temp, 10, bufferLength);
+	this->pHueTextBox->SetText(temp);
+
+	_itoW(pCharacter->ExtraVars.GetVar(SaturationStr, 0), temp, 10, bufferLength);
+	this->pSaturationTextBox->SetText(temp);
 
 	SetSpeechColorTexts(pCharacter->ExtraVars.GetVar(ParamSpeechColorStr, 0));
 
@@ -165,6 +191,18 @@ void CCharacterOptionsDialog::SetSpeechColorTexts(UINT color)
 //*****************************************************************************
 UINT CCharacterOptionsDialog::GetColor(){
 	return (UINT)this->pColorTextBox->GetNumber();
+}
+
+//*****************************************************************************
+UINT CCharacterOptionsDialog::GetHue()
+{
+	return (UINT)this->pHueTextBox->GetNumber();
+}
+
+//*****************************************************************************
+UINT CCharacterOptionsDialog::GetSaturation()
+{
+	return (UINT)this->pSaturationTextBox->GetNumber();
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/CharacterOptionsWidget.h
+++ b/drodrpg/DROD/CharacterOptionsWidget.h
@@ -45,6 +45,8 @@ public:
 
 	CCharacterOptionsDialog();
 
+	CTextBoxWidget *pHueTextBox;
+	CTextBoxWidget *pSaturationTextBox;
 	CTextBoxWidget *pColorTextBox;
 	CTextBoxWidget *pSpeechColorRedTextBox;
 	CTextBoxWidget *pSpeechColorBlueTextBox;
@@ -57,6 +59,8 @@ public:
 	void SetCharacter(const CCharacter *pCharacter);
 	void SetCharacter(HoldCharacter *pCharacter);
 	UINT GetColor();
+	UINT GetHue();
+	UINT GetSaturation();
 	bool GetGhostDisplay();
 	UINT GetSpeechColor();
 	UINT GetProcessSequence();
@@ -72,7 +76,7 @@ private:
 	static const UINT SPACE_CX = 15;
 
 	static const int DIALOG_CX = 400;
-	static const int DIALOG_CY = 390;
+	static const int DIALOG_CY = 480;
 
 	static const int LABEL_CX = 150;
 	static const int LABEL_CY = CY_STANDARD_BUTTON;
@@ -90,9 +94,23 @@ private:
 	static const int TREASURE_BUTTON_X = SPACE_CX;
 	static const int TREASURE_BUTTON_Y = GHOSTDISPLAY_BUTTON_Y + TITLE_CY + SPACE_CY / 2;
 
+	static const int HUELABEL_CX = 150;
+	static const int HUELABEL_X = SPACE_CX;
+	static const int HUELABEL_Y = TREASURE_BUTTON_Y + TITLE_CY + SPACE_CY;
+
+	static const int HUETEXT_X = HUELABEL_X + HUELABEL_CX + SPACE_CX;
+	static const int HUETEXT_Y = HUELABEL_Y;
+
+	static const int SATURATIONLABEL_CX = 150;
+	static const int SATURATIONLABEL_X = SPACE_CX;
+	static const int SATURATIONLABEL_Y = HUELABEL_Y + TITLE_CY + SPACE_CY;
+
+	static const int SATURATIONTEXT_X = SATURATIONLABEL_X + SATURATIONLABEL_CX + SPACE_CX;
+	static const int SATURATIONTEXT_Y = SATURATIONLABEL_Y;
+
 	static const int COLORLABEL_CX = 150;
 	static const int COLORLABEL_X = SPACE_CX;
-	static const int COLORLABEL_Y = TREASURE_BUTTON_Y + TITLE_CY + SPACE_CY;
+	static const int COLORLABEL_Y = SATURATIONLABEL_Y + TITLE_CY + SPACE_CY;
 
 	static const int COLORTEXT_X = COLORLABEL_X + COLORLABEL_CX + SPACE_CX;
 	static const int COLORTEXT_Y = COLORLABEL_Y;

--- a/drodrpg/DROD/EditRoomWidget.cpp
+++ b/drodrpg/DROD/EditRoomWidget.cpp
@@ -1351,6 +1351,7 @@ void CEditRoomWidget::DrawCharacter(
 		TileImageBlitParams blit(pCharacter->wX, pCharacter->wY, wTileImageNo, 0, 0, true, fRaised);
 		blit.nOpacity = opacity;
 		blit.nAddColor = pCharacter->getColor();
+		blit.hsv = pCharacter->getHSV();
 		DrawTileImage(blit, pDestSurface);
 
 		//Draw character with sword.

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -712,7 +712,8 @@ void CGameScreen::RedrawStats(
 			if (i==0)
 			{
 				ASSERT(pCombat->pMonster);
-				this->pRoomWidget->AddColorToTile(pDestSurface, pCombat->pMonster->getColor(), val, X_PIC[i], Y_PIC[i],
+				this->pRoomWidget->AddColorToTile(pDestSurface, pCombat->pMonster->getColor(),
+					pCombat->pMonster->getHSV(), val, X_PIC[i], Y_PIC[i],
 						CBitmapManager::CX_TILE, CBitmapManager::CY_TILE);
 			}
 		}

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -47,6 +47,8 @@
 #include <BackEndLib/CoordStack.h>
 #include <BackEndLib/Types.h>
 
+#include <array>
+
 //Range of weather parameters.
 #define LIGHT_LEVELS (7)	//number of light levels
 #define FOG_INCREMENTS (4)
@@ -189,6 +191,7 @@ struct TileImageBlitParams {
 	Uint8 nOpacity;
 	bool bClipped;
 	int nAddColor;
+	std::array<float, 3> hsv; //hue, saturation, value
 	bool bCastShadowsOnTop;
 	float appliedDarkness; // Normally monsters are drawn with 75% ceiling darkness, but moving T-Objects need to be drawn with the
 						   // same opacity as the stationary ones, which is 100% ceiling darkness, otherwise things look weird.
@@ -214,7 +217,7 @@ public:
 	CRoomWidget(UINT dwSetTagNo, int nSetX, int nSetY, UINT wSetW,
 			UINT wSetH);
 
-	void           AddColorToTile(SDL_Surface* pDestSurface, const int nAddColor, const UINT wTileImageNo,
+	void           AddColorToTile(SDL_Surface* pDestSurface, const int nAddColor, const std::array<float, 3> hsv, const UINT wTileImageNo,
 			const UINT nPixelX, const UINT nPixelY, const UINT wWidth, const UINT wHeight, const int nXOffset=0, const int nYOffset=0);
 	bool           AddDoorEffect(COrbAgentData *pOrbAgent);
 	void           AddInfoSubtitle(CMoveCoord *pCoord, const WSTRING& wstr,

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -49,6 +49,9 @@
 
 const UINT MAX_ANSWERS = 9;
 
+const UINT MAX_HUE = 6000;
+const UINT MAX_SATURATION = 1000;
+
 //Literals used to query and store values for the NPC in the packed vars object.
 //DO NOT CHANGE
 #define commandStr "Commands"
@@ -267,7 +270,7 @@ CCharacter::CCharacter(
 	, customSpeechColor(0)
 	, wLastSpeechLineNumber(0)
 
-	, color(0), sword(NPC_DEFAULT_SWORD)
+	, color(0), hue(0), saturation(0), sword(NPC_DEFAULT_SWORD)
 	, paramX(NO_OVERRIDE), paramY(NO_OVERRIDE), paramW(NO_OVERRIDE), paramH(NO_OVERRIDE), paramF(NO_OVERRIDE)
 	, monsterHPmult(100), monsterATKmult(100), monsterDEFmult(100), monsterGRmult(100), monsterXPmult(100)
 	, itemMult(100), itemHPmult(100), itemATKmult(100), itemDEFmult(100), itemGRmult(100), itemShovelMult(100)
@@ -473,6 +476,10 @@ UINT CCharacter::getPredefinedVarInt(const UINT varIndex) const
 			return this->color;
 		case (UINT)ScriptVars::P_MONSTER_SWORD:
 			return this->sword;
+		case (UINT)ScriptVars::P_MONSTER_HUE:
+			return this->hue;
+		case (UINT)ScriptVars::P_MONSTER_SATURATION:
+			return this->saturation;
 
 		//Room position.
 		case (UINT)ScriptVars::P_MONSTER_X:
@@ -614,6 +621,12 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 		break;
 		case (UINT)ScriptVars::P_MONSTER_SWORD:
 			this->sword = val;
+		break;
+		case (UINT)ScriptVars::P_MONSTER_HUE:
+			this->SetHue(val);
+		break;
+		case (UINT)ScriptVars::P_MONSTER_SATURATION:
+			this->SetSaturation(val);
 		break;
 
 		//Room position.
@@ -5653,6 +5666,24 @@ UINT CCharacter::getColor() const
 }
 
 //*****************************************************************************
+UINT CCharacter::getHue() const
+//Return: monster's hue
+{
+	return this->hue;
+}
+
+//*****************************************************************************
+std::array<float, 3> CCharacter::getHSV() const
+//Return: float-converted color hue, saturation and value
+{
+	float hue = this->hue ? float(this->hue) / MAX_HUE : -1;
+	float saturation = this->saturation ? float(this->saturation) / MAX_SATURATION : -1;
+
+	//Chaning value currently isn't supported
+	return { hue, saturation, -1 };
+}
+
+//*****************************************************************************
 UINT CCharacter::getDEF() const
 //Return: monster's DEF
 //
@@ -5898,6 +5929,8 @@ void CCharacter::ResolveLogicalIdentity(CDbHold *pHold)
 				if (this->commands.empty()) {
 					this->wProcessSequence = this->pCustomChar->ExtraVars.GetVar(ParamProcessSequenceStr, this->wProcessSequence);
 					this->color = this->pCustomChar->ExtraVars.GetVar(ColorStr, this->color);
+					this->hue = this->pCustomChar->ExtraVars.GetVar(HueStr, this->hue);
+					this->saturation = this->pCustomChar->ExtraVars.GetVar(SaturationStr, this->saturation);
 					this->customSpeechColor = this->pCustomChar->ExtraVars.GetVar(ParamSpeechColorStr, this->customSpeechColor);
 					this->bGhostImage = this->pCustomChar->ExtraVars.GetVar(GhostImageStr, this->bGhostImage);
 					this->bMinimapTreasure = this->pCustomChar->ExtraVars.GetVar(MinimapTreasureStr, this->bMinimapTreasure);
@@ -5964,11 +5997,25 @@ void CCharacter::RestartScript()
 	this->GOLD = 0;
 	this->XP = 0;
 	this->color = 0;
+	this->hue = 0;
+	this->saturation = 0;
 	this->sword = NPC_DEFAULT_SWORD;
 
 	//These values are reloaded as they were on setup.
 	this->wLogicalIdentity = this->ExtraVars.GetVar(idStr, this->wLogicalIdentity);
 	this->bVisible = this->ExtraVars.GetVar(visibleStr, this->bVisible);
+}
+
+//*****************************************************************************
+void CCharacter::SetHue(const UINT hue)
+{
+	this->hue = max(0, min(hue, MAX_HUE));
+}
+
+//*****************************************************************************
+void CCharacter::SetSaturation(const UINT saturation)
+{
+	this->saturation = max(0, min(saturation, MAX_SATURATION));
 }
 
 //*****************************************************************************
@@ -6306,6 +6353,8 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 
 	//Stats.
 	this->color = vars.GetVar(ColorStr, this->color);
+	this->hue = vars.GetVar(HueStr, this->hue);
+	this->saturation = vars.GetVar(SaturationStr, this->saturation);
 	this->sword = vars.GetVar(SwordStr, this->sword);
 	this->paramX = vars.GetVar(ParamXStr, this->paramX);
 	this->paramY = vars.GetVar(ParamYStr, this->paramY);
@@ -6470,6 +6519,10 @@ const
 	//Stats.
 	if (this->color)
 		vars.SetVar(ColorStr, this->color);
+	if (this->hue)
+		vars.SetVar(HueStr, this->hue);
+	if (this->saturation)
+		vars.SetVar(SaturationStr, this->saturation);
 	if (this->sword != NPC_DEFAULT_SWORD)
 		vars.SetVar(SwordStr, this->sword);
 	if (this->paramX != NO_OVERRIDE)

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5673,6 +5673,13 @@ UINT CCharacter::getHue() const
 }
 
 //*****************************************************************************
+UINT CCharacter::getSaturation() const
+//Return: monster's saturation
+{
+	return this->saturation;
+}
+
+//*****************************************************************************
 std::array<float, 3> CCharacter::getHSV() const
 //Return: float-converted color hue, saturation and value
 {

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -128,6 +128,7 @@ public:
 	virtual UINT   getATK() const;   //allow "negative" values to be returned
 	virtual UINT   getColor() const;
 	virtual UINT   getHue() const;
+	virtual UINT   getSaturation() const;
 	virtual std::array<float, 3> getHSV() const;
 	virtual UINT   getDEF() const;   //allow "negative" values to be returned
 	virtual UINT   getSword() const;

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -58,6 +58,8 @@ using std::vector;
 #define DefaultCustomCharacterName wszEmpty
 #define ParamProcessSequenceStr "ProcessSequenceParam"
 #define ColorStr "Color"
+#define HueStr "Hue"
+#define SaturationStr "Saturation"
 #define ParamSpeechColorStr "SpeechColorParam"
 #define GhostImageStr "GhostImage"
 #define MinimapTreasureStr "MinimapTreasure"
@@ -125,6 +127,8 @@ public:
 
 	virtual UINT   getATK() const;   //allow "negative" values to be returned
 	virtual UINT   getColor() const;
+	virtual UINT   getHue() const;
+	virtual std::array<float, 3> getHSV() const;
 	virtual UINT   getDEF() const;   //allow "negative" values to be returned
 	virtual UINT   getSword() const;
 
@@ -216,6 +220,8 @@ public:
 	static void    SaveSpeech(const COMMAND_VECTOR& commands);
 	static void    SaveSpeech(const COMMANDPTR_VECTOR& commands);
 	virtual void   SetColor(const UINT color) { this->color = color; }
+	virtual void   SetHue(const UINT hue);
+	virtual void   SetSaturation(const UINT saturation);
 	virtual void   SetCurrentGame(const CCurrentGame *pSetCurrentGame);
 	virtual void   SetCustomSpeechColor(const UINT color) { this->customSpeechColor = color; }
 	virtual void   SetExtraVarsForExport() { PackExtraVars(true); } //include config params and script
@@ -356,7 +362,7 @@ private:
 	vector<UINT> jumpStack; //maintains index of GoTo commands executed, for Return commands
 
 	//Predefined vars.
-	UINT color, sword; //cosmetic details
+	UINT color, sword, hue, saturation; //cosmetic details
 	UINT paramX, paramY, paramW, paramH, paramF; //script-definable script command parameter overrides
 	UINT monsterHPmult, monsterATKmult, monsterDEFmult, monsterGRmult, monsterXPmult; // monster stat modifiers
 	UINT itemMult, itemHPmult, itemATKmult, itemDEFmult, itemGRmult, itemShovelMult; // item value modifiers

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -1036,6 +1036,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_Command_Script_FromText: strText = "Import Script Commands"; break;
 		case MID_CollectableGroup: strText = "Collectable items"; break;
 		case MID_EnableAutosaves: strText = "Enable autosaves"; break;
+		case MID_VarMonsterHue: strText = "_MyHue"; break;
+		case MID_VarMonsterSaturation: strText = "_MySaturation"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1545,6 +1545,13 @@ UINT CMonster::getColor() const
 }
 
 //*****************************************************************************
+std::array<float, 3 > CMonster::getHSV() const
+//Return: float-converted color hue, saturation and value
+{
+	return { -1, -1, -1 }; //no changes by default
+}
+
+//*****************************************************************************
 UINT CMonster::getDEF() const
 //Return: monster's DEF
 {

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -78,6 +78,7 @@
 #include <BackEndLib/MessageIDs.h>
 #include <BackEndLib/AttachableObject.h>
 
+#include <array>
 #include <list>
 using std::list;
 
@@ -214,6 +215,7 @@ public:
 	virtual UINT  getHP() const;
 	virtual UINT  getSword() const;
 	virtual int   getXP() const; //may be negative
+	virtual std::array<float, 3> getHSV() const;
 
 	virtual bool  HasCustomWeakness() const {return false;}
 	virtual bool  HasGoblinWeakness() const {return false;}

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -49,6 +49,7 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][16] =
 	"_Beam", "_Firetrap",
 	"", "",
 	"_MudSwap", "_TarSwap", "_GelSwap",
+	"", "",
 };
 
 //Message texts corresponding to the above short var texts.
@@ -84,6 +85,7 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarBeam, MID_VarFiretrap,
 	MID_VarTotalAtk, MID_VarTotalDef,
 	MID_VarMudSwap, MID_VarTarSwap, MID_VarGelSwap,
+	MID_VarMonsterHue, MID_VarMonsterSaturation
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -159,7 +159,9 @@ namespace ScriptVars
 		P_MUD_SWAP = -102,
 		P_TAR_SWAP = -103,
 		P_GEL_SWAP = -104,
-		FirstPredefinedVar = P_GEL_SWAP, //set this to the last var in the enumeration
+		P_MONSTER_HUE = -105,
+		P_MONSTER_SATURATION = -106,
+		FirstPredefinedVar = P_MONSTER_SATURATION, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -677,6 +677,10 @@ The variable names are case-insensitive.
   </tr><tr>
     <td>_MyColor</td><td>NPC's RGB modifier (<a href="#mycolor">*</a>)</td><td>505050</td><td>000000,999999</td>
   </tr><tr>
+    <td>_MyHue</td><td>NPC's base color modifier (<a href="#myhue">*</a>)</td><td>0</td><td>0,6000</td>
+  </tr><tr>
+    <td>_MySaturation</td><td>NPC's color strength modifier (<a href="#mysaturation">*</a>)</td><td>0</td><td>0,1000</td>
+  </tr><tr>
     <td>_MySword</td><td>NPC's sword type (<a href="#mysword">*</a>)</td><td>-1 (use base type)</td><td>-1,9</td>
 	</tr><tr>
     <td>_MyWeakness</td><td>NPC's custom weakness type (<a href="#myweakness">*</a>)</td><td></td><td>Text</td>
@@ -871,7 +875,20 @@ The variable names are case-insensitive.
   two-digit pair defines the
   amount of R/G/B color offset to the NPC's image.  A value of 50 is normal.
   Lower values (0-49) remove a proportionate amount of that color.
-  Greater values (51-99) enhance that color.
+  Greater values (51-99) enhance that color. This alteration is applied after changes
+  to hue and saturation.
+</p>
+<p><a name="myhue"><b>*_MyHue</b></a> - a number between 0 and 6000, inclusive. If it
+    is set to a non-zero value, it will change the base color of the NPC's image. At a 
+    value of 1, the image is shifted to red. Increasing values will shift to orange, yellow,
+    blue, green, indigo and violet, before cyling back to red as the value reachs 6000. Black,
+    white and greys in the character's image are not affected by this change.
+</p>
+<p>
+    <a name="mysaturation"><b>*_MySaturation</b></a> - a number between 0 and 1000,
+    inclusive. If it is set to a non-zero value, it will change the base colors of
+    the NPC's image. Lower values make the colors less intense, while higher values
+    make them more intense.
 </p>
 <p><a name="mysword"><b>*_MySword</b></a> - set this to change what kind of
   sword the NPC wields.  This affects the NPC's appearance only, and does

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -881,7 +881,7 @@ The variable names are case-insensitive.
 <p><a name="myhue"><b>*_MyHue</b></a> - a number between 0 and 6000, inclusive. If it
     is set to a non-zero value, it will change the base color of the NPC's image. At a 
     value of 1, the image is shifted to red. Increasing values will shift to orange, yellow,
-    blue, green, indigo and violet, before cyling back to red as the value reachs 6000. Black,
+    blue, green, indigo and violet, before cyling back to red as the value approaches 6000. Black,
     white and greys in the character's image are not affected by this change.
 </p>
 <p>

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1822,6 +1822,8 @@ enum MID_CONSTANT {
   MID_VarFiretrap = 1890,
   MID_VarTotalAtk = 1897,
   MID_VarTotalDef = 1898,
+  MID_VarMonsterHue = 2077,
+  MID_VarMonsterSaturation = 2078,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -393,3 +393,11 @@ _TotalATK
 [MID_VarTotalDef]
 [eng]
 _TotalDEF
+
+[MID_VarMonsterHue]
+[eng]
+_MyHue
+
+[MID_VarMonsterSaturation]
+[eng]
+_MySaturation


### PR DESCRIPTION
A much-desired feature to alter character colours. `_MyHue` sets the hue, and `_MySaturation` sets the saturation. It's quite obvious. They both have value ranges which were picked somewhat arbitarily, and can be changed anytime before release.

It might be nicer to have true hue-shifting, but I ran into some issues with that. For now, setting the hue works, even it sometimes blasts away some details.