### PR TITLE
RPG: Separate pushed object tracking for logic and drawing

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -5703,7 +5703,7 @@ void CCurrentGame::ProcessMonsters(
 		ASSERT(!CueEvents.HasOccurred(CID_ExitLevelPending) &&
 			!CueEvents.HasOccurred(CID_ExitToWorldMapPending));
 
-		this->pRoom->ClearPushInfo();
+		this->pRoom->ClearMovedInfo();
 
 		//Platforms fall when mimics are done moving.
 		const bool bIsMimic = pMonster->wType == M_MIMIC;

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -1755,6 +1755,12 @@ const RoomObject* CDbRoom::GetPushedObjectAt(const UINT wX, const UINT wY) const
 }
 
 //*****************************************************************************
+bool CDbRoom::HasObjectAtMoved(const UINT wX, const UINT wY) const
+{
+	return this->moved_objects.has(wX, wY);
+}
+
+//*****************************************************************************
 void CDbRoom::ReevalBriarNear(
 //Alert briar structures that room geometry has changed at (x,y).
 //
@@ -5066,6 +5072,7 @@ void CDbRoom::PushObject(
 			pObj->wPrevX = wSrcX;
 			pObj->wPrevY = wSrcY;
 			this->pushed_objects.insert(pObj);
+			this->moved_objects.insert(wDestX, wDestY);
 			
 			break;
 	}
@@ -6343,10 +6350,17 @@ void CDbRoom::ClearPushInfo()
 }
 
 //*****************************************************************************
+void CDbRoom::ClearMovedInfo()
+{
+	this->moved_objects.clear();
+}
+
+//*****************************************************************************
 void CDbRoom::ClearStateVarsUsedDuringTurn()
 {
 	this->stationary_powder_kegs.clear();
 	this->stabbed_powder_kegs.Clear();
+	this->moved_objects.clear();
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -435,13 +435,15 @@ public:
 	virtual bool   Update();
 //	void           UpdatePathMapAt(const UINT wX, const UINT wY);
 	bool           WasObjectPushedThisTurn(const UINT wX, const UINT wY) const {
-		return (GetPushedObjectAt(wX, wY)) != NULL; }
+		return HasObjectAtMoved(wX, wY); }
 
 	//scope: used while processing the current turn
 	const RoomObject* GetPushedObjectAt(const UINT wX, const UINT wY) const;
+	bool HasObjectAtMoved(const UINT wX, const UINT wY) const;
 
 private:
 	set<const RoomObject*> pushed_objects; //a simplified implementation of pushed objects to facilitate mirror movement animation
+	CCoordSet moved_objects; //objects that have been moved this processing step, to prevent body + weapon push from single entity
 
 	enum tartype {oldtar, newtar, notar};
 
@@ -449,6 +451,7 @@ private:
 	bool           CanExpandMist(const UINT wX, const UINT wY) const;
 	void           Clear();
 	void           ClearPushInfo();
+	void           ClearMovedInfo();
 	void           ClearStateVarsUsedDuringTurn();
 	void           CloseDoor(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 //	void           DeletePathMaps();


### PR DESCRIPTION
Since the front end code uses `CDbRoom::pushed_objects` to decide how to animate pushed objects, clearing it mid-turn breaks the animations. So I've split out the tracking to prevent multi-pushes into a new member, `CdbRoom::moved_objects` which only needs to care about positions.