### PR TITLE
RPG: Move GetScore statics to CCurrentGame

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -4778,16 +4778,16 @@ void CGameScreen::ShowScoreDialog(const WSTRING pTitle, const PlayerStats& st)
 	dwXP = st.XP;
 	dwShovels = st.shovels;
 
-	dwHPScore = CDbSavedGames::CalculateStatScore(dwHP, st.scoreHP);
-	dwATKScore = CDbSavedGames::CalculateStatScore(dwATK, st.scoreATK);
-	dwDEFScore = CDbSavedGames::CalculateStatScore(dwDEF, st.scoreDEF);
-	dwGOLDScore = CDbSavedGames::CalculateStatScore(dwGOLD, st.scoreGOLD);
-	dwXPScore = CDbSavedGames::CalculateStatScore(dwXP, st.scoreXP);
-	dwYKeysScore = CDbSavedGames::CalculateStatScore(dwYKeys, st.scoreYellowKeys);
-	dwGKeysScore = CDbSavedGames::CalculateStatScore(dwGKeys, st.scoreGreenKeys);
-	dwBKeysScore = CDbSavedGames::CalculateStatScore(dwBKeys, st.scoreBlueKeys);
-	dwSKeysScore = CDbSavedGames::CalculateStatScore(dwSKeys, st.scoreSkeletonKeys);
-	dwShovelsScore = CDbSavedGames::CalculateStatScore(dwShovels, st.scoreShovels);
+	dwHPScore = CCurrentGame::CalculateStatScore(dwHP, st.scoreHP);
+	dwATKScore = CCurrentGame::CalculateStatScore(dwATK, st.scoreATK);
+	dwDEFScore = CCurrentGame::CalculateStatScore(dwDEF, st.scoreDEF);
+	dwGOLDScore = CCurrentGame::CalculateStatScore(dwGOLD, st.scoreGOLD);
+	dwXPScore = CCurrentGame::CalculateStatScore(dwXP, st.scoreXP);
+	dwYKeysScore = CCurrentGame::CalculateStatScore(dwYKeys, st.scoreYellowKeys);
+	dwGKeysScore = CCurrentGame::CalculateStatScore(dwGKeys, st.scoreGreenKeys);
+	dwBKeysScore = CCurrentGame::CalculateStatScore(dwBKeys, st.scoreBlueKeys);
+	dwSKeysScore = CCurrentGame::CalculateStatScore(dwSKeys, st.scoreSkeletonKeys);
+	dwShovelsScore = CCurrentGame::CalculateStatScore(dwShovels, st.scoreShovels);
 	dwTotalScore = this->pCurrentGame->GetScore();
 
 	CTilesWidget* pTilesWidget = DYN_CAST(CTilesWidget*, CWidget*, this->pScoreDialog->GetWidget(TAG_SCORETILES));

--- a/drodrpg/DROD/SettingsScreen.cpp
+++ b/drodrpg/DROD/SettingsScreen.cpp
@@ -2113,7 +2113,7 @@ void CSettingsScreen::UploadScoreCheckpointSaves(const UINT dwPlayerID)
 
 			PlayerStats ps;
 			ps.Unpack(pSavedGame->stats);
-			const UINT score = CDbSavedGames::GetScore(ps);
+			const UINT score = CCurrentGame::GetScore(ps);
 
 			const UINT wUploadingScoreHandle = g_pTheNet->UploadScore(text, pSavedGame->stats.GetVar(szSavename, wszEmpty), score);
 			delete pSavedGame;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1285,7 +1285,44 @@ UINT CCurrentGame::GetScore() const
 	st.ATK = getPlayerATK();
 	st.DEF = getPlayerDEF();
 
-	return CDbSavedGames::GetScore(st);
+	return GetScore(st);
+}
+
+//*******************************************************************************
+UINT CCurrentGame::GetScore(const PlayerStats& st)
+//Return: score for these player stats
+{
+	UINT dwScore = 0;
+	dwScore += CalculateStatScore(st.HP, st.scoreHP);
+	dwScore += CalculateStatScore(st.ATK, st.scoreATK);
+	dwScore += CalculateStatScore(st.DEF, st.scoreDEF);
+	dwScore += CalculateStatScore(st.yellowKeys, st.scoreYellowKeys);
+	dwScore += CalculateStatScore(st.greenKeys, st.scoreGreenKeys);
+	dwScore += CalculateStatScore(st.blueKeys, st.scoreBlueKeys);
+	dwScore += CalculateStatScore(st.skeletonKeys, st.scoreSkeletonKeys);
+	dwScore += CalculateStatScore(st.GOLD, st.scoreGOLD);
+	dwScore += CalculateStatScore(st.XP, st.scoreXP);
+	dwScore += CalculateStatScore(st.shovels, st.scoreShovels);
+
+	return dwScore;
+}
+
+//*******************************************************************************
+UINT CCurrentGame::CalculateStatScore(const int stat, const int scoreMultiplier)
+//Return: score for a particular stat
+{
+	const int maxAllowedScore = 100000000;
+	if (scoreMultiplier > 0)
+	{
+		if (stat > maxAllowedScore / scoreMultiplier) return maxAllowedScore;
+		if (stat < -maxAllowedScore / scoreMultiplier) return -maxAllowedScore;
+		return stat * scoreMultiplier;
+	}
+	if (scoreMultiplier < 0)
+	{
+		return min(maxAllowedScore, max(-maxAllowedScore, stat / abs(scoreMultiplier)));
+	}
+	return 0;
 }
 
 //*****************************************************************************
