### PR TITLE
RPG: Fix bad logic in IsRoomExplored.

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -7795,11 +7795,12 @@ void CCurrentGame::SetPlayerToRoomStart()
 		roomIter != this->ExploredRooms.end(); ++roomIter)
 	{
 		ExploredRoom* pExpRoom = *roomIter;
-		map<UINT, pair<ScriptVars::MapIcon, ScriptVars::MapIconState>>::const_iterator finder =
+		map<UINT, MapIconPair>::const_iterator finder =
 			this->mapIconsAtRoomStart.find(pExpRoom->roomID);
 		if (finder != this->mapIconsAtRoomStart.end()) {
-			pExpRoom->mapIcon = finder->second.first;
-			pExpRoom->mapIconState = finder->second.second;
+			const MapIconPair mapIconPair = finder->second;
+			pExpRoom->mapIcon = mapIconPair.first;
+			pExpRoom->mapIconState = mapIconPair.second;
 		}
 	}
 

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -188,6 +188,8 @@ struct TarstuffStab {
 	CMonster* pTarstuffMonster;
 };
 
+typedef pair<ScriptVars::MapIcon, ScriptVars::MapIconState> MapIconPair;
+
 //*******************************************************************************
 class CCombat;
 class CDb;
@@ -419,7 +421,7 @@ public:
 	map<UINT, map<int, int>> scriptArraysAtRoomStart;
 	CIDSet   roomsExploredAtRoomStart;
 	RoomMapStates roomsMappedAtRoomStart;
-	map <UINT, pair<ScriptVars::MapIcon, ScriptVars::MapIconState>> mapIconsAtRoomStart;
+	map <UINT, MapIconPair> mapIconsAtRoomStart;
 	vector<CMoveCoordEx> ambientSounds;  //ambient sounds playing now
 	vector<SpeechLog> roomSpeech; //speech played up to this moment in the current room
 //	bool     bRoomExitLocked; //safety to prevent player from exiting room when set


### PR DESCRIPTION
ExploredRooms objects should be scanned after checking the current room. Otherwise, the current room may not appear as explored (e.g., when a map icon is defined for the current room, then picking up a map, then restarting the room).