### PR TITLE
RPG: Fix bug with empty mapIconChanges vector

### DIFF
--- a/drodrpg/DROD/EffectChangeHistory.h
+++ b/drodrpg/DROD/EffectChangeHistory.h
@@ -45,8 +45,13 @@ public:
 
 	//Remove all records after a given turn.
 	void removeAfter(UINT turn) {
-		while (!empty() && changeTurns.back() >= turn) {
-			changeTurns.pop_back();
+		if (turn == 0) {
+			reset();
+		}
+		else {
+			while (!empty() && changeTurns.back() >= turn) {
+				changeTurns.pop_back();
+			}
 		}
 	}
 


### PR DESCRIPTION
If mapIconChanges removed all effects after turn zero it would end up with an empty vector, when it expects to always have a turn zero entry in it.