### PR TITLE
RPG: Make some ability descriptions shorter

### DIFF
--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -103,7 +103,7 @@ WSTRING EquipmentDescription::GetPredefinedWeaponAbility(
 		break;
 		case SwordType::SerpentSword: {
 			wstr += separator;
-			wstr += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Serpent));
+			wstr += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Wyrm));
 		}
 		break;
 		case SwordType::BriarSword: {
@@ -161,7 +161,7 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 	{
 		if (needSeparator)
 			text += separator;
-		text += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Serpent));
+		text += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Wyrm));
 		needSeparator = true;
 	}
 	if (pCharacter->HasCustomWeakness())

--- a/drodrpg/DROD/EquipmentDescription.cpp
+++ b/drodrpg/DROD/EquipmentDescription.cpp
@@ -88,7 +88,7 @@ WSTRING EquipmentDescription::GetPredefinedWeaponAbility(
 	switch (type) {
 		case SwordType::GoblinSword: {
 			wstr += separator;
-			wstr += g_pTheDB->GetMessageText(MID_BehaviorGoblinWeakness);
+			wstr += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Goblin));
 		}
 		break;
 		case SwordType::ReallyBigSword: {
@@ -103,7 +103,7 @@ WSTRING EquipmentDescription::GetPredefinedWeaponAbility(
 		break;
 		case SwordType::SerpentSword: {
 			wstr += separator;
-			wstr += g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness);
+			wstr += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Serpent));
 		}
 		break;
 		case SwordType::BriarSword: {
@@ -154,14 +154,14 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 	{
 		if (needSeparator)
 			text += separator;
-		text += g_pTheDB->GetMessageText(MID_BehaviorGoblinWeakness);
+		text += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Goblin));
 		needSeparator = true;
 	}
 	if (pCharacter->HasSerpentWeakness())
 	{
 		if (needSeparator)
 			text += separator;
-		text += g_pTheDB->GetMessageText(MID_BehaviorSerpentWeakness);
+		text += MakeStrongAgainstDescription(g_pTheDB->GetMessageText(MID_Serpent));
 		needSeparator = true;
 	}
 	if (pCharacter->HasCustomWeakness())
@@ -173,11 +173,7 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 			if (needSeparator)
 				text += separator;
 
-			text += WCSReplace(
-				g_pTheDB->GetMessageText(MID_StrongAgainstType),
-				wszStringToken,
-				weakness
-			);
+			text += MakeStrongAgainstDescription(weakness);
 
 			needSeparator = true;
 		}
@@ -303,4 +299,14 @@ WSTRING EquipmentDescription::GetEquipmentAbility(
 	}
 
 	return text;
+}
+
+//*****************************************************************************
+WSTRING EquipmentDescription::MakeStrongAgainstDescription(const WSTRING& type)
+{
+	return WCSReplace(
+		g_pTheDB->GetMessageText(MID_StrongAgainstType),
+		wszStringToken,
+		type
+	);
 }

--- a/drodrpg/DROD/EquipmentDescription.h
+++ b/drodrpg/DROD/EquipmentDescription.h
@@ -41,4 +41,6 @@ public:
 		ScriptFlag::EquipmentType equipType,
 		const WSTRING& separator
 	);
+
+	static WSTRING MakeStrongAgainstDescription(const WSTRING& type);
 };

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2227,7 +2227,7 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		wstr += WCSReplace(
 			g_pTheDB->GetMessageText(MID_CustomType),
 			wszStringToken,
-			g_pTheDB->GetMessageText(MID_Serpent)
+			g_pTheDB->GetMessageText(MID_Wyrm)
 		);
 
 		++count;

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2006,6 +2006,8 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 	bool bSurprisedBehind = pMonster->wType == M_EYE || pMonster->wType == M_MADEYE;
 	bool bAttackInFrontWhenBack = pMonster->wType == M_GOBLIN || pMonster->wType == M_GOBLINKING;
 	bool bSpawnEggs = pMonster->wType == M_QROACH;
+	bool bGoblinWeakness = pMonster->HasGoblinWeakness();
+	bool bSerpentWeakness = pMonster->HasSerpentWeakness();
 	bool bCustomWeakness = false, bCustomDescription = false;
 	bool bExplosiveSafe = pMonster->IsExplosiveSafe();
 	bool bMistImmune = pMonster->IsMistImmune();
