### PR TITLE
RPG: Revert to old splash screen door positioning

### DIFF
--- a/drodrpg/DROD/Main.cpp
+++ b/drodrpg/DROD/Main.cpp
@@ -965,9 +965,9 @@ sdl_error:
 	SDL_SetCursor(g_pTheSM->GetCursor(CUR_Wait));
 
 	//Show splash screen graphic.
-	const int X_TITLE = (CScreen::CX_SCREEN - 512) / 2; //center
-	const int Y_TITLE = 125;
-	static const WCHAR wszSplashscreenGraphic[] = {We('D'),We('o'),We('o'),We('r'),We(0)}; //Door
+	const int X_TITLE = (CScreen::CX_SCREEN - 182) / 2; //center
+	const int Y_TITLE = 200;
+	static const WCHAR wszSplashscreenGraphic[] = { We('D'),We('o'),We('o'),We('r'),We(0) }; // Door
 	CImageWidget *pTitleImage = new CImageWidget(0, X_TITLE, Y_TITLE, wszSplashscreenGraphic);
 	pTitleImage->Paint();
 	PresentRect();


### PR DESCRIPTION
Reverts #638 as we've gone back to the original door image.