### PR TITLE
RPG: Fix sword clipping when offset is positive

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -8221,8 +8221,19 @@ void CRoomWidget::DrawSwordFor(
 
 	//Sword isn't fully in display -- just draw it clipped.
 	//(This is needed for when stepping onto room edge.)
-	UINT offsetCol = ((blit.wCol * CX_TILE) + blit.wXOffset) / CX_TILE;
-	UINT offsetRow = ((blit.wRow * CY_TILE) + blit.wYOffset) / CY_TILE;
+	signed int columnOffset = 0;
+	if ((signed int)blit.wXOffset > 0)
+		columnOffset = 1;
+	if ((signed int)blit.wXOffset < 0)
+		columnOffset = -1;
+	UINT offsetCol = blit.wCol + columnOffset;
+
+	signed int rowOffset = 0;
+	if ((signed int)blit.wYOffset > 0)
+		rowOffset = 1;
+	if ((signed int)blit.wYOffset < 0)
+		rowOffset = -1;
+	UINT offsetRow = blit.wRow + rowOffset;
 
 	if (!IS_COLROW_IN_DISP(blit.wCol, blit.wRow) ||
 		!IS_COLROW_IN_DISP(blit.wCol + nSgnX, blit.wRow + nSgnY) ||


### PR DESCRIPTION
#676 only fixed sword clipping when the offset was negative, which just so happened to be the case for all previous examples we had. This change properly accounts for both positive and negative offsets.