### PR TITLE
Fix issues with Slayer door-opening state

### DIFF
--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -280,6 +280,7 @@ void CSlayer::Process(
 		if (bWispOnTarget || ExtendWisp(CueEvents)) //assuming left-to-right evaluation
 		{
 			CueEvents.Add(CID_WispOnPlayer);
+			StopOpeningDoor();
 			AdvanceAlongWisp(CueEvents);
 		}
 		return;
@@ -307,6 +308,7 @@ void CSlayer::Process(
 				//The wisp continues to stretch towards the target each turn using the above rules
 				//with the goal of maintaining a constant connection to the target.
 				CueEvents.Add(CID_WispOnPlayer);
+				StopOpeningDoor();
 				AdvanceAlongWisp(CueEvents);
 			}
 		break;
@@ -591,6 +593,9 @@ bool CSlayer::CheckWispIntegrity()
 		{
 			++piece;
 			SeverWispAt(piece);  //don't need any wisp past target
+			if (this->state == OpeningDoor) {
+				StopOpeningDoor();
+			}
 			return true;
 		}
 

--- a/DRODLib/Slayer.cpp
+++ b/DRODLib/Slayer.cpp
@@ -1089,8 +1089,11 @@ void CSlayer::MoveToOpenDoor(CCueEvents &CueEvents)     //(in/out)
 		ASSERT(room.IsValidColRow(destX, destY));
 		const UINT orbStrikingOrientation = GetOrientationFacingTarget(destX, destY);
 		ASSERT(orbStrikingOrientation != NO_ORIENTATION);
-		if (!MakeSlowTurnIfOpen(orbStrikingOrientation))
-		{
+		if (this->weaponType == WT_Dagger) {
+			//Use dagger to bump orb (rotation won't work)
+			this->wO = orbStrikingOrientation;
+			this->wSwordMovement = orbStrikingOrientation;
+		} else if (!MakeSlowTurnIfOpen(orbStrikingOrientation)) {
 			//Slayer can't turn to strike the orb.  Start searching for player again.
 			StopStrikingOrb(CueEvents);
 			StopOpeningDoor();

--- a/DRODLib/Slayer.h
+++ b/DRODLib/Slayer.h
@@ -48,6 +48,7 @@ public:
 	virtual bool IsTileObstacle(const UINT wTileNo) const;
 	virtual bool IsOpenMove(const int dx, const int dy) const;
 	virtual bool IsOpenMove(const UINT wX, const UINT wY, const int dx, const int dy) const;
+	virtual bool IsExplosiveSafe(const UINT& wX, const UINT& wY, const UINT& wSO) const;
 	virtual bool IsSafeToStab(const UINT wFromX, const UINT wFromY, const UINT wSO) const;
 	virtual bool OnStabbed(CCueEvents &CueEvents, const UINT wX=(UINT)-1, const UINT wY=(UINT)-1,
 			WeaponType weaponType=WT_Sword);


### PR DESCRIPTION
Slayers opening doors do some dubious things. While some of these behaviours have been around since 2.0, they're weird and unintuitive enough that they should be changed.

1. A Slayer in the door opening state will ignore a target that is caught by or steps on its wisp. It makes much more sense for Slayers to abandon opening a door in favour of chasing a wisped target. (related thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46689)
2. Slayers in the door opening state will stab explosives. Mowing down guards and other Slayers is slightly weird, but it doesn't harm the Slayer doing it. Stabbing explosives is much less expected. Slayers should avoid stabbing explosives in all cases. This is so obscure and unexpected that the only demo this change breaks is an untended solution that prompted a bug report. (related thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46754)
3. Dagger-weilding Slayers will rotate to strike orbs. In addition to looking stupid, this doesn't actually strike the orb, but the Slayer thinks it does. In this cases, Slayers should "bump" orbs to strike them with the dagger.