### PR TITLE
RPG: Support monsters with negative ATK and DEF

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -544,6 +544,7 @@ void CGameScreen::RedrawStats(
 	for (i=0; i<numStats; ++i)
 	{
 		int val = 0, val_percent = 0, val_mod = 0;
+		bool hasValue = true;
 		switch (i)
 		{
 			case 0: val = ps.HP; if (val < 0) val = 0; break;
@@ -554,9 +555,30 @@ void CGameScreen::RedrawStats(
 			case 5: val = ps.greenKeys >= MAX_KEY_DISPLAY ? MAX_KEY_DISPLAY : ps.greenKeys ; break;
 			case 6: val = ps.blueKeys >= MAX_KEY_DISPLAY ? MAX_KEY_DISPLAY : ps.blueKeys; break;
 			case 7: wstr = (bCombat ? this->pRoomWidget->GetMonsterName(pCombat->pMonster) : wszEmpty); break;
-			case 8: val = bCombat ? pCombat->pMonster->getHP() : BLANK_ITEM; break;
-			case 9: val = bCombat ? pCombat->monATK : BLANK_ITEM; break;
-			case 10: val = bCombat ? pCombat->monDEF : BLANK_ITEM; break;
+			case 8:
+				if (pCombat)
+				{
+					val = pCombat->pMonster->getHP();
+				} else {
+					hasValue = false;
+				}
+			break;
+			case 9:
+				if (pCombat)
+				{
+					val = pCombat->monATK;
+				} else {
+					hasValue = false;
+				}
+			break;
+			case 10:
+				if (pCombat)
+				{
+					val = pCombat->monDEF;
+				} else {
+					hasValue = false;
+				}
+			break;
 			case 11: val = ps.sword != NoSword ? CRoomWidget::GetSwordMID(ps.sword) : (UINT)MID_NoText; break;
 			case 12: val = ps.shield != NoShield ? CRoomWidget::GetShieldMID(ps.shield) : (UINT)MID_NoText; break;
 			case 13: val = ps.accessory != NoAccessory ? CRoomWidget::GetAccessoryMID(ps.accessory) : (UINT)MID_NoText; break;
@@ -647,7 +669,7 @@ void CGameScreen::RedrawStats(
 			break;
 			default:
 				//allow values to be blank
-				pLabel->SetText(val == (int)BLANK_ITEM ? wszEmpty : _itoW(val, temp, 10));
+				pLabel->SetText(hasValue ? _itoW(val, temp, 10): wszEmpty);
 			break;
 		}
 		pLabel->RequestPaint();

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -787,11 +787,11 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 			{
 				case (UINT)ScriptVars::P_ENEMY_HP: pMonster->HP = (int)val > 0 ? val : 0; break;
 				case (UINT)ScriptVars::P_ENEMY_ATK:
-					pMonster->ATK = (int)val > 0 ? val : 0;
+					pMonster->ATK = val;
 					bRefreshCombat = true;
 				break;
 				case (UINT)ScriptVars::P_ENEMY_DEF:
-					pMonster->DEF = (int)val > 0 ? val : 0;
+					pMonster->DEF = val;
 					bRefreshCombat = true;
 				break;
 				case (UINT)ScriptVars::P_ENEMY_GOLD: pMonster->GOLD = val; break;

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1529,12 +1529,12 @@ const
 UINT CMonster::getATK() const
 //Return: monster's ATK
 {
-	UINT val = this->ATK;
+	int val = this->ATK;
 	if (!this->pCurrentGame || !val) //multiply by zero will still be zero, so return now
 		return val;
 	const float fMult = this->pCurrentGame->GetTotalStatModifier(ScriptVars::MonsterATK);
-	val = UINTBounds(val * fMult);
-	return !val ? 1 : val; //ATK always >= 1
+	val = intBounds(val * fMult);
+	return !val ? 1 : val; //ATK can be negative
 }
 
 //*****************************************************************************
@@ -1555,15 +1555,16 @@ std::array<float, 3 > CMonster::getHSV() const
 UINT CMonster::getDEF() const
 //Return: monster's DEF
 {
-	if (IsOnMistTile() && !IsMistImmune())
-		return 0; //Mist tile nullifies DEF
-
-	UINT val = this->DEF;
+	int val = this->DEF;
 	if (!this->pCurrentGame || !val)
 		return val;
 	const float fMult = this->pCurrentGame->GetTotalStatModifier(ScriptVars::MonsterDEF);
-	val = UINTBounds(val * fMult);
-	return !val ? 1 : val; //DEF always >= 1
+	val = intBounds(val * fMult);
+
+	if (val < 0 && IsOnMistTile() && !IsMistImmune())
+		return 0; //Mist tile nullifies +ve DEF
+
+	return val; //DEF get be negative
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1534,7 +1534,7 @@ UINT CMonster::getATK() const
 		return val;
 	const float fMult = this->pCurrentGame->GetTotalStatModifier(ScriptVars::MonsterATK);
 	val = intBounds(val * fMult);
-	return !val ? 1 : val; //ATK can be negative
+	return val; //ATK can be negative
 }
 
 //*****************************************************************************
@@ -1561,10 +1561,10 @@ UINT CMonster::getDEF() const
 	const float fMult = this->pCurrentGame->GetTotalStatModifier(ScriptVars::MonsterDEF);
 	val = intBounds(val * fMult);
 
-	if (val < 0 && IsOnMistTile() && !IsMistImmune())
-		return 0; //Mist tile nullifies +ve DEF
+	if (val > 0 && IsOnMistTile() && !IsMistImmune())
+		return 0; //Mist tile nullifies positive DEF
 
-	return val; //DEF get be negative
+	return val; //DEF can be negative
 }
 
 //*****************************************************************************

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -675,9 +675,9 @@ The variable names are case-insensitive.
   </tr><tr>
     <td>_MyHP</td><td>NPC's HP</td><td>0 (<a href="#myhp">*</a>)</td><td>0,MAX</td>
   </tr><tr>
-    <td>_MyATK</td><td>NPC's ATK</td><td>0</td><td>0,MAX</td>
+    <td>_MyATK</td><td>NPC's ATK</td><td>0</td><td>-MAX,MAX</td>
   </tr><tr>
-    <td>_MyDEF</td><td>NPC's DEF</td><td>0</td><td>0,MAX</td>
+    <td>_MyDEF</td><td>NPC's DEF</td><td>0</td><td>-MAX,MAX</td>
   </tr><tr>
     <td>_MyGold</td><td>NPC's GR (battle loot)</td><td>0</td><td>-MAX,MAX</td>
   </tr><tr>
@@ -843,9 +843,9 @@ The variable names are case-insensitive.
   </tr><tr>
     <td>_EnemyHP</td><td>Enemy's HP(<a href="#enemy">*</a>)</td><td></td><td>0,MAX</td>
   </tr><tr>
-    <td>_EnemyATK</td><td>Enemy's ATK</td><td></td><td>0,MAX</td>
+    <td>_EnemyATK</td><td>Enemy's ATK</td><td></td><td>-MAX,MAX</td>
   </tr><tr>
-    <td>_EnemyDEF</td><td>Enemy's DEF</td><td></td><td>0,MAX</td>
+    <td>_EnemyDEF</td><td>Enemy's DEF</td><td></td><td>-MAX,MAX</td>
   </tr><tr>
     <td>_EnemyGR</td><td>Enemy's GR (battle loot)</td><td></td><td>-MAX,MAX</td>
   </tr><tr>


### PR DESCRIPTION
Have negative values for ATK and DEF already works in combat calculations. Since there are some fringe uses for them, I've made it work correctly in other places.