### PR TITLE
RPG: Preserve local high scores through hold update

### DIFF
--- a/drodrpg/DRODLib/Db.cpp
+++ b/drodrpg/DRODLib/Db.cpp
@@ -798,6 +798,17 @@ CIDSet CDb::getLevelsInHold(const UINT holdID)
 }
 
 //*****************************************************************************
+CIDSet CDb::getLocalHighscoresForHold(const UINT holdID)
+//Returns: set of local highScoreIDs belong to this hold
+{
+	CIDSet IDs;
+	CDb db;
+	db.HighScores.FilterByHold(holdID);
+	db.HighScores.GetIDs(IDs);
+	return IDs;
+}
+
+//*****************************************************************************
 CIDSet CDb::getRoomsInHold(const UINT holdID)
 //Returns: set of roomIDs belonging to this hold, or empty set if level doesn't exist
 {

--- a/drodrpg/DRODLib/Db.h
+++ b/drodrpg/DRODLib/Db.h
@@ -126,6 +126,7 @@ public:
 	static CIDSet getDemosInRoom(const UINT roomID);
 	static UINT   getHoldOfDemo(const UINT demoID);
 	static CIDSet getLevelsInHold(const UINT holdID);
+	static CIDSet getLocalHighscoresForHold(const UINT holdID);
 	static CIDSet getRoomsInHold(const UINT holdID);
 	static CIDSet getRoomsInLevel(const UINT levelID);
 	static UINT   getSavedGameOfDemo(const UINT demoID);

--- a/drodrpg/DRODLib/DbHolds.cpp
+++ b/drodrpg/DRODLib/DbHolds.cpp
@@ -3018,6 +3018,7 @@ MESSAGE_ID CDbHold::SetProperty(
 
 				case CImportInfo::Demo:
 				case CImportInfo::SavedGame:
+				case CImportInfo::HighScore:
 					//A saved game/demo in this hold is being imported.
 					//No hold version checking is done.
 					bSaveRecord = false;

--- a/drodrpg/DRODLib/ImportInfo.h
+++ b/drodrpg/DRODLib/ImportInfo.h
@@ -101,7 +101,8 @@ public:
 		Hold,
 		Player,
 		SavedGame,
-		LanguageMod
+		LanguageMod,
+		HighScore,
 	};
 	ImportType  typeBeingImported;
 
@@ -113,7 +114,8 @@ public:
 	CIDSet localHoldIDs;
 	std::set<WSTRING> roomStyles; //room style references encountered in import
 
-	string   exportedDemos, exportedSavedGames;  //saved games temporarily exported while hold is being upgraded
+	string   exportedDemos, exportedSavedGames,
+		exportedHighScores;  //saved games temporarily exported while hold is being upgraded
 	WSTRING  userMessages;     //text messages for the user's convenience
 
 	MESSAGE_ID ImportStatus;   //result of import process


### PR DESCRIPTION
Local high scores are exported as part of players, not saved games or demos. This means that they get destroyed when updating a hold. This is bad.

I've now added the mechanisms required to export and import high score data during a hold update.