@@ -8456,7 +8493,7 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 	}
 
 	CDbLocalHighScore* pHighScore = NULL;
-	int score = CDbSavedGames::GetScore(st);
+	int score = GetScore(st);
 	CDb db;
 	UINT holdID = this->pHold->dwHoldID;
 	UINT playerID = pPlayer->dwPlayerID;

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -271,6 +271,8 @@ public:
 	WSTRING  GetScrollTextAt(const UINT wX, const UINT wY);
 	UINT     GetRoomExitDirection(const UINT wMoveO) const;
 	UINT     GetScore() const;
+	static UINT GetScore(const PlayerStats& st);
+	static UINT CalculateStatScore(const int stat, const int scoreMultiplier);
 	CEntity* getSpeakingEntity(CFiredCharacterCommand* pFiredCommand);
 	bool     GetSwordsman(UINT& wSX, UINT& wSY, const bool bIncludeNonTarget=false) const;
 	UINT     GetSwordMovement() const;

--- a/drodrpg/DRODLib/DbSavedGames.cpp
+++ b/drodrpg/DRODLib/DbSavedGames.cpp
@@ -2964,43 +2964,6 @@ UINT CDbSavedGames::GetSavedGameID(
 	return 0;
 }
 
-//*******************************************************************************
-UINT CDbSavedGames::GetScore(const PlayerStats& st)
-//Return: score for these player stats
-{
-	UINT dwScore = 0;
-	dwScore += CalculateStatScore(st.HP, st.scoreHP);
-	dwScore += CalculateStatScore(st.ATK, st.scoreATK);
-	dwScore += CalculateStatScore(st.DEF, st.scoreDEF);
-	dwScore += CalculateStatScore(st.yellowKeys, st.scoreYellowKeys);
-	dwScore += CalculateStatScore(st.greenKeys, st.scoreGreenKeys);
-	dwScore += CalculateStatScore(st.blueKeys, st.scoreBlueKeys);
-	dwScore += CalculateStatScore(st.skeletonKeys, st.scoreSkeletonKeys);
-	dwScore += CalculateStatScore(st.GOLD, st.scoreGOLD);
-	dwScore += CalculateStatScore(st.XP, st.scoreXP);
-	dwScore += CalculateStatScore(st.shovels, st.scoreShovels);
-
-	return dwScore;
-}
-
-//*******************************************************************************
-UINT CDbSavedGames::CalculateStatScore(const int stat, const int scoreMultiplier)
-//Return: score for a particular stat
-{
-	const int maxAllowedScore = 100000000;
-	if (scoreMultiplier > 0)
-	{
-		if (stat > maxAllowedScore / scoreMultiplier) return maxAllowedScore;
-		if (stat < -maxAllowedScore / scoreMultiplier) return -maxAllowedScore;
-		return stat * scoreMultiplier;
-	}
-	if (scoreMultiplier < 0)
-	{
-		return min(maxAllowedScore, max(-maxAllowedScore, stat / abs(scoreMultiplier)));
-	}
-	return 0;
-}
-
 //*****************************************************************************
 CIDSet CDbSavedGames::GetExploredRooms(const UINT savedGameID)
 //Returns: set of explored rooms for saved game with specified ID

--- a/drodrpg/DRODLib/DbSavedGames.h
+++ b/drodrpg/DRODLib/DbSavedGames.h
@@ -268,8 +268,6 @@ public:
 	static UINT GetRoomIDofSavedGame(const UINT dwSavedGameID);
 	static UINT GetSavedGameID(const UINT dwRoomID, const CDate& Created, const UINT dwPlayerID);
 	static vector<SAVE_INFO> GetSaveInfo(const CIDSet& savedGameIDs);
-	static UINT GetScore(const PlayerStats& st);
-	static UINT CalculateStatScore(const int stat, const int scoreMultiplier);
 	static SAVETYPE GetType(const UINT savedGameID);
 	static UINT GetWorldMapID(const UINT savedGameID);
 


### PR DESCRIPTION
CDbSavedGames had some static methods for determining the current game score. These methods did not interact with the database at all, so it was odd that they were placed there. Instead I consider it a function of your current game, so this relocates them to CCurrentGame.

Alternatively, the GetScore(playerStats) static might be better off as a member method of the PlayerStats object instead of a static, given it must have a PlayerStats object. That would leave the question of where CalculateStatScore should live, which still feels best placed in CCurrentGame, but could just be a static of PlayerStats.