### PR TITLE
RPG: Fix rooms with icons revealed by a map element not resetting on room restart.

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -4446,11 +4446,6 @@ void CCurrentGame::SaveToContinue()
 	if (this->bNoSaves)
 		return;
 
-	/*
-	bool bExploredOnEntrance;
-	const bool bConqueredOnEntrance = SavePrep(bExploredOnEntrance);
-	*/
-
 	//Must store what state game was in on room entrance, so when moves are
 	//replayed, we'll end up at the current state once more.
 	CDbPackedVars _stats = this->stats;
@@ -7640,8 +7635,7 @@ void CCurrentGame::SetRoomStartToPlayer()
 	PackData(this->stats);
 	this->statsAtRoomStart = this->stats;
 	this->roomsExploredAtRoomStart = GetExploredRooms();
-	this->roomsMappedAtRoomStart = GetMappedRooms();
-	this->roomsMappedAtRoomStart += GetInvisibleRooms();
+	this->roomsMappedAtRoomStart = GetMappedRoomsWithState();
 
 	this->mapIconsAtRoomStart.clear();
 	for (vector<ExploredRoom*>::const_iterator room = this->ExploredRooms.begin();

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -414,7 +414,8 @@ public:
 //	bool     bWaitedOnHotFloorLastTurn;
 	CDbPackedVars statsAtRoomStart; //stats when room was begun
 	map<UINT, map<int, int>> scriptArraysAtRoomStart;
-	CIDSet   roomsExploredAtRoomStart, roomsMappedAtRoomStart;
+	CIDSet   roomsExploredAtRoomStart;
+	RoomMapStates roomsMappedAtRoomStart;
 	map <UINT, pair<ScriptVars::MapIcon, ScriptVars::MapIconState>> mapIconsAtRoomStart;
 	vector<CMoveCoordEx> ambientSounds;  //ambient sounds playing now
 	vector<SpeechLog> roomSpeech; //speech played up to this moment in the current room

--- a/drodrpg/DRODLib/DbSavedGames.h
+++ b/drodrpg/DRODLib/DbSavedGames.h
@@ -109,6 +109,8 @@ struct SAVE_INFO {
 
 typedef std::multimap<UINT, SAVE_INFO> SORTED_SAVES;
 
+typedef map<UINT, MapState> RoomMapStates;
+
 //******************************************************************************************
 class CDbSavedGames;
 class CCurrentGame;
@@ -159,7 +161,7 @@ public:
 	ExploredRoom* getExploredRoom(const UINT roomID) const;
 	CIDSet    GetExploredRooms(const bool bMapOnlyAlso=false, const bool bIncludeNoSavedAlso=true) const;
 	CIDSet    GetMappedRooms() const {return GetExploredRooms(true);}
-	CIDSet    GetInvisibleRooms() const;
+	RoomMapStates GetMappedRoomsWithState() const;
 	bool      IsRoomExplored(const UINT roomID, const bool bConsiderCurrentRoom=true) const;
 	void      LoadExploredRooms(const c4_View& ExploredRoomsView);
 	CMonster* LoadMonster(const c4_RowRef& row);
@@ -167,7 +169,7 @@ public:
 	void      ReloadMonsterList(CMonster *pAlternateMonsterList=NULL);
 	void      removeGlobalScriptForEquipment(const UINT type);
 	void      removeGlobalScripts(const CIDSet& completedScripts);
-	void      RemoveMappedRoomsNotIn(const CIDSet& exploredRoomIDs, const CIDSet& mappedRoomIDs,
+	void      RemoveMappedRoomsNotIn(const CIDSet& exploredRoomIDs, const RoomMapStates& mappedRoomIDs,
 			const CIDSet& roomPreviewIDs);
 	void      SetMonsterListAtRoomStart();
 	void      setMonstersCurrentGame(CCurrentGame* pCurrentGame);


### PR DESCRIPTION
The core change is to keep track of mapState for RemoveMappedRoomsNotIn().