### PR TITLE
RPG: Fix problems with changing HP during combat

### DIFF
--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -646,7 +646,8 @@ void CDrodScreen::AdvanceDemoPlayback(
 				CueEvents.HasOccurred(CID_WinGame) ||
 				CueEvents.HasOccurred(CID_ExitLevelPending) ||
 				CueEvents.HasOccurred(CID_ExitToWorldMapPending) ||
-				CueEvents.HasOccurred(CID_InvalidAttackMove))) //invalid move indicates play sequence is for a different hold version
+				CueEvents.HasOccurred(CID_InvalidAttackMove)) || //invalid move indicates play sequence is for a different hold version
+				CueEvents.HasOccurred(CID_StalledCombat)) //stalled combat indicates play sequence is for a different hold version
 		{
 			while (commandIter != pGame->Commands.end())
 				commandIter = pGame->Commands.GetNext();

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -5578,7 +5578,8 @@ SCREENTYPE CGameScreen::ProcessCommand(
 				this->pRoomWidget->RemoveMLayerEffectsOfType(EFADETILE); //no damage shield
 			}
 
-			if (this->sCueEvents.HasOccurred(CID_InvalidAttackMove))
+			if (this->sCueEvents.HasOccurred(CID_InvalidAttackMove) ||
+				this->sCueEvents.HasOccurred(CID_StalledCombat))
 			{
 				//This move was just undone.
 				//Speech pointers need to be relinked and room state refreshed.
@@ -6000,7 +6001,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 
 	if (CueEvents.HasOccurred(CID_MonsterEngaged))
 	{
-		if (this->pCurrentGame->pCombat)
+		if (this->pCurrentGame->pCombat && !this-pCurrentGame->pCombat->bCombatStalled)
 		{
 			//If a monster can't be harmed, report on it
 			CMonster *pMonster = this->pCurrentGame->pCombat->PlayerCantHarmAQueuedMonster();
@@ -6875,8 +6876,16 @@ SCREENTYPE CGameScreen::ProcessCueEventsAfterRoomDraw(
 	if (yFlashingTextOffset < Y_FLASHING_TEXT_MIN)
 		yFlashingTextOffset = Y_FLASHING_TEXT_MIN;
 
-	if (CueEvents.HasOccurred(CID_InvalidAttackMove))
+	if (CueEvents.HasOccurred(CID_StalledCombat))
 	{
+		pObj = CueEvents.GetFirstPrivateData(CID_StalledCombat);
+		ASSERT(pObj);
+		const CMoveCoord* pCoord = DYN_CAST(const CMoveCoord*, const CAttachableObject*, pObj);
+		static CMoveCoord coord;
+		coord = *pCoord;
+		this->pRoomWidget->AddInfoSubtitle(&coord, g_pTheDB->GetMessageText(MID_CombatStalled), 2000);
+		ShowStatsForMonsterAt(pCoord->wX, pCoord->wY);
+	} else if (CueEvents.HasOccurred(CID_InvalidAttackMove)) {
 		pObj = CueEvents.GetFirstPrivateData(CID_InvalidAttackMove);
 		ASSERT(pObj);
 		const CMoveCoord *pCoord = DYN_CAST(const CMoveCoord*, const CAttachableObject*, pObj);

--- a/drodrpg/DRODLib/Combat.cpp
+++ b/drodrpg/DRODLib/Combat.cpp
@@ -566,6 +566,11 @@ bool CCombat::Advance(
 		this->playerTicks += ps.speed * (player.IsHasted() ? 2 : 1);
 		this->monsterTicks += MON_SPEED;
 
+		//Update enemy HP if in non-simulated quick combat
+		if (bQuick && !this->bSimulated) {
+			monHP = pMonsterBeingFought->getHP();
+		}
+
 		//Does either the player or enemy perform a strike this iteration?
 		const bool bStrike = (this->playerTicks >= CCombat::hitTicks) ||
 				(this->monsterTicks >= CCombat::hitTicks);

--- a/drodrpg/DRODLib/Combat.h
+++ b/drodrpg/DRODLib/Combat.h
@@ -159,6 +159,8 @@ public:
 
 	//combat progress
 	UINT playerTicks, monsterTicks; //progress toward next hit
+	UINT playerStalls, monsterStalls; //how many hits resulted in no progress (hp was same or higher than before hit)
+	bool bCombatStalled; //indicates combat ended due to not having enough progress
 
 private:
 	UINT playerAttacksMade, monsterAttacksMade;

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -722,6 +722,11 @@ enum CUEEVENT_ID
 	//Private data: (UINT) World map to go to
 	CID_ExitToWorldMapPending,
 
+	//Player engaged in a combat that seemed unlikely to ever end
+	//
+	//Private data: CMoveCoord *pMoveCoord
+	CID_StalledCombat,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3244,6 +3244,14 @@ void CCurrentGame::ProcessCommand(
 			UndoCommand(CueEvents); //can't undo when move sequence is frozen (avoid infinite recursion)
 		CueEvents.Clear(); //don't show events from previous turn again
 		CueEvents.Add(CID_InvalidAttackMove, &coord); //add an event to let the front-end know what happened
+	} else if (this->pCombat && this->pCombat->bCombatStalled) {
+		static CMoveCoord coord;
+		coord.wX = this->pCombat->pMonster->wX;
+		coord.wY = this->pCombat->pMonster->wY;
+		if (!this->Commands.IsFrozen())
+			UndoCommand(CueEvents); //can't undo when move sequence is frozen (avoid infinite recursion)
+		CueEvents.Clear(); //don't show events from previous turn again
+		CueEvents.Add(CID_StalledCombat, &coord); //add an event to let the front-end know what happened
 	}
 }
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -1212,6 +1212,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_RemoveTransparentLayer: strText = "Remove transparent layer object"; break;
 		case MID_NoMoreMemory: strText = "DROD ran out of memory. You might free up enough memory by closing other applications."; break;
 		case MID_ShowPercentOptimal: strText = "Show banner for non-best local scores"; break;
+		case MID_CombatStalled: strText = "Combat failed to resolve (invalid move)"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -363,3 +363,7 @@ New personal best!
 [MID_Wyrm]
 [eng]
 Wyrm
+
+[MID_CombatStalled]
+[eng]
+Combat failed to resolve (invalid move)

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -637,6 +637,7 @@ enum MID_CONSTANT {
   MID_NewLocalHighScore = 1987,
   MID_PercentOptimal = 1989,
   MID_Wyrm = 2110,
+  MID_CombatStalled = 2115,
 
   //Messages from General.uni:
   MID_SDLInitFailed = 464,


### PR DESCRIPTION
There are two problems with changing HP values during combat:

1. Changing enemy HP during combat doesn't work correctly when combat is quick. This is because the code that sets the HP value used by the combat is outside of the main combat loop. This means changing the combat rate setting can affect the outcome of combats, which is bad. Fixed by updating the HP value on each loop iteration when doing quick non-simulated combat.
2. Increasing HP during combat can lead to an endless combat. At the highest combat rate, this can lead to the game freezing up. To fix this, I've introduced "stall tracking". A stall is counted whenever a combatant's HP increases during a round, or they fail to reduce their opponents HP. If *both* combatants have more stalls that a certain threshold (currently at least 25 each), the combat is aborted and the move that started it is undone. A tooltip is also shown to reduce player confusion.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46725