### PR TITLE
RPG: Fix entended TOC help doc, again

### DIFF
--- a/drodrpg/Data/Help/1/extendedtoc.html
+++ b/drodrpg/Data/Help/1/extendedtoc.html
@@ -134,7 +134,7 @@
           <li><a href="customchar.html#tiles">Tile sets</a></li>
           <li><a href="customchar.html#animationspeed">Animation speed</a></li>
 		</ul></li>
-      </ul>
+      </ul></li>
       <li><a href="editroom.html#customize">Customizing and Special Objects</a>
       <ul>
         <li><a href="character.html">NPCs</a></li>
@@ -153,7 +153,7 @@
       <li><a href="editroom.html#roomerrors">Room Errors</a></li>
       <li><a href="editroom.html#miscnotes">Misc. Notes</a></li>
       <li><a href="editroom.html#keyboardref">Keyboard commands</a></li>
-    </ul>
+    </ul></li>
     <li><a href="modscreen.html"><b>Mod management</b></a></li>
     <li><a href="weather.html"><b>Environmental settings</b></a></li>
   </ul></li>


### PR DESCRIPTION
#908 fixed a bad tag in the extended help file doc then broke it in two other places, doh! Now it's fixed for real.