### PR TITLE
RPG: Update hold status for new official hold

### DIFF
--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -1455,7 +1455,7 @@ void CDrodScreen::ExportHold(const UINT dwHoldID)
 
 #ifndef STEAMBUILD
 	//Load graphics/music into hold for inclusion in export.
-	if (pHold->status == CDbHold::Main)
+	if (CDbHold::IsOfficialHold(pHold->status))
 		ImportMedia();
 #endif
 
@@ -1856,7 +1856,7 @@ bool CDrodScreen::IsGameFullVersion()
 	if (Metadata::GetInt(MetaKey::EMBEDMEDIA) == 1)
 		return Metadata::GetInt(MetaKey::DEMO) != 1;
 
-	const UINT mainholdID = g_pTheDB->Holds.GetHoldIDWithStatus(CDbHold::Main);
+	const UINT mainholdID = g_pTheDB->Holds.GetHoldIDWithStatus(CDbHold::GetOfficialHoldStatus());
 	if (!mainholdID)
 		return false;
 	CDbHold *pHold = g_pTheDB->Holds.GetByID(mainholdID);

--- a/drodrpg/DROD/LevelStartScreen.cpp
+++ b/drodrpg/DROD/LevelStartScreen.cpp
@@ -160,7 +160,7 @@ bool CLevelStartScreen::SetForActivate()
 	this->pHoldNameWidget->SetText(pHold->NameText);
 	this->pLevelNameWidget->SetText(pLevel->NameText);
 
-	if (pHold->status == CDbHold::Main || pHold->status == CDbHold::Tutorial) {
+	if (CDbHold::IsOfficialHold(pHold->status) || pHold->status == CDbHold::Tutorial) {
 		this->pCreatedWidget->SetText(wszEmpty);
 		this->pAuthorWidget->SetText(wszEmpty);
 	} else {

--- a/drodrpg/DROD/WinStartScreen.cpp
+++ b/drodrpg/DROD/WinStartScreen.cpp
@@ -84,7 +84,7 @@ CWinStartScreen::CWinStartScreen()
 bool CWinStartScreen::IsMainDungeon() const
 //Returns: whether this is the official hold that came with the game
 {
-	const UINT dwOfficialHoldID = g_pTheDB->Holds.GetHoldIDWithStatus(CDbHold::Main);
+	const UINT dwOfficialHoldID = g_pTheDB->Holds.GetHoldIDWithStatus(CDbHold::ACR);
 	if (g_pTheDB->GetHoldID() != dwOfficialHoldID)
 		return false; //not the official hold
 	return IsGameFullVersion();

--- a/drodrpg/DRODLib/DbHolds.h
+++ b/drodrpg/DRODLib/DbHolds.h
@@ -64,6 +64,16 @@ public:
 
 	virtual ~CDbHold();
 
+	enum HoldStatus
+	{
+		NoStatus = -1,
+		Homemade = 0,
+		Tendry = 1, //Tendry's Tale
+		Official = 2,
+		Tutorial = 3,
+		ACR = 4, //A Courageous Rescue
+	};
+
 	UINT        AddCharacter(const WCHAR* pwszName);
 	void        AddEntrance(CEntranceData* pEntrance, const bool bReplaceMainEntrance=true);
 	UINT        AddVar(const WCHAR* pwszName);
@@ -101,6 +111,7 @@ public:
 	HoldWorldMap::DisplayType GetWorldMapDisplayType(const UINT worldMapID) const;
 	WSTRING     GetWorldMapName(const UINT worldMapID) const;
 	void        InsertLevel(CDbLevel *pLevel);
+	static bool IsOfficialHold(HoldStatus holdstatus);
 	bool        IsArrayVar(UINT varID) const { return this->arrayScriptVars.count(varID); }
 	static bool IsVarNameGoodSyntax(const WCHAR* pName);
 	bool        Load(const UINT dwHoldID, const bool bQuick=false);
@@ -152,21 +163,14 @@ public:
 	};
 	EditAccess     editingPrivileges;  //who can edit the hold
 
-	enum HoldStatus
-	{
-		NoStatus=-1,
-		Homemade=0,
-		Main=1,
-		Official=2,
-		Tutorial=3
-	};
+	static HoldStatus GetOfficialHoldStatus();
 	HoldStatus		status;	//type of hold
 	bool           bCaravelNetMedia; //whether d/led from CaravelNet
 
 private:
 	void     Clear();
 	void     ClearEntrances();
-	UINT     GetLocalID(const HoldStatus eStatusMatching=NoStatus) const;
+	UINT     GetLocalID(const HoldStatus eStatusMatching, const CIDSet& playerIDs, UINT& matchedPlayerID) const;
 	UINT     GetNewCharacterID();
 	bool     LoadCharacters(c4_View &CharsView);
 	bool     LoadEntrances(c4_View& EntrancesView);

--- a/drodrpg/DRODLib/DbLevels.cpp
+++ b/drodrpg/DRODLib/DbLevels.cpp
@@ -867,7 +867,7 @@ void CDbLevel::RekeyExitIDs(
 	const bool bDifferentHold = pNewHold->dwHoldID != pOldHold->dwHoldID;
 
 	//Special official hold considerations.
-	const bool bOfficialHoldTransfer = pOldHold->status == CDbHold::Main && (pOldHold->status == pNewHold->status);
+	const bool bOfficialHoldTransfer = CDbHold::IsOfficialHold(pOldHold->status) && (pOldHold->status == pNewHold->status);
 
 	CDb db;
 	const CIDSet roomIDs = CDb::getRoomsInLevel(this->dwLevelID);

--- a/drodrpg/DRODLib/ImportInfo.h
+++ b/drodrpg/DRODLib/ImportInfo.h
@@ -47,6 +47,7 @@ using std::vector;
 //Used during DB import.
 //Maps old local IDs to new local IDs and stores other needed information.
 typedef std::map<UINT, UINT> PrimaryKeyMap;
+typedef std::multimap<UINT, UINT> PrimaryKeyMultiMap;
 
 //Used during export.
 //Tracks records with owner IDs.  May be used to test for duplicate entries.


### PR DESCRIPTION
Replaces the `Main` status with `Tendry`, and adds a new `ACR` status. Additionally, where required, checks for the `Main` status have been replaced with `CDbHold::IsOfficialHold`.