### PR TITLE
Tweak main-level exception handling

### DIFF
--- a/DROD/Main.cpp
+++ b/DROD/Main.cpp
@@ -542,7 +542,7 @@ int main(int argc, char *argv[])
 
 #ifndef NO_EXCEPTIONS
 		}
-		catch (CException& e)
+		catch (std::exception& e)
 		{
 		  m_pFiles->AppendErrorLog(e.what());
 		  if (g_pTheDB->IsOpen())
@@ -552,6 +552,7 @@ int main(int argc, char *argv[])
 		}
 		catch (...)
 		{
+			m_pFiles->AppendErrorLog("Unkown exception");
 		  if (g_pTheDB->IsOpen())
 		  {
 			  g_pTheDB->Close();


### PR DESCRIPTION
A couple of changes to exceptions in `Main.cpp`:

1. Made it so we're catching `std::exception` rather than `CException`. This allows exceptions that don't inherit from `CException` to be caught and processed (which should be all of them).
2. If we do catch an exception not derived from `std::exception`, log that an unknown exception was encountered.