### PR TITLE
RPG: Reset LastQueryIter when unsetting packed var

### DIFF
--- a/drodrpg/DRODLib/DbPackedVars.cpp
+++ b/drodrpg/DRODLib/DbPackedVars.cpp
@@ -107,7 +107,7 @@ void CDbPackedVars::Unset(const char* pszVarName)
 {
 	this->vars.erase(pszVarName);
 
-	this->varIter = this->vars.end(); //invalidate
+	this->lastQueryIter = this->varIter = this->vars.end(); //invalidate
 }
 
 //*******************************************************************************************


### PR DESCRIPTION
When importing an old player profile we need to replace old key bindings with new ones in the new extended format. To do this we find a var, then unset and set a new value it. Unfortunately, unsetting it caused lastQueryIter to point at an invalid location.