### PR TITLE
RPG: Part 1 of alternative way of tracking map states

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -2447,12 +2447,12 @@ void CGameScreen::OnClick(
 					{
 						ExploredRoom *pExpRoom = this->pCurrentGame->getExploredRoom(roomID);
 						if ((pExpRoom && pExpRoom->HasDetail()) ||
-							this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(roomID) >= MapState::Preview)
+							this->pCurrentGame->GetStoredMapStateForRoom(roomID) >= MapState::Preview)
 						{
 							ShowRoomTemporarily(roomID);
-						}
-						else
+						} else {
 							ToggleBigMap();
+						}
 					}
 				}
 			}
@@ -2494,12 +2494,13 @@ void CGameScreen::OnClick(
 				} else {
 					ExploredRoom *pExpRoom = this->pCurrentGame->getExploredRoom(roomID);
 					if ((pExpRoom && pExpRoom->HasDetail()) ||
-						this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(roomID) >= MapState::Preview)
+						this->pCurrentGame->GetStoredMapStateForRoom(roomID) >= MapState::Preview)
 					{
 						ShowRoomTemporarily(roomID);
 					}
-					else
+					else {
 						ToggleBigMap(); //no room to show -- close map
+					}
 				}
 			}
 			break;
@@ -4370,7 +4371,7 @@ void CGameScreen::SearchForPathToNextRoom(
 		const UINT newRoomID = pRoom->dwRoomID;
 		delete pRoom;
 		if (!this->pCurrentGame->IsRoomExplored(newRoomID) &&
-			this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(newRoomID) != MapState::Invisible)
+			this->pCurrentGame->GetStoredMapStateForRoom(newRoomID) != MapState::Invisible)
 		{
 			this->pRoomWidget->DisplaySubtitle(
 					g_pTheDB->GetMessageText(MID_QuickPathNotAvailable), wPX, wPY, true);
@@ -8654,8 +8655,8 @@ void CGameScreen::DisplayAdjacentTempRoom(const UINT direction)
 
 	const UINT dwNewRoomID = this->pCurrentGame->pLevel->GetRoomIDAtCoords(newRoomX, newRoomY);
 
-	if (!this->pCurrentGame->IsRoomAtCoordsExplored(newRoomX, newRoomY) &&
-		this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(dwNewRoomID) < MapState::Preview) {
+	if (!this->pCurrentGame->CDbSavedGame::IsRoomExplored(dwNewRoomID) &&
+		this->pCurrentGame->GetStoredMapStateForRoom(dwNewRoomID) < MapState::Preview) {
 		g_pTheSound->PlaySoundEffect(SEID_CHECKPOINT);
 		return;
 	}

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8655,7 +8655,7 @@ void CGameScreen::DisplayAdjacentTempRoom(const UINT direction)
 
 	const UINT dwNewRoomID = this->pCurrentGame->pLevel->GetRoomIDAtCoords(newRoomX, newRoomY);
 
-	if (!this->pCurrentGame->CDbSavedGame::IsRoomExplored(dwNewRoomID) &&
+	if (!this->pCurrentGame->IsRoomExplored(dwNewRoomID) &&
 		this->pCurrentGame->GetStoredMapStateForRoom(dwNewRoomID) < MapState::Preview) {
 		g_pTheSound->PlaySoundEffect(SEID_CHECKPOINT);
 		return;

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -2446,9 +2446,13 @@ void CGameScreen::OnClick(
 					if (!this->pCurrentGame->InCombat() && !this->bNeedToProcessDelayedQuestions)
 					{
 						ExploredRoom *pExpRoom = this->pCurrentGame->getExploredRoom(roomID);
-						if (pExpRoom && pExpRoom->HasDetail())
+						if ((pExpRoom && pExpRoom->HasDetail()) ||
+							this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(roomID) >= MapState::Preview)
+						{
 							ShowRoomTemporarily(roomID);
-						else ToggleBigMap();
+						}
+						else
+							ToggleBigMap();
 					}
 				}
 			}
@@ -2489,9 +2493,13 @@ void CGameScreen::OnClick(
 					ToggleBigMap();
 				} else {
 					ExploredRoom *pExpRoom = this->pCurrentGame->getExploredRoom(roomID);
-					if (pExpRoom && pExpRoom->HasDetail())
+					if ((pExpRoom && pExpRoom->HasDetail()) ||
+						this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(roomID) >= MapState::Preview)
+					{
 						ShowRoomTemporarily(roomID);
-					else ToggleBigMap(); //no room to show -- close map
+					}
+					else
+						ToggleBigMap(); //no room to show -- close map
 				}
 			}
 			break;
@@ -4361,7 +4369,8 @@ void CGameScreen::SearchForPathToNextRoom(
 		}
 		const UINT newRoomID = pRoom->dwRoomID;
 		delete pRoom;
-		if (!this->pCurrentGame->IsRoomExplored(newRoomID))
+		if (!this->pCurrentGame->IsRoomExplored(newRoomID) &&
+			this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(newRoomID) != MapState::Invisible)
 		{
 			this->pRoomWidget->DisplaySubtitle(
 					g_pTheDB->GetMessageText(MID_QuickPathNotAvailable), wPX, wPY, true);
@@ -8643,7 +8652,10 @@ void CGameScreen::DisplayAdjacentTempRoom(const UINT direction)
 		default: ASSERT(!"Unsupported temp room pan direction"); return;
 	}
 
-	if (!this->pCurrentGame->IsRoomAtCoordsExplored(newRoomX, newRoomY)) {
+	const UINT dwNewRoomID = this->pCurrentGame->pLevel->GetRoomIDAtCoords(newRoomX, newRoomY);
+
+	if (!this->pCurrentGame->IsRoomAtCoordsExplored(newRoomX, newRoomY) &&
+		this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(dwNewRoomID) < MapState::Preview) {
 		g_pTheSound->PlaySoundEffect(SEID_CHECKPOINT);
 		return;
 	}

--- a/drodrpg/DROD/MapWidget.cpp
+++ b/drodrpg/DROD/MapWidget.cpp
@@ -933,9 +933,9 @@ bool CMapWidget::SelectRoomIfValid(
 		
 		//Has it been explored?
 		if (this->bEditing ||
+			storedMapState != MapState::Invisible ||
 			this->ExploredRooms.has(dwRoomID) ||
-			this->NoDetailRooms.has(dwRoomID) ||
-			storedMapState != MapState::Invisible) //Yes.
+			this->NoDetailRooms.has(dwRoomID)) //Yes.
 		{
 			//Select the room.
 			SelectRoom(dwRoomX, dwRoomY);

--- a/drodrpg/DROD/MapWidget.cpp
+++ b/drodrpg/DROD/MapWidget.cpp
@@ -120,7 +120,7 @@ CMapWidget::CMapWidget(
 	UINT dwSetTagNo,                //(in)   Required params for CWidget 
 	int nSetX, int nSetY,               //    constructor.
 	UINT wSetW, UINT wSetH,             //
-	CCurrentGame *pSetCurrentGame,   //(in) Game to use for drawing the map.
+	const CCurrentGame *pSetCurrentGame,   //(in) Game to use for drawing the map.
 	const UINT sizeMultiplier) //[default=1]
 	: CFocusWidget((WIDGETTYPE)WT_Map, dwSetTagNo, nSetX, nSetY, wSetW, wSetH)
 	, bVacantRoom(false)
@@ -399,7 +399,7 @@ bool CMapWidget::LoadFromCurrentGame(
 //Sets current game used by map.
 //
 //Params:
-	CCurrentGame *pSetCurrentGame,   //(in) New current game.
+	const CCurrentGame *pSetCurrentGame,   //(in) New current game.
 	const bool bDrawSurface)   //(in) if true [default], draw rooms onto map surface
 //
 //Returns:

--- a/drodrpg/DROD/MapWidget.cpp
+++ b/drodrpg/DROD/MapWidget.cpp
@@ -927,9 +927,14 @@ bool CMapWidget::SelectRoomIfValid(
 			dwRoomX, dwRoomY);
 	if (dwRoomID) //Yes.
 	{
+		MapState storedMapState = MapState::Invisible;
+		if (this->pCurrentGame && this->pCurrentGame->pTotalMapStates)
+			storedMapState = this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(dwRoomID);
 		//Has it been explored?
-		if (this->bEditing || this->ExploredRooms.has(dwRoomID) ||
-				this->NoDetailRooms.has(dwRoomID)) //Yes.
+		if (this->bEditing ||
+			this->ExploredRooms.has(dwRoomID) ||
+			this->NoDetailRooms.has(dwRoomID) ||
+			storedMapState != MapState::Invisible) //Yes.
 		{
 			//Select the room.
 			SelectRoom(dwRoomX, dwRoomY);
@@ -1085,9 +1090,15 @@ bool CMapWidget::LoadMapSurface(
 	for (CIDSet::const_iterator iter=roomIDs.begin(); iter != roomIDs.end(); ++iter)
 	{
 		CDbRoom *pRoom = g_pTheDB->Rooms.GetByID(*iter, true);  //load only coord data
+
+		MapState storedMapState = MapState::Invisible;
+		if (this->pCurrentGame && this->pCurrentGame->pTotalMapStates)
+			storedMapState = this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(*iter);
+
 		const bool bIncludeRoom = this->bEditing ||
 				this->NoDetailRooms.has(*iter) ||
-				this->pCurrentGame->IsRoomAtCoordsExplored(pRoom->dwRoomX, pRoom->dwRoomY);
+				this->pCurrentGame->IsRoomAtCoordsExplored(pRoom->dwRoomX, pRoom->dwRoomY) ||
+				storedMapState != MapState::Invisible;
 
 		if (!bInScrollWindow || bIncludeRoom)
 		{
@@ -1346,14 +1357,28 @@ void CMapWidget::DrawMapSurfaceFromRoom(
 
 	//Get variables that affect how map pixels are set.
 	//When there is no current game, then show everything fully.
-	ExploredRoom *pExpRoom = this->pCurrentGame ? this->pCurrentGame->getExploredRoom(pRoom->dwRoomID) : NULL;
+	ExploredRoom* pExpRoom = NULL;
+	MapState drawState = MapState::Invisible;
+	if (this->pCurrentGame)
+	{
+		pExpRoom = this->pCurrentGame->getExploredRoom(pRoom->dwRoomID);
+		if (pExpRoom)
+			drawState = max(pExpRoom->mapState, this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(pRoom->dwRoomID));
+		else
+		{
+			if (this->pCurrentGame->pRoom->dwRoomID == pRoom->dwRoomID)
+				drawState = MapState::Explored;
+			else
+				drawState = this->pCurrentGame->pTotalMapStates->GetStoredMapStateForRoom(pRoom->dwRoomID);
+		}
+	}
 
 	//Room previews are shown distinctly on the map
-	const bool bRoomPreview = pExpRoom && (pExpRoom->mapState == MapState::Preview);
+	const bool bRoomPreview = drawState == MapState::Preview;
 	if (bRoomPreview)
 		this->PreviewedRooms += pRoom->dwRoomID;
 
-	const bool bNoDetails = !bRoomPreview && this->NoDetailRooms.has(pRoom->dwRoomID);
+	const bool bNoDetails = !bRoomPreview && (drawState == MapState::NoDetail || this->NoDetailRooms.has(pRoom->dwRoomID));
 
 	//Map markers override default room coloring.
 	SURFACECOLOR color, maxColor = { 0, 0, 0 };

--- a/drodrpg/DROD/MapWidget.h
+++ b/drodrpg/DROD/MapWidget.h
@@ -39,7 +39,7 @@ class CMapWidget : public CFocusWidget
 {     
 public:
 	CMapWidget(UINT dwSetTagNo, int nSetX, int nSetY, UINT wSetW, 
-			UINT wSetH, CCurrentGame *pSetCurrentGame, const UINT sizeMultiplier=1);
+			UINT wSetH, const CCurrentGame *pSetCurrentGame, const UINT sizeMultiplier=1);
 
 	void           ClearMap();
 	void           ClearState();
@@ -52,7 +52,7 @@ public:
 	void           GetVisibleMapRect(SDL_Rect &rect) const;
 	void           HighlightRoom(SDL_Rect& dest, const UINT wWidth=1);
 	bool           IsDeletingRoom() const {return this->bDeletingRoom;}
-	bool           LoadFromCurrentGame(CCurrentGame *pSetCurrentGame,
+	bool           LoadFromCurrentGame(const CCurrentGame *pSetCurrentGame,
 			const bool bDrawSurface=true);
 	bool           LoadFromLevel(CDbLevel *pLevel);
 	virtual void   Paint(bool bUpdateRect = true);
@@ -108,7 +108,7 @@ private:
 	CIDSet               NoDetailRooms, PreviewedRooms;
 	bool              bIsLevelComplete;
 
-	CCurrentGame * pCurrentGame;  //to show map of a game in progress
+	const CCurrentGame * pCurrentGame;  //to show map of a game in progress
 	CDbLevel *           pLevel;        //to show map of entire level
 	SDL_Surface *        pMapSurface;
 

--- a/drodrpg/DROD/MapWidget.h
+++ b/drodrpg/DROD/MapWidget.h
@@ -39,7 +39,7 @@ class CMapWidget : public CFocusWidget
 {     
 public:
 	CMapWidget(UINT dwSetTagNo, int nSetX, int nSetY, UINT wSetW, 
-			UINT wSetH, const CCurrentGame *pSetCurrentGame, const UINT sizeMultiplier=1);
+			UINT wSetH, CCurrentGame *pSetCurrentGame, const UINT sizeMultiplier=1);
 
 	void           ClearMap();
 	void           ClearState();
@@ -52,7 +52,7 @@ public:
 	void           GetVisibleMapRect(SDL_Rect &rect) const;
 	void           HighlightRoom(SDL_Rect& dest, const UINT wWidth=1);
 	bool           IsDeletingRoom() const {return this->bDeletingRoom;}
-	bool           LoadFromCurrentGame(const CCurrentGame *pSetCurrentGame,
+	bool           LoadFromCurrentGame(CCurrentGame *pSetCurrentGame,
 			const bool bDrawSurface=true);
 	bool           LoadFromLevel(CDbLevel *pLevel);
 	virtual void   Paint(bool bUpdateRect = true);
@@ -108,7 +108,7 @@ private:
 	CIDSet               NoDetailRooms, PreviewedRooms;
 	bool              bIsLevelComplete;
 
-	const CCurrentGame * pCurrentGame;  //to show map of a game in progress
+	CCurrentGame * pCurrentGame;  //to show map of a game in progress
 	CDbLevel *           pLevel;        //to show map of entire level
 	SDL_Surface *        pMapSurface;
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2443,10 +2443,9 @@ void CCharacter::Process(
 					if (roomID)
 					{
 						const bool bMarkExplored = command.w != 0;
-						MapState mapState = bMarkExplored ? MapState::Explored : MapState::NoDetail;
+						const MapState mapState = bMarkExplored ? MapState::Explored : MapState::NoDetail;
 						pGame->AddRoomToMap(roomID, mapState);
-						ASSERT(this->pCurrentGame->pTotalMapStates);
-						this->pCurrentGame->pTotalMapStates->Update(roomID, mapState, this->pCurrentGame->bNoSaves);
+						pGame->UpdateStoredMapState(roomID, mapState);
 						CueEvents.Add(CID_LevelMap, new CAttachableWrapper<UINT>(
 							bMarkExplored ? T_MAP_DETAIL : T_MAP));
 					}

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2443,7 +2443,10 @@ void CCharacter::Process(
 					if (roomID)
 					{
 						const bool bMarkExplored = command.w != 0;
-						pGame->AddRoomToMap(roomID, bMarkExplored ? MapState::Explored : MapState::NoDetail);
+						MapState mapState = bMarkExplored ? MapState::Explored : MapState::NoDetail;
+						pGame->AddRoomToMap(roomID, mapState);
+						ASSERT(this->pCurrentGame->pTotalMapStates);
+						this->pCurrentGame->pTotalMapStates->Update(roomID, mapState, this->pCurrentGame->bNoSaves);
 						CueEvents.Add(CID_LevelMap, new CAttachableWrapper<UINT>(
 							bMarkExplored ? T_MAP_DETAIL : T_MAP));
 					}

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -453,7 +453,7 @@ public:
 
 	//TotalMapStates
 	CTotalMapStates TotalMapStates;
-	MapState GetStoredMapStateForRoom(const UINT roomID) { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
+	const MapState GetStoredMapStateForRoom(const UINT roomID) { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
 	void UpdateStoredMapState(const UINT roomID, const MapState state) { TotalMapStates.Update(roomID, state, this->bNoSaves); }
 	void UpdateStoredMapState(const CIDSet roomIDs, const MapState state) { TotalMapStates.Update(roomIDs, state, this->bNoSaves); }
 

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -453,7 +453,7 @@ public:
 
 	//TotalMapStates
 	CTotalMapStates TotalMapStates;
-	const MapState GetStoredMapStateForRoom(const UINT roomID) { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
+	const MapState GetStoredMapStateForRoom(const UINT roomID) const { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
 	void UpdateStoredMapState(const UINT roomID, const MapState state) { TotalMapStates.Update(roomID, state, this->bNoSaves); }
 	void UpdateStoredMapState(const CIDSet roomIDs, const MapState state) { TotalMapStates.Update(roomIDs, state, this->bNoSaves); }
 

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -453,7 +453,7 @@ public:
 
 	//TotalMapStates
 	CTotalMapStates TotalMapStates;
-	const MapState GetStoredMapStateForRoom(const UINT roomID) const { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
+	MapState GetStoredMapStateForRoom(const UINT roomID) const { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
 	void UpdateStoredMapState(const UINT roomID, const MapState state) { TotalMapStates.Update(roomID, state, this->bNoSaves); }
 	void UpdateStoredMapState(const CIDSet& roomIDs, const MapState state) { TotalMapStates.Update(roomIDs, state, this->bNoSaves); }
 

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -205,7 +205,7 @@ protected:
 	CCurrentGame();
 	CCurrentGame(const CCurrentGame &Src)
 		: CDbSavedGame(false), pRoom(NULL), pLevel(NULL),
-		  pHold(NULL), pEntrance(NULL), pTotalMapStates(NULL)//, pSnapshotGame(NULL)
+		  pHold(NULL), pEntrance(NULL)//, pSnapshotGame(NULL)
 	{SetMembers(Src);}
 
 public:
@@ -400,7 +400,6 @@ public:
 	CDbLevel *  pLevel;
 	CDbHold *   pHold;
 	CEntranceData *pEntrance;
-	CTotalMapStates *pTotalMapStates;
 
 	//Player state
 	CSwordsman *pPlayer;
@@ -451,6 +450,12 @@ public:
 	bool     bQuickCombat; //combat resolves immediately when set
 	CCombat  *pCombat;
 	CMonster *pBlockedSwordHit; //when not NULL, indicates this turn's movement is invalid due to a forbidden attack on this monster
+
+	//TotalMapStates
+	CTotalMapStates TotalMapStates;
+	MapState GetStoredMapStateForRoom(const UINT roomID) { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
+	void UpdateStoredMapState(const UINT roomID, const MapState state) { TotalMapStates.Update(roomID, state, this->bNoSaves); }
+	void UpdateStoredMapState(const CIDSet roomIDs, const MapState state) { TotalMapStates.Update(roomIDs, state, this->bNoSaves); }
 
 private:
 	void AdvanceCombat(CCueEvents& CueEvents);
@@ -536,6 +541,8 @@ private:
 
 	void     AddRoomsPreviouslyExploredByPlayerToMap(UINT playerID = 0);
 	CIDSet   PreviouslyExploredRooms; //cache values
+
+	void     InitializeTotalMapStates();
 };
 
 #endif //...#ifndef CURRENTGAME_H

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -80,6 +80,7 @@
 #include "MonsterMessage.h"
 #include "PlayerDouble.h"
 #include "PlayerStats.h"
+#include "TotalMapStates.h"
 #include <BackEndLib/Assert.h>
 #include <BackEndLib/AttachableObject.h>
 #include <BackEndLib/Coord.h>
@@ -204,7 +205,7 @@ protected:
 	CCurrentGame();
 	CCurrentGame(const CCurrentGame &Src)
 		: CDbSavedGame(false), pRoom(NULL), pLevel(NULL),
-		  pHold(NULL), pEntrance(NULL)//, pSnapshotGame(NULL)
+		  pHold(NULL), pEntrance(NULL), pTotalMapStates(NULL)//, pSnapshotGame(NULL)
 	{SetMembers(Src);}
 
 public:
@@ -399,6 +400,7 @@ public:
 	CDbLevel *  pLevel;
 	CDbHold *   pHold;
 	CEntranceData *pEntrance;
+	CTotalMapStates *pTotalMapStates;
 
 	//Player state
 	CSwordsman *pPlayer;
@@ -406,6 +408,7 @@ public:
 	//Game state vars
 //	bool     bIsDemoRecording;
 	bool     bIsGameActive;
+	bool     bNoSaves;   //don't save anything to DB when set (e.g., for dummy game sessions)
 	UINT     wTurnNo;
 	UINT     wPlayerTurn;      //player move #
 	UINT     wSpawnCycleCount; //monster move #
@@ -523,7 +526,6 @@ private:
 	CIDSet   CompletedScriptsPending;   //saved permanently on room exit
 
 	bool     bRoomDisplayOnly; //indicates player is not in room and no player interaction should be processed
-	bool     bNoSaves;   //don't save anything to DB when set (e.g., for dummy game sessions)
 	bool     bValidatingPlayback; //for streamlining parts of the playback process
 
 /*

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -455,7 +455,7 @@ public:
 	CTotalMapStates TotalMapStates;
 	const MapState GetStoredMapStateForRoom(const UINT roomID) const { return TotalMapStates.GetStoredMapStateForRoom(roomID); }
 	void UpdateStoredMapState(const UINT roomID, const MapState state) { TotalMapStates.Update(roomID, state, this->bNoSaves); }
-	void UpdateStoredMapState(const CIDSet roomIDs, const MapState state) { TotalMapStates.Update(roomIDs, state, this->bNoSaves); }
+	void UpdateStoredMapState(const CIDSet& roomIDs, const MapState state) { TotalMapStates.Update(roomIDs, state, this->bNoSaves); }
 
 private:
 	void AdvanceCombat(CCueEvents& CueEvents);

--- a/drodrpg/DRODLib/DRODLib.2019.vcxproj
+++ b/drodrpg/DRODLib/DRODLib.2019.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="BuildDats|Win32">
@@ -454,6 +454,7 @@
     <ClCompile Include="Swordsman.cpp" />
     <ClCompile Include="TarBaby.cpp" />
     <ClCompile Include="TarMother.cpp" />
+    <ClCompile Include="TotalMapStates.cpp" />
     <ClCompile Include="WraithWing.cpp" />
     <ClCompile Include="Wubba.cpp" />
     <ClCompile Include="Zombie.cpp" />
@@ -528,6 +529,7 @@
     <ClInclude Include="RoachQueen.h" />
     <ClInclude Include="RockGiant.h" />
     <ClInclude Include="RoomData.h" />
+    <ClInclude Include="TotalMapStates.h" />
     <ClInclude Include="Seep.h" />
     <ClInclude Include="Serpent.h" />
     <ClInclude Include="SettingsKeys.h" />

--- a/drodrpg/DRODLib/DRODLib.2019.vcxproj.filters
+++ b/drodrpg/DRODLib/DRODLib.2019.vcxproj.filters
@@ -240,6 +240,9 @@
     <ClCompile Include="I18N.cpp">
       <Filter>General</Filter>
     </ClCompile>
+    <ClCompile Include="TotalMapStates.cpp">
+      <Filter>General</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Combat.h">
@@ -487,6 +490,9 @@
       <Filter>General</Filter>
     </ClInclude>
     <ClInclude Include="CurrentGameRecords.h">
+      <Filter>General</Filter>
+    </ClInclude>
+    <ClInclude Include="TotalMapStates.h">
       <Filter>General</Filter>
     </ClInclude>
   </ItemGroup>

--- a/drodrpg/DRODLib/DbSavedGames.h
+++ b/drodrpg/DRODLib/DbSavedGames.h
@@ -57,6 +57,7 @@ enum SAVETYPE
 	ST_DemoUpload=9,       //tracks demos tested to upload for high-score submission (2.0; deprecated)
 	ST_PlayerTotal=10,     //contains set of all rooms ever explored/conquered
 	ST_WorldMap = 11,        //saved on entering a world map
+	ST_TotalMapStates=12, //for tracking the best MapState seen for each room across all sessions
 };
 
 enum MapState

--- a/drodrpg/DRODLib/TotalMapStates.cpp
+++ b/drodrpg/DRODLib/TotalMapStates.cpp
@@ -46,7 +46,7 @@ void CTotalMapStates::Load(const UINT dwPlayerID, const UINT dwHoldID)
 
 //*****************************************************************************
 //Returns the stored room state for a room id
-const MapState CTotalMapStates::GetStoredMapStateForRoom(const UINT roomID) const
+MapState CTotalMapStates::GetStoredMapStateForRoom(const UINT roomID) const
 {
 	MapState foundMapState = MapState::Invisible;
 

--- a/drodrpg/DRODLib/TotalMapStates.cpp
+++ b/drodrpg/DRODLib/TotalMapStates.cpp
@@ -1,0 +1,142 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is Deadly Rooms of Death.
+ *
+ * The Initial Developer of the Original Code is
+ * Caravel Software.
+ * Portions created by the Initial Developer are Copyright (C) 2025
+ * Caravel Software. All Rights Reserved.
+ *
+ * Contributor(s):
+ * Kieran Millar
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+ //TotalMapStates.cpp.
+ //Implementation of CTotalMapStates.
+
+#include "TotalMapStates.h"
+#include "DbSavedGames.h"
+#include <BackEndLib/Types.h>
+
+#include <map>
+
+//*****************************************************************************
+//
+//Public methods.
+//
+
+//*****************************************************************************
+//Constructor
+CTotalMapStates::CTotalMapStates()
+{
+	this->mapStates = map<UINT, MapState>();
+}
+
+//*****************************************************************************
+//Load the map states from the saved game
+void CTotalMapStates::Load(const UINT dwPlayerID, const UINT dwHoldID)
+{
+	//TODO
+}
+
+//*****************************************************************************
+//Returns the stored room state for a room id
+MapState CTotalMapStates::GetStoredMapStateForRoom(const UINT roomID)
+{
+	MapState foundMapState = MapState::Invisible;
+
+	std::map<UINT, MapState>::const_iterator it = this->mapStates.find(roomID);
+	if (it != this->mapStates.end()) {
+		foundMapState = it->second;
+	}
+
+	if (foundMapState == MapState::Explored)
+		foundMapState = MapState::Preview; //Rooms explored in other play sessions should only appear as a preview at best
+
+	return foundMapState;
+}
+
+//*****************************************************************************
+//Updates the map state for a room id, adding it if not currently in the list
+//The saved game is saved if the map state is larger than the current one
+void CTotalMapStates::Update(
+	const UINT roomID, // The room ID
+	const MapState state, // The MapState to update the room to (if better)
+	const bool bNoSaves) // If saving to the db should be prevented
+{
+	if (UpdateRoom(roomID, state) && !bNoSaves)
+		Save();
+}
+
+//*****************************************************************************
+//Updates the map state for many room ids, adding them if not currently in the list
+//This is more efficient for updating rooks in bulk, only triggering a single save
+//Used by map collectibles
+void CTotalMapStates::Update(
+	const CIDSet roomIDs, // A set of room IDs
+	const MapState state, // The MapState to update the rooms to (if better)
+	const bool bNoSaves) // If saving to the db should be prevented
+{
+	if (state == MapState::Invisible)
+		return;
+
+	bool bSave = false;
+	for (CIDSet::const_iterator it = roomIDs.begin(); it != roomIDs.end(); ++it)
+	{
+		if (UpdateRoom(*it, state))
+			bSave = true;
+	}
+	if (bSave && !bNoSaves)
+		Save();
+}
+
+//*****************************************************************************
+//
+//Private methods.
+//
+
+//*****************************************************************************
+//Updates the state for a single room
+//Returns if the room state was changed
+bool CTotalMapStates::UpdateRoom(const UINT roomID, const MapState state)
+{
+	if (state == MapState::Invisible)
+		return false; // No need to store the state if the lowest and default value, this saves time when setting many minimap icons
+
+	MapState currentMapState = MapState::Invisible;
+
+	std::map<UINT, MapState>::const_iterator it = this->mapStates.find(roomID);
+	if (it != this->mapStates.end()) {
+		currentMapState = it->second;
+	}
+	else {
+		this->mapStates[roomID] = state;
+		return true;
+	}
+
+	if (currentMapState < state) {
+		this->mapStates[roomID] = state;
+		return true;
+	}
+
+	return false;
+}
+
+//*****************************************************************************
+//Saves the map states into the ST_TotalMapStates saved game
+void CTotalMapStates::Save()
+{
+	// TODO
+}

--- a/drodrpg/DRODLib/TotalMapStates.cpp
+++ b/drodrpg/DRODLib/TotalMapStates.cpp
@@ -38,13 +38,6 @@
 //
 
 //*****************************************************************************
-//Constructor
-CTotalMapStates::CTotalMapStates()
-{
-	this->mapStates = map<UINT, MapState>();
-}
-
-//*****************************************************************************
 //Load the map states from the saved game
 void CTotalMapStates::Load(const UINT dwPlayerID, const UINT dwHoldID)
 {

--- a/drodrpg/DRODLib/TotalMapStates.cpp
+++ b/drodrpg/DRODLib/TotalMapStates.cpp
@@ -46,7 +46,7 @@ void CTotalMapStates::Load(const UINT dwPlayerID, const UINT dwHoldID)
 
 //*****************************************************************************
 //Returns the stored room state for a room id
-const MapState CTotalMapStates::GetStoredMapStateForRoom(const UINT roomID)
+const MapState CTotalMapStates::GetStoredMapStateForRoom(const UINT roomID) const
 {
 	MapState foundMapState = MapState::Invisible;
 

--- a/drodrpg/DRODLib/TotalMapStates.cpp
+++ b/drodrpg/DRODLib/TotalMapStates.cpp
@@ -75,10 +75,10 @@ void CTotalMapStates::Update(
 
 //*****************************************************************************
 //Updates the map state for many room ids, adding them if not currently in the list
-//This is more efficient for updating rooks in bulk, only triggering a single save
+//This is more efficient for updating rooms in bulk, only triggering a single update
 //Used by map collectibles
 void CTotalMapStates::Update(
-	const CIDSet roomIDs, // A set of room IDs
+	const CIDSet& roomIDs, // A set of room IDs
 	const MapState state, // The MapState to update the rooms to (if better)
 	const bool bNoSaves) // If saving to the db should be prevented
 {

--- a/drodrpg/DRODLib/TotalMapStates.cpp
+++ b/drodrpg/DRODLib/TotalMapStates.cpp
@@ -46,7 +46,7 @@ void CTotalMapStates::Load(const UINT dwPlayerID, const UINT dwHoldID)
 
 //*****************************************************************************
 //Returns the stored room state for a room id
-MapState CTotalMapStates::GetStoredMapStateForRoom(const UINT roomID)
+const MapState CTotalMapStates::GetStoredMapStateForRoom(const UINT roomID)
 {
 	MapState foundMapState = MapState::Invisible;
 

--- a/drodrpg/DRODLib/TotalMapStates.h
+++ b/drodrpg/DRODLib/TotalMapStates.h
@@ -9,8 +9,8 @@
 //*******************************************************************************
 class CTotalMapStates {
 public:
-	CTotalMapStates();
-	~CTotalMapStates() { };
+	CTotalMapStates() { }
+	~CTotalMapStates() { }
 	void Load(const UINT dwPlayerID, const UINT dwHoldID);
 	MapState GetStoredMapStateForRoom(const UINT roomID);
 	void Update(const UINT roomID, const MapState state, const bool bNoSaves);

--- a/drodrpg/DRODLib/TotalMapStates.h
+++ b/drodrpg/DRODLib/TotalMapStates.h
@@ -12,7 +12,7 @@ public:
 	CTotalMapStates() { }
 	~CTotalMapStates() { }
 	void Load(const UINT dwPlayerID, const UINT dwHoldID);
-	const MapState GetStoredMapStateForRoom(const UINT roomID);
+	const MapState GetStoredMapStateForRoom(const UINT roomID) const;
 	void Update(const UINT roomID, const MapState state, const bool bNoSaves);
 	void Update(const CIDSet roomIDs, const MapState state, const bool bNoSaves);
 

--- a/drodrpg/DRODLib/TotalMapStates.h
+++ b/drodrpg/DRODLib/TotalMapStates.h
@@ -12,7 +12,7 @@ public:
 	CTotalMapStates() { }
 	~CTotalMapStates() { }
 	void Load(const UINT dwPlayerID, const UINT dwHoldID);
-	MapState GetStoredMapStateForRoom(const UINT roomID);
+	const MapState GetStoredMapStateForRoom(const UINT roomID);
 	void Update(const UINT roomID, const MapState state, const bool bNoSaves);
 	void Update(const CIDSet roomIDs, const MapState state, const bool bNoSaves);
 

--- a/drodrpg/DRODLib/TotalMapStates.h
+++ b/drodrpg/DRODLib/TotalMapStates.h
@@ -14,7 +14,7 @@ public:
 	void Load(const UINT dwPlayerID, const UINT dwHoldID);
 	const MapState GetStoredMapStateForRoom(const UINT roomID) const;
 	void Update(const UINT roomID, const MapState state, const bool bNoSaves);
-	void Update(const CIDSet roomIDs, const MapState state, const bool bNoSaves);
+	void Update(const CIDSet& roomIDs, const MapState state, const bool bNoSaves);
 
 private:
 	map<UINT, MapState> mapStates;

--- a/drodrpg/DRODLib/TotalMapStates.h
+++ b/drodrpg/DRODLib/TotalMapStates.h
@@ -1,0 +1,26 @@
+#ifndef TOTALMAPSTATES_H
+#define TOTALMAPSTATES_H
+
+#include "DbSavedGames.h"
+#include <BackEndLib/Types.h>
+
+#include <map>
+
+//*******************************************************************************
+class CTotalMapStates {
+public:
+	CTotalMapStates();
+	~CTotalMapStates() { };
+	void Load(const UINT dwPlayerID, const UINT dwHoldID);
+	MapState GetStoredMapStateForRoom(const UINT roomID);
+	void Update(const UINT roomID, const MapState state, const bool bNoSaves);
+	void Update(const CIDSet roomIDs, const MapState state, const bool bNoSaves);
+
+private:
+	map<UINT, MapState> mapStates;
+
+	bool UpdateRoom(const UINT roomID, const MapState state);
+	void Save();
+};
+
+#endif

--- a/drodrpg/DRODLib/TotalMapStates.h
+++ b/drodrpg/DRODLib/TotalMapStates.h
@@ -12,7 +12,7 @@ public:
 	CTotalMapStates() { }
 	~CTotalMapStates() { }
 	void Load(const UINT dwPlayerID, const UINT dwHoldID);
-	const MapState GetStoredMapStateForRoom(const UINT roomID) const;
+	MapState GetStoredMapStateForRoom(const UINT roomID) const;
 	void Update(const UINT roomID, const MapState state, const bool bNoSaves);
 	void Update(const CIDSet& roomIDs, const MapState state, const bool bNoSaves);
 


### PR DESCRIPTION
Part 1 of trying to fix the endless plague of bug reports at map states not persisting correctly across play sessions. I'm splitting this into 2 PRs to get some earlier feedback about the current state of things, and as a backup because I've been working on it for a while. This PR implements everything except saving and loading the saved game.

As outlined at https://forum.caravelgames.com/viewtopic.php?TopicID=46823&page=0#454693 my plan to fix this endless stream of bugs is to create a new saved game whose purpose is to keep track of the best room state a player has seen a room in. This saved game will be saved every time it is updated, so that persistence is guaranteed.

Room map states are updated in 3 occasions:
1) We enter a room not in preview mode (set to Explored)
2) We pick up a map collectible (all relevant rooms set to either NoDetail or Explored accordingly)
3) We use the script command (set to either NoDetail or Explored)

Note that CCurrentGame has a method AddRoomToMap but I have avoided setting state in there so we can make a big efficiency gain when collecting a level map, which would call this once for each room, potentially saving to the DB many many times in a row. Instead I collect the list of rooms to update, update them all together then make one save afterwards.

Room map states are read by:
1) Drawing the minimap
2) Clicking on rooms on the minmap (big and small)
3) Checking if we can scroll to that room when in room preview mode
4) Checking if we can quick travel to the room when its adjacent