### PR TITLE
RPG: Fix setting default movement type for custom identites

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -6285,7 +6285,7 @@ void CCharacter::SetCurrentGame(
 	ResolveLogicalIdentity(this->pCurrentGame ? this->pCurrentGame->pHold : NULL);
 
 	//Set the movement type
-	if(bIsFirstTurn)
+	if(!bMovementChanged)
 		SetDefaultMovementType();
 
 	//If this NPC is a custom character with no script,


### PR DESCRIPTION
Fixes a regression where monsters with custom identities were not correctly setting their default movement type.