### PR TITLE
RPG: Tweak display of unearned scorepoints on scorepoint dialog

### DIFF
--- a/drodrpg/DROD/RestoreScreen.cpp
+++ b/drodrpg/DROD/RestoreScreen.cpp
@@ -922,6 +922,22 @@ void CRestoreScreen::PopulateListBoxFromSavedGames()
 	}
 }
 
+//*****************************************************************************
+WSTRING obscureScorepointName(const WSTRING& name)
+//Returns: Copy of string with alphanumeric characters replaced by question marks
+{
+	WSTRING obscured;
+	for (WSTRING::const_iterator it = name.cbegin(); it != name.cend(); ++it) {
+		if (isalnum(*it)) {
+			obscured.push_back('?');
+		} else {
+			obscured.push_back(*it);
+		}
+	}
+
+	return obscured;
+}
+
 void CRestoreScreen::PopulateScorepoints(CListBoxWidget* pListBoxWidget)
 {
 	//Complete scanning any remaining rooms for scorepoints.
@@ -959,7 +975,7 @@ void CRestoreScreen::PopulateScorepoints(CListBoxWidget* pListBoxWidget)
 		bool hasScore = (db.HighScores.HasScorepoint(scorepointName));
 #ifndef ENABLE_CHEATS
 		if (!(hasScore || bShowName)) {
-			pListBoxWidget->AddItem(0, L"???", true);
+			pListBoxWidget->AddItem(0, obscureScorepointName(scorepointName).c_str(), true);
 		}	else
 #endif
 		{

--- a/drodrpg/DROD/RestoreScreen.cpp
+++ b/drodrpg/DROD/RestoreScreen.cpp
@@ -947,9 +947,9 @@ void CRestoreScreen::PopulateScorepoints(CListBoxWidget* pListBoxWidget)
 #ifndef ENABLE_CHEATS
 	// Check hold authorship
 	// Not required if cheats are active
-	bool bIsAuthor = (pPlayer->dwPlayerID == pHold->dwPlayerID);
-	delete pPlayer;
+	bool bShowName = db.Holds.PlayerCanEditHold(pHold->dwHoldID);
 #endif
+	delete pPlayer;
 
 	for (CDbHolds::VARCOORDMAP::const_iterator vars = this->scorepointVarMap.begin();
 		vars != this->scorepointVarMap.end(); ++vars)
@@ -958,7 +958,7 @@ void CRestoreScreen::PopulateScorepoints(CListBoxWidget* pListBoxWidget)
 		WSTRING scorepointName = vars->first;
 		bool hasScore = (db.HighScores.HasScorepoint(scorepointName));
 #ifndef ENABLE_CHEATS
-		if (!(hasScore || bIsAuthor)) {
+		if (!(hasScore || bShowName)) {
 			pListBoxWidget->AddItem(0, L"???", true);
 		}	else
 #endif


### PR DESCRIPTION
Two changes to make it easier to check for and discuss missing scorepoints:

1. Scorepoint names are not obscured for holds you can edit
2. Rather than all scorepoints being obscured as "???", alphanumeric characters in the scorepoint name are instead replaced with question marks.
3. 
Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=41708