### PR TITLE
Fix issue with hold updates with large number of saves

### DIFF
--- a/BackEndLib/IDSet.h
+++ b/BackEndLib/IDSet.h
@@ -144,6 +144,29 @@ public:
 	inline UINT getLast() const {return size() ? *rbegin() : 0;}
 	inline UINT getMax() const {return size() ? *(this->ids.rbegin()) : 0;}
 
+	// Split the given set into a number of sets that are no larger than the given amount
+	static std::vector<CIDSet> divide(CIDSet& set, size_t amount) {
+		if (set.size() <= amount) {
+			return { set };
+		}
+
+		std::vector<CIDSet> result;
+		result.push_back(CIDSet());
+		size_t n = 0;
+		size_t count = 0;
+		for (IDSet::const_iterator it = set.begin(); it != set.end(); ++it) {
+			result[n] += *it;
+			++count;
+			if (count >= amount) {
+				count = 0;
+				++n;
+				result.push_back(CIDSet());
+			}
+		}
+
+		return result;
+	}
+
 private:
 	std::set<UINT> ids;
 };

--- a/DRODLib/ImportInfo.h
+++ b/DRODLib/ImportInfo.h
@@ -116,7 +116,7 @@ public:
 	CIDSet localHoldIDs;
 	std::set<WSTRING> roomStyles; //room style references encountered in import
 
-	string   exportedDemos, exportedSavedGames;  //saved games temporarily exported while hold is being upgraded
+	std::vector<string> exportedDemos, exportedSavedGames;  //saved games temporarily exported while hold is being upgraded
 	WSTRING  userMessages;     //text messages for the user's convenience
 
 	MESSAGE_ID ImportStatus;   //result of import process


### PR DESCRIPTION
If you try to update a hold that has a lot of demos or saved games, DROD will crash. This is because we export the existing data into an in-memory string, which can run out of space if there's enough data being exported.

My fix to this is to break up sufficently large amounts of exportables into smaller groups, then export each group into separate strings (which can then be reimported). The current group size is 2000, which is based on experimenting to find a value that worked.