### PR TITLE
RPG: Fix serialization of changed character movement

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -224,6 +224,7 @@ CCharacter::CCharacter(
 	, bAttacked(false)
 	, equipType(ScriptFlag::NotEquipment)
 	, movementIQ(SmartDiagonalOnly)
+	, bMovementChanged(false)
 
 	, wCurrentCommandIndex(0)
 	, wTurnDelay(0)
@@ -2942,6 +2943,7 @@ void CCharacter::Process(
 
 				const MovementType eNewMovementType = (MovementType)command.x;
 				this->eMovement = eNewMovementType;
+				bMovementChanged = true;
 			}
 			break;
 
@@ -6036,6 +6038,8 @@ void CCharacter::SetDefaultMovementType()
 			eMovement = MovementType::GROUND;
 		break;
 	}
+
+	bMovementChanged = false;
 }
 
 //*****************************************************************************
@@ -6300,6 +6304,7 @@ void CCharacter::setBaseMembers(const CDbPackedVars& vars)
 
 	if (vars.DoesVarExist(MovementTypeStr)) {
 		this->eMovement = (MovementType)vars.GetVar(MovementTypeStr, this->eMovement);
+		bMovementChanged = true;
 	} else {
 		SetDefaultMovementType();
 	}
@@ -6464,7 +6469,7 @@ const
 		vars.SetVar(MistImmuneStr, this->bMistImmune);
 	if (this->bWallDwelling)
 		vars.SetVar(WallDwellingStr, this->bWallDwelling);
-	if (this->eMovement)
+	if (this->bMovementChanged)
 		vars.SetVar(MovementTypeStr, this->eMovement);
 
 	//Stats.

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -251,6 +251,7 @@ public:
 	bool  bAttacked;        //only one behavior-based attack per turn is allowed
 	ScriptFlag::EquipmentType equipType;//what type of inventory I represent
 	MovementIQ movementIQ;  //movement behavior
+	bool  bMovementChanged; //movement type is changed
 	bool  bParseIfElseAsCondition; //a multi-turn elseif sequence is in play
 
 private:


### PR DESCRIPTION
In short, ground movement type would never get saved due to being value zero, and monsters with non-ground movement would save it from the editor, causing weirdness if you changed their type. A new flag should fix this issue.