### PR TITLE
Fix problem with rewinding temporal split into cutscene start

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -2766,9 +2766,15 @@ void CCurrentGame::ActivateTemporalSplit(CCueEvents& CueEvents)
 
 		UndoCommands(num_commands_to_undo, CueEvents);
 
+		UINT returnedTo = this->wTurnNo;
 		this->wPlayerTurn = playerTurn_;
 		this->wTurnNo = turnNo_;
 		this->checkpointTurns = checkpointTurns_;
+
+		//If the player rewinds to the exact turn a cutscene starts, update the tracked turn
+		//number so that undoing doesn't undo too far.
+		if (this->cutSceneStartTurn == returnedTo)
+			this->cutSceneStartTurn = this->wTurnNo;
 
 		ASSERT(this->activatingTemporalSplit > 0);
 		--this->activatingTemporalSplit;


### PR DESCRIPTION
If you start recording a temporal split on the same turn a cutscene starts, `CCurrentGame::cutSceneStartTurn` will get set to the original turn number when you rewind back, rather than the current turn number. This means that if you undo the rewind, the game reverts all the way back to the start of recording. This can be fixed by updating the tracking after a rewind.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46771