### PR TITLE
RPG: Remove _TotalTime from docs

### DIFF
--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -837,8 +837,6 @@ The variable names are case-insensitive.
   </tr><tr>
     <td>_TotalMoves</td><td>total moves made by the player this game</td><td></td><td></td>
   </tr><tr>
-    <td>_TotalTime</td><td>total time spent by the player this game (in ms)</td><td></td><td></td>
-  </tr><tr>
     <td><b>Combat stats</b></td><td></td><td></td><td></td>
   </tr><tr>
     <td>_EnemyHP</td><td>Enemy's HP(<a href="#enemy">*</a>)</td><td></td><td>0,MAX</td>


### PR DESCRIPTION
_TotalTime was removed as a predefined variable a long time ago, but was still in the docs by mistake.