@@ -2198,6 +2200,36 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 			wstr += wszSpace;
 		}
 		wstr += g_pTheDB->GetMessageText(MID_WallMirrorSafe);
+		++count;
+	}
+	if (bGoblinWeakness) {
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+
+		wstr += WCSReplace(
+			g_pTheDB->GetMessageText(MID_CustomType),
+			wszStringToken,
+			g_pTheDB->GetMessageText(MID_Goblin)
+		);
+
+		++count;
+	}
+	if (bSerpentWeakness) {
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+
+		wstr += WCSReplace(
+			g_pTheDB->GetMessageText(MID_CustomType),
+			wszStringToken,
+			g_pTheDB->GetMessageText(MID_Serpent)
+		);
+
 		++count;
 	}
 	if (bCustomWeakness) {

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -838,6 +838,11 @@ const WCHAR* CDbBase::GetMessageText(
 	{
 		//TODO 2.0: remove all of these when building barebones and release build dat files
 		case MID_NewLevel: strText = "(add new level)"; break;
+		case MID_EyeAbility: strText = "Strikes in front"; break;
+		case MID_RoachQueenAbility: strText = "Spawns eggs"; break;
+		case MID_GoblinAbility: strText = "Strikes when back turned"; break;
+		case MID_MimicAbility: strText = "Moves and fights like you"; break;
+		case MID_TarMotherAbility: strText = "Attached tarstuff becomes alive"; break;
 		case MID_TitleMainMenu: strText = "&Back"; break;
 		case MID_DoubleXP: strText = "Double REP"; break;
 		case MID_DisableMouseMovement: strText = "Disable mouse movement"; break;

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -1202,6 +1202,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarReturnX: strText = "_ReturnX"; break;
 		case MID_WaitForArrayEntry: strText = "Wait for array entry"; break;
 		case MID_CountArrayEntries: strText = "Count array entries"; break;
+		case MID_Wyrm: strText = "Wyrm"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -1070,7 +1070,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_WallMirrorSafe: strText = "Wall and mirror safe"; break;
 		case MID_HotTileImmune: strText = "Heatproof"; break;
 		case MID_FiretrapImmune: strText = "Fireproof"; break;
-		case MID_MistImmune: strText = "Mist protection"; break;
+		case MID_MistImmune: strText = "Mistproof"; break;
 		case MID_Sword11: strText = "Dagger"; break;
 		case MID_Sword12: strText = "Staff"; break;
 		case MID_Sword13: strText = "Spear"; break;

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -180,15 +180,15 @@ Doubles ATK power of monsters in the room
 
 [MID_EyeAbility]
 [eng]
-Strikes when you step in front
+Strikes in front
 
 [MID_RoachQueenAbility]
 [eng]
-Spawns a tough egg when a monster is fought
+Spawns eggs
 
 [MID_GoblinAbility]
 [eng]
-Strikes when you turn your back to it
+Strikes when back turned
 
 [MID_MimicAbility]
 [eng]
@@ -224,7 +224,7 @@ Strikes when adjacent
 
 [MID_TarMotherAbility]
 [eng]
-Attached tarstuff becomes alive and dangerous
+Attached tarstuff becomes alive
 
 [MID_QuickPathNotAvailable]
 [eng]

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -192,7 +192,7 @@ Strikes when back turned
 
 [MID_MimicAbility]
 [eng]
-Moves like you do, fights monsters as you
+Moves and fights like you
 
 [MID_AumtlichAbility]
 [eng]
@@ -359,3 +359,7 @@ New personal best!
 [MID_PercentOptimal]
 [eng]
 %s% of personal best
+
+[MID_Wyrm]
+[eng]
+Wyrm

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -636,6 +636,7 @@ enum MID_CONSTANT {
   MID_SKEYStatFull = 1827,
   MID_NewLocalHighScore = 1987,
   MID_PercentOptimal = 1989,
+  MID_Wyrm = 2110,
 
   //Messages from General.uni:
   MID_SDLInitFailed = 464,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1654,7 +1654,7 @@ Fireproof
 
 [MID_MistImmune]
 [eng]
-Mist protection
+Mistproof
 
 [MID_RemoveOverheadImage]
 [eng]


### PR DESCRIPTION
It's nice if ability descriptions aren't so long they take up more than one line on the combat preview dialog. Some suggestions have been made for how they can be more concise.

This PR also makes it so that Goblin and Wyrm weaknesses use the same verbiage as custom weaknesses, for flawless consistency.