### PR TITLE
RPG: Remove bad assert in CGameScreen::ClearSpeech

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -1721,7 +1721,6 @@ void CGameScreen::ClearSpeech(const bool bForceClearAll) //[default=false]
 			} else {
 				pCommand->pExecutingNPC = pCommand->pSpeakingEntity =
 						pCurrentGame->GetCharacterWithScriptID(pCommand->scriptID);
-				ASSERT(pCommand->pExecutingNPC);
 				if (pCommand->pExecutingNPC) //robustness
 				{
 					//This speech command may be reliably retained.


### PR DESCRIPTION
This assert fires when speech can't be reattached to a character. This can happen when a speaking character is killed, and then the player undoes some later moves. Nothing bad happens in this case, and the TSS version of the function doesn't have the assert, so it can probably be removed.