### PR TITLE
Fix world map tile images when using non-animated custom character

### DIFF
--- a/DROD/WorldMapWidget.cpp
+++ b/DROD/WorldMapWidget.cpp
@@ -489,9 +489,17 @@ const
 		if (pChar->animationSpeed && pChar->dwDataID_Tiles)
 			return ANIMATED_TILE; //calculated during real-time animation
 
-		const UINT tile = g_pTheBM->GetCustomTileNo(pChar->dwDataID_Tiles, orientation, frame);
+		static const UINT tileIndex = 4; //index for south-facing tile
+		UINT tile = g_pTheBM->GetCustomTileNo(pChar->dwDataID_Tiles, tileIndex, frame);
 		if (tile != TI_UNSPECIFIED)
 			return tile;
+
+		//If there isn't an animation row, try using default row
+		if (frame != 0) {
+			tile = g_pTheBM->GetCustomTileNo(pChar->dwDataID_Tiles, tileIndex, 0);
+			if (tile != TI_UNSPECIFIED)
+				return tile;
+		}
 
 		//Use stock/default character tileset.
 		return GetTileImageForEntity(pChar->wType == M_NONE ?


### PR DESCRIPTION
Using custom characters as world map icons doesn't work correctly. This has two causes:

1. When getting the tile image, the value for the south orientation is passed to `g_pTheBM->GetCustomTileNo` for the x-index. However, the index for a south-facing tile isn't the same as the orientation value. This means the character isn't facing the correct direction. To fix, the correct index should be used.
2. If the custom character doesn't have at least two rows of tiles, the default tile for it's base type is used for its animation frame. This leads to the icon "blinking" between the custom tile and base tile. To fix, we should try to use the default tile row before falling back to the base type's tiles.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46693