### PR TITLE
RPG: Add cue event on scripted character back strike.

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4419,7 +4419,7 @@ void CCharacterDialogWidget::PopulateEventListBox()
 	this->pEventListBox->AddItem(CID_FuseBurning, g_pTheDB->GetMessageText(MID_FuseBurning));
 	this->pEventListBox->AddItem(CID_GelBabyFormed, g_pTheDB->GetMessageText(MID_GelBabyFormed));
 //	this->pEventListBox->AddItem(CID_GelGrew, g_pTheDB->GetMessageText(MID_GelGrew));
-	this->pEventListBox->AddItem(CID_GoblinAttacks, g_pTheDB->GetMessageText(MID_GoblinAttacks));
+	this->pEventListBox->AddItem(CID_EnemySneakAttack, g_pTheDB->GetMessageText(MID_EnemySneakAttack));
 	this->pEventListBox->AddItem(CID_HitObstacle, g_pTheDB->GetMessageText(MID_HitObstacle));
 	this->pEventListBox->AddItem(CID_ItemUsed, g_pTheDB->GetMessageText(MID_ItemUsed));
 	this->pEventListBox->AddItem(CID_Jump, g_pTheDB->GetMessageText(MID_PlayerJumped));

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -6508,7 +6508,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		ProcessFuseBurningEvents(CueEvents);
 
 	//3rd. Monster actions.
-	if (CueEvents.HasOccurred(CID_GoblinAttacks))
+	if (CueEvents.HasOccurred(CID_EnemySneakAttack))
 		g_pTheSound->PlaySoundEffect(SEID_HIT);
 
 	for (pObj = CueEvents.GetFirstPrivateData(CID_SnakeDiedFromTruncation);

--- a/drodrpg/DRODLib/Ant.cpp
+++ b/drodrpg/DRODLib/Ant.cpp
@@ -50,6 +50,6 @@ void CAnt::Process(
 	FaceTarget();
 
 	if (AttackPlayerWhenAdjacent(CueEvents))
-		CueEvents.Add(CID_GoblinAttacks);
+		CueEvents.Add(CID_EnemySneakAttack);
 }
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3771,8 +3771,9 @@ Finish:
 
 			if (this->bAttackInFrontWhenBackIsTurned && !this->bAttacked)
 			{
-				this->bAttacked = true;
 				this->bAttacked = AttackPlayerInFrontWhenBackIsTurned(CueEvents);
+				if (this->bAttacked)
+					CueEvents.Add(CID_EnemySneakAttack);
 			}
 		}
 	}

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -191,10 +191,10 @@ enum CUEEVENT_ID
 	//Private data: CDbMessageText *pScrollText (one)
 	CID_StepOnScroll,
 
-	//A goblin attacks the player from behind.
+	//An enemy attacks the player from behind.
 	//
 	//Private data: NONE
-	CID_GoblinAttacks,
+	CID_EnemySneakAttack,
 
 	//A score checkpoint is triggered.
 	//

--- a/drodrpg/DRODLib/Goblin.cpp
+++ b/drodrpg/DRODLib/Goblin.cpp
@@ -46,5 +46,5 @@ void CGoblin::Process(
 	FaceTarget();
 
 	if (AttackPlayerInFrontWhenBackIsTurned(CueEvents))
-		CueEvents.Add(CID_GoblinAttacks);
+		CueEvents.Add(CID_EnemySneakAttack);
 }

--- a/drodrpg/DRODLib/Seep.cpp
+++ b/drodrpg/DRODLib/Seep.cpp
@@ -50,5 +50,5 @@ void CSeep::Process(
 	FaceTarget();
 
 	if (AttackPlayerWhenAdjacent(CueEvents))
-		CueEvents.Add(CID_GoblinAttacks);
+		CueEvents.Add(CID_EnemySneakAttack);
 }

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1355,7 +1355,7 @@ enum MID_CONSTANT {
   MID_PushObjects = 1688,
   MID_EvilEyeWoke = 1015,
   MID_FuseBurning = 1016,
-  MID_GoblinAttacks = 1353,
+  MID_EnemySneakAttack = 1353,
   MID_HitObstacle = 1018,
   MID_ItemUsed = 1512,
   MID_MirrorShattered = 1168,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -286,9 +286,9 @@ Evil eye woke
 [eng]
 Fuse burning
 
-[MID_GoblinAttacks]
+[MID_EnemySneakAttack]
 [eng]
-Goblin attacks
+Enemy sneak attack
 
 [MID_HitObstacle]
 [eng]


### PR DESCRIPTION
Fixes missing sfx and not catching this event in scripts.