### PR TITLE
RPG: Make fast travel use currently explored rooms

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -4357,7 +4357,7 @@ void CGameScreen::SearchForPathToNextRoom(
 		}
 		const UINT newRoomID = pRoom->dwRoomID;
 		delete pRoom;
-		if (!this->pCurrentGame->roomsExploredAtRoomStart.has(newRoomID))
+		if (!this->pCurrentGame->IsRoomExplored(newRoomID))
 		{
 			this->pRoomWidget->DisplaySubtitle(
 					g_pTheDB->GetMessageText(MID_QuickPathNotAvailable), wPX, wPY, true);


### PR DESCRIPTION
Fix a bug where fast travel was only considering what rooms were explored at room start. This meant it didn't let you fast travel immediately after picking up a full reveal map, or right at the start of a level that you've played before (where the adjacent room is a preview)