### PR TITLE
Add optional swirl effect when placing doubles

### DIFF
--- a/DROD/DemoScreen.cpp
+++ b/DROD/DemoScreen.cpp
@@ -159,6 +159,8 @@ bool CDemoScreen::SetForActivate()
 		settings.GetVar(Settings::DescribeCitizenColor, false));
 
 	SetShowVoicedSubtitle(settings.GetVar(Settings::ShowSubtitlesWithVoices, true));
+	SetShowHalphEffects(settings.GetVar(Settings::ShowHalphEffects, false));
+	SetShowPlaceDoubleSwirl(settings.GetVar(Settings::ShowDoublePlacementEffect, false));
 
 	PaintClock(true);
 

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -2079,6 +2079,10 @@ void CGameScreen::ApplyPlayerSettings()
 	this->pRoomWidget->DescribeCitizenColor(
 		settings.GetVar(Settings::DescribeCitizenColor, false));
 
+	//Set extra hinting effects
+	this->bShowHalphEffects = settings.GetVar(Settings::ShowHalphEffects, false);
+	this->bShowDoublePlacementSwirl = settings.GetVar(Settings::ShowDoublePlacementEffect, false);
+
 	this->bAutoUndoOnDeath = settings.GetVar(Settings::AutoUndoOnDeath, false);
 
 	//Move repeat rate.
@@ -3749,35 +3753,43 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		const CHalph *pHalph = DYN_CAST(const CHalph*, const CAttachableObject*,
 			CueEvents.GetFirstPrivateData(CID_HalphStriking) );
 		PlaySpeakerSoundEffect(pHalph->wType == M_HALPH ? SEID_HALPHSTRIKING : SEID_HALPH2STRIKING);
-		this->pRoomWidget->AddMLayerEffect(
-			new CDottedLineEffect(this->pRoomWidget, 750, *pHalph, pHalph->GetCurrentGoal()));
+		if (this->bShowHalphEffects) {
+			this->pRoomWidget->AddMLayerEffect(
+				new CDottedLineEffect(this->pRoomWidget, 750, *pHalph, pHalph->GetCurrentGoal()));
+		}
 	}
 	else if (CueEvents.HasOccurred(CID_HalphCantOpen))
 	{
 		const CHalph *pHalph = DYN_CAST(const CHalph*, const CAttachableObject*,
 			CueEvents.GetFirstPrivateData(CID_HalphCantOpen) );
 		PlaySpeakerSoundEffect(pHalph->wType == M_HALPH ? SEID_HALPHCANTOPEN : SEID_HALPH2CANTOPEN);
-		this->pRoomWidget->AddMLayerEffect(new CFadeTileEffect(this->pRoomWidget, *pHalph, TI_CHECKPOINT, 750));
-		this->pRoomWidget->AddMLayerEffect(
-			new CFadeTileEffect(this->pRoomWidget, pHalph->GetLatestRequest(), TI_CHECKPOINT, 750));
+		if (this->bShowHalphEffects) {
+			this->pRoomWidget->AddMLayerEffect(new CFadeTileEffect(this->pRoomWidget, *pHalph, TI_CHECKPOINT, 750));
+			this->pRoomWidget->AddMLayerEffect(
+				new CFadeTileEffect(this->pRoomWidget, pHalph->GetLatestRequest(), TI_CHECKPOINT, 750));
+		}
 	}
 	else if (CueEvents.HasOccurred(CID_HalphInterrupted))
 	{
 		const CHalph *pHalph = DYN_CAST(const CHalph*, const CAttachableObject*,
 			CueEvents.GetFirstPrivateData(CID_HalphInterrupted) );
 		PlaySpeakerSoundEffect(pHalph->wType == M_HALPH ? SEID_HALPHINTERRUPTED : SEID_HALPH2INTERRUPTED);
-		this->pRoomWidget->AddMLayerEffect(
-			new CFadeTileEffect(this->pRoomWidget, *pHalph, TI_CHECKPOINT, 750));
-		this->pRoomWidget->AddMLayerEffect(
-			new CFadeTileEffect(this->pRoomWidget, pHalph->GetCurrentGoal(), TI_CHECKPOINT, 750));
+		if (this->bShowHalphEffects) {
+			this->pRoomWidget->AddMLayerEffect(
+				new CFadeTileEffect(this->pRoomWidget, *pHalph, TI_CHECKPOINT, 750));
+			this->pRoomWidget->AddMLayerEffect(
+				new CFadeTileEffect(this->pRoomWidget, pHalph->GetCurrentGoal(), TI_CHECKPOINT, 750));
+		}
 	}
 	else if (CueEvents.HasOccurred(CID_HalphHurryUp))
 	{
 		const CHalph *pHalph = DYN_CAST(const CHalph*, const CAttachableObject*,
 			CueEvents.GetFirstPrivateData(CID_HalphHurryUp) );
 		PlaySpeakerSoundEffect(pHalph->wType == M_HALPH ? SEID_HALPHHURRYUP : SEID_HALPH2HURRYUP);
-		this->pRoomWidget->AddMLayerEffect(
-			new CDottedLineEffect(this->pRoomWidget, 750, *pHalph, pHalph->GetCurrentGoal()));
+		if (this->bShowHalphEffects) {
+			this->pRoomWidget->AddMLayerEffect(
+				new CDottedLineEffect(this->pRoomWidget, 750, *pHalph, pHalph->GetCurrentGoal()));
+		}
 	}
 
 	//Handle dynamically-allocated sound channels -- give most important sounds priority.
