### PR TITLE
RPG: Remove tutorial from main menu options

### DIFF
--- a/drodrpg/DROD/TitleScreen.cpp
+++ b/drodrpg/DROD/TitleScreen.cpp
@@ -184,7 +184,7 @@ CTitleScreen::CTitleScreen() : CDrodScreen(SCR_Title)
 	this->pPlayMenu = new CMenuWidget(TAG_PLAYMENU, X_MENU, Y_MENU, CX_MENU, CY_MENU,
 			F_TitleMenu, F_TitleMenuActive, F_TitleMenuSelected);
 	AddWidget(this->pPlayMenu);
-	this->pPlayMenu->AddText(g_pTheDB->GetMessageText(MID_TitleTutorial), MNU_TUTORIAL);
+	//this->pPlayMenu->AddText(g_pTheDB->GetMessageText(MID_TitleTutorial), MNU_TUTORIAL);
 	this->pPlayMenu->AddText(g_pTheDB->GetMessageText(MID_TitleNewGame), MNU_NEWGAME);
 	this->pPlayMenu->AddText(g_pTheDB->GetMessageText(MID_TitleContinue), MNU_CONTINUE);
 	this->pPlayMenu->AddText(g_pTheDB->GetMessageText(MID_TitleRestore), MNU_RESTORE);
@@ -354,7 +354,7 @@ void CTitleScreen::OnBetweenEvents()
 	else
 		switch (this->pPlayMenu->GetOnOption())
 		{
-			case MNU_TUTORIAL: RequestToolTip(MID_TutorialTip); break;
+			//case MNU_TUTORIAL: RequestToolTip(MID_TutorialTip); break;
 			case MNU_NEWGAME: RequestToolTip(MID_NewGameTip); break;
 			case MNU_CONTINUE: RequestToolTip(MID_ContinueTip); break;
 			case MNU_RESTORE: RequestToolTip(MID_RestoreTip); break;
@@ -1300,7 +1300,7 @@ void CTitleScreen::SetMenuOptionStatus()
 	this->pMenu->Enable(MNU_SETTINGS, dwPlayerID != 0);
 
 	//Check for Tutorial hold.
-	this->pPlayMenu->Enable(MNU_TUTORIAL, g_pTheDB->Holds.GetHoldIDWithStatus(CDbHold::Tutorial) != 0);
+	//this->pPlayMenu->Enable(MNU_TUTORIAL, g_pTheDB->Holds.GetHoldIDWithStatus(CDbHold::Tutorial) != 0);
 
 	db.SavedGames.FilterByHold(g_pTheDB->GetHoldID());
 	db.SavedGames.FilterByPlayer(g_pTheDB->GetPlayerID());

--- a/drodrpg/Data/Help/1/commands.html
+++ b/drodrpg/Data/Help/1/commands.html
@@ -9,8 +9,6 @@
 <p>This is a summary of the commands shown on the main menu of the Title Screen:</p>
 <p><a name="playgame"><b><u>P</u>lay Game</b></a> - Goes to the play sub-menu, which allows you to</p>
 <ul>
-  <li><a name="tutorial"><b>Play <u>T</u>utorial</b></a> - Learn how to use the <a href="quickstart.html">movement
-      commands</a> to play the game and encounter some common <a href="elements.html">game elements</a>.</li>
   <li><a name="newgame"><b>Play <u>N</u>ew Game</b></a> - Start a new game from the beginning of the selected hold.</li>
   <li><a name="continue"><b>Continue <u>P</u>laying Game</b></a> - Continues from the point
       you last played this hold.</li>


### PR DESCRIPTION
Removes the tutorial as an option. Also updates the help files to remove mention of it.