### PR TITLE
RPG: Support multiple custom weaknesses

### DIFF
--- a/BackEndLib/Wchar.cpp
+++ b/BackEndLib/Wchar.cpp
@@ -909,6 +909,22 @@ const std::vector<WSTRING> WCSExplode(WSTRING const &source, WCHAR const delimit
 }
 
 //*****************************************************************************
+const std::set<WSTRING> WCSExplodeSet(WSTRING const& source, WCHAR const delimiter)
+// Explodes a string into pieces, and put them into a set
+{
+	std::set<WSTRING> result;
+	std::wistringstream iss(source);
+
+	for (WSTRING token; std::getline(iss, token, delimiter); )
+	{
+		if (!token.empty())
+			result.insert(token);
+	}
+
+	return result;
+}
+
+//*****************************************************************************
 bool WCSContainsAll(WSTRING const &haystack, std::vector<WSTRING> const &needles)
 // Returns true if haystack contains every string in needle, even if they overlap
 {

--- a/BackEndLib/Wchar.h
+++ b/BackEndLib/Wchar.h
@@ -36,6 +36,7 @@
 #include "Types.h"  //need BYTE, UINT
 
 #include <cstring>
+#include <set>
 #include <vector>
 
 #define STRFY(x) #x
@@ -165,6 +166,7 @@ std::string strReplace(std::string const &source, std::string const &from, std::
 WSTRING WCSReplace(WSTRING const &source, WSTRING const &from, WSTRING const &to);
 WSTRING WCSToLower(WSTRING const& source);
 const std::vector<WSTRING> WCSExplode(WSTRING const& source, WCHAR const delimiter);
+const std::set<WSTRING>    WCSExplodeSet(WSTRING const& source, WCHAR const delimiter);
 bool WCSContainsAll(WSTRING const& haystack, std::vector<WSTRING> const& needles);
 
 

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -166,14 +166,21 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 	}
 	if (pCharacter->HasCustomWeakness())
 	{
-		if (needSeparator)
-			text += separator;
-		text += WCSReplace(
-			g_pTheDB->GetMessageText(MID_StrongAgainstType),
-			wszStringToken,
-			pCharacter->GetCustomWeakness()
-		);
-		needSeparator = true;
+		std::set<WSTRING> weaknesses = pCharacter->GetCustomWeaknesses();
+		for (std::set<WSTRING>::const_iterator iter = weaknesses.cbegin();
+			iter != weaknesses.cend(); ++iter) {
+			const WSTRING weakness = *iter;
+			if (needSeparator)
+				text += separator;
+
+			text += WCSReplace(
+				g_pTheDB->GetMessageText(MID_StrongAgainstType),
+				wszStringToken,
+				weakness
+			);
+
+			needSeparator = true;
+		}
 	}
 	if (pCharacter->HasRayBlocking())
 	{

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2201,19 +2201,25 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		++count;
 	}
 	if (bCustomWeakness) {
-		if (count)
-		{
-			wstr += wszComma;
-			wstr += wszSpace;
-		}
 		CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
 		ASSERT(pCharacter);
-		wstr += WCSReplace(
-			g_pTheDB->GetMessageText(MID_CustomType),
-			wszStringToken,
-			pCharacter->GetCustomWeakness()
-		);
-		++count;
+		std::set<WSTRING> weaknesses = pCharacter->GetCustomWeaknesses();
+		for (std::set<WSTRING>::const_iterator iter = weaknesses.cbegin();
+			iter != weaknesses.cend(); ++iter) {
+			const WSTRING weakness = *iter;
+			if (count)
+			{
+				wstr += wszComma;
+				wstr += wszSpace;
+			}
+		
+			wstr += WCSReplace(
+				g_pTheDB->GetMessageText(MID_CustomType),
+				wszStringToken,
+				weakness
+			);
+			++count;
+		}
 	}
 	if (bCustomDescription) {
 		CCharacter* pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5441,6 +5441,13 @@ vector<WSTRING> CCharacter::GetCustomDescriptions() const
 	return WCSExplode(this->customDescription, *wszSemicolon);
 }
 
+//*****************************************************************************
+//Returns: custom weaknesses for the NPC, divided into a set
+set<WSTRING> CCharacter::GetCustomWeaknesses() const
+{
+	return WCSExplodeSet(this->customWeakness, *wszSemicolon);
+}
+
 UINT CCharacter::GetSpawnType(UINT defaultMonsterID) const
 {
 	if (this->wSpawnType >= 0) {

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -52,6 +52,7 @@
 #include "PlayerDouble.h"
 #include "PlayerStats.h"
 
+#include <set>
 #include <vector>
 using std::vector;
 
@@ -113,7 +114,7 @@ public:
 	void           FailedIfCondition();
 	const CCharacterCommand* GetCommandWithLabel(const UINT label) const;
 	vector<WSTRING> GetCustomDescriptions() const;
-	WSTRING        GetCustomWeakness() const { return this->customWeakness; };
+	std::set<WSTRING> GetCustomWeaknesses() const;
 	virtual UINT   GetIdentity() const {return this->wIdentity;}
 	virtual UINT   GetLogicalIdentity() const {return this->wLogicalIdentity;}
 	UINT           GetNextSpeechID();

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -4242,8 +4242,14 @@ bool CCurrentGame::IsEquipmentStrongAgainst(const CMonster* pMonster, const UINT
 		if (pMonster->HasCustomWeakness() && pEquipment->HasCustomWeakness()) {
 			const CCharacter* pCharacter = dynamic_cast<const CCharacter*>(pMonster);
 			ASSERT(pCharacter);
-			if (pCharacter->GetCustomWeakness() == pEquipment->GetCustomWeakness())
-				return true;
+			std::set<WSTRING> equipStrengths = pEquipment->GetCustomWeaknesses();
+			std::set<WSTRING> characterWeaknesses = pCharacter->GetCustomWeaknesses();
+			for (std::set<WSTRING>::const_iterator iter = equipStrengths.cbegin();
+				iter != equipStrengths.cend(); ++iter) {
+				if (characterWeaknesses.count(*iter) > 0) {
+					return true;
+				}
+			}
 		}
 	}
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -905,7 +905,7 @@ The variable names are case-insensitive.
   available choices, numbered in order of appearance.
   A value of 0 indicates no sword.
 </p>
-<p><a name="myweakness"><b>*_MyWeakness</b></a> - Allows a custom weakness to be set for a monster or equipment. A weapon or accessory is strong (i.e. player gets x2 ATK) against a monster if both _MyWeakness values are the same. A shield can also be strong against a monster, and will give x2 DEF against attacks from it. The comparison is case-sensitive, so for example the values "Eyeball" and "eyeball" would not be considered the same.
+<p><a name="myweakness"><b>*_MyWeakness</b></a> - Allows a custom weakness to be set for a monster or equipment. A semi-colon can be used to split the weakness into multiple weaknessess that are checked separately. A weapon or accessory is strong (i.e. player gets x2 ATK) against a monster if the two have a matching _MyWeakness value. A shield can also be strong against a monster, and will give x2 DEF against attacks from it. The comparison is case-sensitive, so for example the values "Eyeball" and "eyeball" would not be considered the same.
 </p>
 <p><a name="mydescription"><b>*_MyDescription</b></a> - A custom description property that can be set for a monster or equipment. It will be displayed after any behavior descriptors that apply to the character. A semi-colon can be used to split the description into multiple descriptors that will be displayed separately.
 </p>


### PR DESCRIPTION
Allows `_MyWeakness` values to be split up using semi-colons, to have multiple weakness categories on the same custom monster or equipment.