@@ -3824,7 +3836,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		PlaySoundEffect(SEID_MIMIC);
 		this->pRoomWidget->RenderRoomInPlay(); //remove double placement effect
 		pObj = CueEvents.GetFirstPrivateData(CID_DoublePlaced);
-		if (pObj) {
+		if (pObj && this->bShowDoublePlacementSwirl) {
 			const CCoord* pCoord = DYN_CAST(const CCoord*, const CAttachableObject*, pObj);
 			this->pRoomWidget->AddMLayerEffect(new CTileSwirlEffect(this->pRoomWidget, CMoveCoord(pCoord->wX, pCoord->wY, 0)));
 		}

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -56,6 +56,7 @@
 #include "SwordsmanSwirlEffect.h"
 #include "SwordSwingEffect.h"
 #include "TarStabEffect.h"
+#include "TileSwirlEffect.h"
 #include "TrapdoorFallEffect.h"
 #include "VerminEffect.h"
 #include "WadeEffect.h"
@@ -3822,6 +3823,11 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 	{
 		PlaySoundEffect(SEID_MIMIC);
 		this->pRoomWidget->RenderRoomInPlay(); //remove double placement effect
+		pObj = CueEvents.GetFirstPrivateData(CID_DoublePlaced);
+		if (pObj) {
+			const CCoord* pCoord = DYN_CAST(const CCoord*, const CAttachableObject*, pObj);
+			this->pRoomWidget->AddMLayerEffect(new CTileSwirlEffect(this->pRoomWidget, CMoveCoord(pCoord->wX, pCoord->wY, 0)));
+		}
 	}
 	if (CueEvents.HasOccurred(CID_SeedingBeaconActivated))
 		PlaySoundEffect(SEID_SEEDING_BEACON_ON);

--- a/DROD/GameScreen.h
+++ b/DROD/GameScreen.h
@@ -121,6 +121,8 @@ protected:
 	void           RetainEffectCleanup(const bool bVal=false);
 	virtual bool   SetForActivate();
 	void           SetShowVoicedSubtitle(bool showSubtitle) { this->bShowingSubtitlesWithVoice = showSubtitle; }
+	void           SetShowHalphEffects(bool showEffects) { this->bShowHalphEffects = showEffects; }
+	void           SetShowPlaceDoubleSwirl(bool showSwirl) { this->bShowDoublePlacementSwirl = showSwirl; }
 	virtual bool   UnloadOnDeactivate() const {return false;}
 
 	//These are called by CDemoScreen.
@@ -224,6 +226,8 @@ private:
 	deque<CFiredCharacterCommand*> speech; //speech dialog queued to play
 	Uint32 dwNextSpeech; //time next speech can begin
 	bool   bShowingSubtitlesWithVoice;	//whether subtitles are shown when voices are playing
+	bool   bShowHalphEffects; //are effects shown for Halph actions (door-knocking, path becoming blocked)
+	bool   bShowDoublePlacementSwirl; //is a swirl effect added when placing a player double
 	Uint32 dwTimeMinimized; //time game is minimized
 	Uint32 dwLastCutSceneMove, dwSavedMoveDuration;
 

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -115,6 +115,8 @@ const UINT TAG_GROUPEDITORMENUITEMS = 1072;
 const UINT TAG_UNDOLEVEL_NUM_LABEL = 1073;
 const UINT TAG_AUTOUNDOONDEATH = 1074;
 const UINT TAG_CITIZEN_DESCRIBE_COLOR = 1075;
+const UINT TAG_HALPH_EFFECTS = 1076;
+const UINT TAG_PLACE_DOUBLE_EFFECT = 1077;
 
 const UINT TAG_CANCEL = 1091;
 const UINT TAG_HELP = 1092;
@@ -338,7 +340,16 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 	static const UINT CX_DESCRIBE_CITIZEN_COLOR = CX_AUTOUNDOONDEATH;
 	static const UINT CY_DESCRIBE_CITIZEN_COLOR = CY_AUTOUNDOONDEATH;
 
-	static const UINT CY_SPECIAL_FRAME = Y_DESCRIBE_CITIZEN_COLOR + CY_DESCRIBE_CITIZEN_COLOR + CY_SPACE;
+	static const int X_HALPH_EFFECTS = CX_SPACE;
+	static const int Y_HALPH_EFFECTS = Y_DESCRIBE_CITIZEN_COLOR + CY_AUTOUNDOONDEATH;
+	static const UINT CX_HALPH_EFFECTS = CX_SPECIAL_FRAME - X_HALPH_EFFECTS;
+	static const UINT CY_HALPH_EFFECTS = CY_STANDARD_OPTIONBUTTON;
+	static const int X_PLACE_DOUBLE_EFFECT = CX_SPACE;
+	static const int Y_PLACE_DOUBLE_EFFECT = Y_HALPH_EFFECTS + CY_AUTOUNDOONDEATH;
+	static const UINT CX_PLACE_DOUBLE_EFFECT = CX_SPECIAL_FRAME - X_PLACE_DOUBLE_EFFECT;
+	static const UINT CY_PLACE_DOUBLE_EFFECT = CY_STANDARD_OPTIONBUTTON;
+
+	static const UINT CY_SPECIAL_FRAME = Y_PLACE_DOUBLE_EFFECT + CY_PLACE_DOUBLE_EFFECT + CY_SPACE;
 
 	//Demo frame and children
 	static const UINT X_DEMO_FRAME = X_EDITOR_FRAME;
@@ -442,6 +453,18 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 	pOptionButton = new COptionButtonWidget(TAG_CITIZEN_DESCRIBE_COLOR, X_DESCRIBE_CITIZEN_COLOR,
 		Y_DESCRIBE_CITIZEN_COLOR, CX_DESCRIBE_CITIZEN_COLOR, CY_DESCRIBE_CITIZEN_COLOR,
 		g_pTheDB->GetMessageText(MID_DescribeCitizenColor),
+		false);
+	pSpecialFrame->AddWidget(pOptionButton);
+
+	pOptionButton = new COptionButtonWidget(TAG_HALPH_EFFECTS, X_HALPH_EFFECTS,
+		Y_HALPH_EFFECTS, CX_HALPH_EFFECTS, CY_HALPH_EFFECTS,
+		g_pTheDB->GetMessageText(MID_ShowHalphEffects),
+		false);
+	pSpecialFrame->AddWidget(pOptionButton);
+
+	pOptionButton = new COptionButtonWidget(TAG_PLACE_DOUBLE_EFFECT, X_PLACE_DOUBLE_EFFECT,
+		Y_PLACE_DOUBLE_EFFECT, CX_PLACE_DOUBLE_EFFECT, CY_PLACE_DOUBLE_EFFECT,
+		g_pTheDB->GetMessageText(MID_ShowPlaceDoubleEffect),
 		false);
 	pSpecialFrame->AddWidget(pOptionButton);
 
@@ -1681,6 +1704,14 @@ void CSettingsScreen::UpdateWidgetsFromPlayerData(
 		GetWidget(TAG_CITIZEN_DESCRIBE_COLOR));
 	pOptionButton->SetChecked(settings.GetVar(Settings::DescribeCitizenColor, false));
 
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_HALPH_EFFECTS));
+	pOptionButton->SetChecked(settings.GetVar(Settings::ShowHalphEffects, false));
+
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_PLACE_DOUBLE_EFFECT));
+	pOptionButton->SetChecked(settings.GetVar(Settings::ShowDoublePlacementEffect, false));
+
 	//Editor settings.
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 			GetWidget(TAG_AUTOSAVE));
@@ -1840,6 +1871,14 @@ void CSettingsScreen::UpdatePlayerDataFromWidgets(
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
 		GetWidget(TAG_CITIZEN_DESCRIBE_COLOR));
 	settings.SetVar(Settings::DescribeCitizenColor, pOptionButton->IsChecked());
