### PR TITLE
RPG: Fix duplicated message id

### DIFF
--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -1208,6 +1208,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_WaitForArrayEntry: strText = "Wait for array entry"; break;
 		case MID_CountArrayEntries: strText = "Count array entries"; break;
 		case MID_Wyrm: strText = "Wyrm"; break;
+		case MID_MusicElizabeth: strText = "Elizabeth"; break;
 		case MID_RemoveTransparentLayer: strText = "Remove transparent layer object"; break;
 		default: break;
 	}

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1753,7 +1753,7 @@ enum MID_CONSTANT {
   MID_WorldMapDestinationPrompt = 2104,
   MID_WaitForArrayEntry = 2108,
   MID_CountArrayEntries = 2109,
-  MID_RemoveTransparentLayer = 2111,
+  MID_RemoveTransparentLayer = 2112,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,


### PR DESCRIPTION
`MID_MusicElizabeth` and `MID_RemoveTransparentLayer` had the same value, which is bad. Also, there wasn't a entry for `MID_MusicElizabeth` in `DbBase`.