### PR TITLE
Fix crash with zero command image overlay

### DIFF
--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -171,6 +171,9 @@ bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElaps
 	if (!this->pImageSurface)
 		return false;
 
+	if (this->commands.empty())
+		return false;
+
 	if ((endTime > 0 && dwTimeElapsed >= endTime) ||
 		(endTurn > 0 && GetGameTurn() >= endTurn))
 		return false;


### PR DESCRIPTION
If a `CImageOverlayEffect` is created with no commands, it will cause a crash when it tries to update. Easily fixed with a sanity check in `CImageOverlayEffect::Update`