### PR TITLE
RPG: Port over fix for level rearranging

### DIFF
--- a/drodrpg/DROD/EditSelectScreen.cpp
+++ b/drodrpg/DROD/EditSelectScreen.cpp
@@ -1221,11 +1221,13 @@ void CEditSelectScreen::OnRearranged(const UINT dwTagNo)
 			{
 				const UINT dwLevelID = this->pLevelListBoxWidget->GetKeyAtLine(dwIndex);
 				ASSERT(dwLevelID);
-				CDbLevel *pLevel = g_pTheDB->Levels.GetByID(dwLevelID);
-				ASSERT(pLevel);
-				pLevel->dwOrderIndex = dwIndex + 1;
-				pLevel->Update();
-				delete pLevel;
+				if (dwLevelID != ADD_LEVEL_ID) {
+					CDbLevel* pLevel = g_pTheDB->Levels.GetByID(dwLevelID);
+					ASSERT(pLevel);
+					pLevel->dwOrderIndex = dwIndex + 1;
+					pLevel->Update();
+					delete pLevel;
+				}
 			}
 			//Reload selected level so local state is synched.
 			const UINT dwLevelID = this->pSelectedLevel->dwLevelID;


### PR DESCRIPTION
Porting over a fix from classic DROD that stops the editor crashing when you try to rearrange the level list, a regression introduced by the world map feature.