### PR TITLE
RPG: Fix cursor light during cutscene with none player role

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -882,12 +882,12 @@ void CRoomWidget::HandleMouseUp(const SDL_MouseButtonEvent &Button)
 			DisplayRoomCoordSubtitle(wX, wY);
 		}
 
+		PlacePlayerLightAt(pixel_x, pixel_y);
+
 		//Highlighting a customized item.
 		this->wHighlightX = wX;
 		this->wHighlightY = wY;
 		HighlightSelectedTile();
-
-		PlacePlayerLightAt(pixel_x, pixel_y);
 	}
 }
 
@@ -3565,6 +3565,9 @@ void CRoomWidget::RenderPlayerLight()
 // Pre-condition: player light vars are clear
 void CRoomWidget::PropagatePlayerLight()
 {
+	this->pActiveLightedTiles = &this->lightedPlayerTiles;
+	this->lightMaps.pActiveLight = this->lightMaps.psPlayerLight;
+
 	CEntity *pEntity = GetLightholder();
 	if (pEntity)
 	{
@@ -3583,8 +3586,6 @@ void CRoomWidget::PropagatePlayerLight()
 		static const UINT wPlayerLightRadius = 3;
 		static const UINT wLightParam = (wPlayerLightRadius-1)*NUM_LIGHT_TYPES+0; //white light
 
-		this->pActiveLightedTiles = &this->lightedPlayerTiles;
-		this->lightMaps.pActiveLight = this->lightMaps.psPlayerLight;
 		PropagateLight(fxPos, fyPos, fZ, wLightParam);
 
 		this->wLastPlayerLightX = pEntity->wX;

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -882,12 +882,12 @@ void CRoomWidget::HandleMouseUp(const SDL_MouseButtonEvent &Button)
 			DisplayRoomCoordSubtitle(wX, wY);
 		}
 
-		PlacePlayerLightAt(pixel_x, pixel_y);
-
 		//Highlighting a customized item.
 		this->wHighlightX = wX;
 		this->wHighlightY = wY;
 		HighlightSelectedTile();
+
+		PlacePlayerLightAt(pixel_x, pixel_y);
 	}
 }
 


### PR DESCRIPTION
If you have a cutscene playing with a player role of None, and the room is dark enough to have a player light, then right-clicking during the cutscene would cause the cursor light source to not clear each time you clicked or moved the mouse. This is because the code to maintain the active light source and tiles affected by it was wrapped inside a block to get the current light holder, and it wasn't considered to have one because of player role None.