### PR TITLE
RPG: Don't block player import due to holdless high score

### DIFF
--- a/drodrpg/DRODLib/DbLocalHighScores.cpp
+++ b/drodrpg/DRODLib/DbLocalHighScores.cpp
@@ -122,9 +122,7 @@ MESSAGE_ID CDbLocalHighScore::SetProperty(
 			this->dwHoldID = convertToUINT(str);
 			//Set to local ID.
 			localID = info.HoldIDMap.find(this->dwHoldID);
-			if (localID == info.HoldIDMap.end())
-				return MID_HoldNotFound;   //record should have been loaded already
-			this->dwHoldID = (*localID).second;
+			this->dwHoldID = localID != info.HoldIDMap.end() ? (*localID).second : 0;
 			if (!this->dwHoldID)
 			{
 				//Records for this hold are being ignored. Don't save this high score.


### PR DESCRIPTION
Having a local high score that can't be matched to hold record in a player file that's being imported is not expected, but it shouldn't cause the import to be cancelled.