### PR TITLE
RPG: Wait for entity monster should not count the player

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4209,11 +4209,6 @@ bool CCharacter::IsEntityAt(
 	}
 	if ((pflags & ScriptFlag::MONSTER) != 0)
 	{
-		//excludes player doubles, friendly enemies, and NPCs
-		if (!bIsHuman(player.wAppearance) &&
-			player.wX >= px && player.wX <= px + pw &&
-			player.wY >= py && player.wY <= py + ph)
-			return true;
 		if (room.IsMonsterInRect(px, py,
 			px + pw, py + ph))
 			return true;


### PR DESCRIPTION
Fix regression where RPG used to be different from classic DROD in that player roles as monsters should not count when waiting while a monster is at some coordinate.