+
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_HALPH_EFFECTS));
+	settings.SetVar(Settings::ShowHalphEffects, pOptionButton->IsChecked());
+
+	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,
+		GetWidget(TAG_PLACE_DOUBLE_EFFECT));
+	settings.SetVar(Settings::ShowDoublePlacementEffect, pOptionButton->IsChecked());
 
 	//Editor settings.
 	pOptionButton = DYN_CAST(COptionButtonWidget*, CWidget*,

--- a/DRODLib/CueEvents.h
+++ b/DRODLib/CueEvents.h
@@ -279,7 +279,7 @@ enum CUEEVENT_ID
 
 	//Swordsman placed a double.
 	//
-	//Private data: NONE
+	//Private data: CCoord (one)
 	CID_DoublePlaced,
 
 	//Swordsman ran into obstacle.

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -5710,7 +5710,7 @@ void CCurrentGame::ProcessDoublePlacement(
 						++this->dwLevelMoves;
 						ASSERT(this->dwLevelMoves > 0);
 
-						CueEvents.Add(CID_DoublePlaced);
+						CueEvents.Add(CID_DoublePlaced, new CCoord(pDouble->wX, pDouble->wY), true);
 						pDouble->SetCurrentGame(this);
 						pDouble->wPrevX = pDouble->wX;
 						pDouble->wPrevY = pDouble->wY;

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1045,6 +1045,8 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_CanKillNonTargetPlayer: strText = "Can Kill Non-target Player"; break;
 	case MID_WakesEvilEyes: strText = "Wakes Evil Eyes"; break;
 	case MID_AppearOnWeapons: strText = "Can Appear On Weapons"; break;
+	case MID_ShowHalphEffects: strText = "Show visual confirmation for Halph actions"; break;
+	case MID_ShowPlaceDoubleEffect: strText = "Show swirl at double placement position"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -76,7 +76,9 @@ namespace Settings
 	DEF(ResizableWindow);
 	DEF(ShowCheckpoints);
 	DEF(ShowDemosFromLevel);
+	DEF(ShowDoublePlacementEffect);
 	DEF(ShowErrors);
+	DEF(ShowHalphEffects);
 	DEF(ShowSubtitlesWithVoices);
 	DEF(SoundEffects);
 	DEF(SoundEffectsVolume);

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -76,7 +76,9 @@ namespace Settings
 	DEF(ResizableWindow);
 	DEF(ShowCheckpoints);
 	DEF(ShowDemosFromLevel);
+	DEF(ShowDoublePlacementEffect);
 	DEF(ShowErrors);
+	DEF(ShowHalphEffects);
 	DEF(ShowSubtitlesWithVoices);
 	DEF(SoundEffects);
 	DEF(SoundEffectsVolume);

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1419,6 +1419,8 @@ enum MID_CONSTANT {
   MID_Command_Script_SelectAll = 2154,
   MID_Command_Script_ToText = 2155,
   MID_Command_Script_FromText = 2156,
+  MID_ShowHalphEffects = 2160,
+  MID_ShowPlaceDoubleEffect = 2161,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/Texts/SettingsScreen.uni
+++ b/Texts/SettingsScreen.uni
@@ -749,3 +749,11 @@ Export Script Commands
 [MID_Command_Script_FromText]
 [eng]
 Import Script Commands
+
+[MID_ShowHalphEffects]
+[eng]
+Show visual confirmation for Halph actions
+
+[MID_ShowPlaceDoubleEffect]
+[eng]
+Show swirl at double placement position


### PR DESCRIPTION
Adds a setting that makes a swirl appear when placing a double. The new "Halph effects" are now also configurable, for people who might find them bothersome.

https://forum.caravelgames.com/viewtopic.php?TopicID=46552