### PR TITLE
RPG: When loading new style keybinds, save a default if none present

### DIFF
--- a/drodrpg/DROD/DrodScreen.cpp
+++ b/drodrpg/DROD/DrodScreen.cpp
@@ -2451,6 +2451,8 @@ void CDrodScreen::EnablePlayerSettings(
 		return;
 	}
 
+	CDbPlayer::ConvertInputSettings(pPlayer->Settings);
+
 	g_pTheSound->EnableSoundEffects(pPlayer->Settings.GetVar(Settings::SoundEffects, true));
 	g_pTheSound->SetSoundEffectsVolume(pPlayer->Settings.GetVar(Settings::SoundEffectsVolume, (BYTE)DEFAULT_SOUND_VOLUME));
 

--- a/drodrpg/DRODLib/DbPlayers.cpp
+++ b/drodrpg/DRODLib/DbPlayers.cpp
@@ -514,7 +514,6 @@ bool CDbPlayer::Load(
 		return false;
 	}
 
-	ConvertInputSettings(this->Settings);
 	return true;
 }
 

--- a/drodrpg/DRODLib/DbPlayers.cpp
+++ b/drodrpg/DRODLib/DbPlayers.cpp
@@ -936,6 +936,7 @@ void CDbPlayer::ConvertInputSettings(CDbPackedVars& settings)
 		const KeyDefinition* keyDefinition = GetKeyDefinition(i);
 
 		if (!settings.DoesVarExist(keyDefinition->settingName))
+			settings.SetVar(keyDefinition->settingName, keyDefinition->GetDefaultKey(wKeyboardMode));
 			continue;
 
 		const UNPACKEDVARTYPE varType = settings.GetVarType(keyDefinition->settingName);


### PR DESCRIPTION
When a player is loaded, we run through their key settings and convert them from the old style to the new 5.2 style which allows modifier keys. This change also makes it save down a default setting if the key setting does not exist.

This can happen when a new player is created and hasn't yet opened the settings screen, or the profile is an old one that didn't have all the expanded keybinds that weren't previously configurable.

Due to various refactors to support these new style keybinds, trying to convert these into text for e.g. displaying on scrolls would not work if the key wasn't saved down into the player's settings blob. This change ensures they are always present.