### PR TITLE
RPG: Make move counter persist between sessions

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -4299,6 +4299,11 @@ void CGameScreen::ApplyPlayerSettings()
 	this->pRoomWidget->ShowDamagePreview(bShowDamagePreview);
 	this->pTempRoomWidget->ShowDamagePreview(bShowDamagePreview);
 
+	//Enable/disable move counter.
+	if (this->pRoomWidget->IsShowingMoveCount() !=
+		settings.GetVar(Settings::MoveCounter, false))
+		this->pRoomWidget->ToggleMoveCount();
+
 /*
 	//Set times when saved games and demos are saved automatically.
 	if (!this->bPlayTesting)

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -294,6 +294,7 @@ public:
 	bool           IsMoveAnimating() const {return this->dwMovementStepsLeft != 0;}
 	virtual bool   IsPlayerLightRendered() const;
 	bool           IsPlayerLightShowing() const;
+	bool           IsShowingMoveCount() const { return this->bShowMoveCount; }
 	bool           IsWeatherRendered() const;
 	bool           LoadFromCurrentGame(CCurrentGame *pSetCurrentGame, const bool bLoad=true);
 	bool           LoadFromRoom(CDbRoom *pRoom, const bool bLoad=true);


### PR DESCRIPTION
Reported as a bug, although it looks like RPG just didn't support this

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46824