### PR TITLE
RPG: Fix Steam uses of CDbHold::Main

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -9324,7 +9324,7 @@ void CGameScreen::SendAchievement(const char* achievement, const UINT dwScore)
 {
 #ifdef STEAMBUILD
 	if (GetScreenType() == SCR_Game && !this->bPlayTesting &&
-			(this->pCurrentGame->pHold && this->pCurrentGame->pHold->status == CDbHold::Main) &&
+			this->pCurrentGame->pHold && CDbHold::IsOfficialHold(this->pCurrentGame->pHold->status) &&
 			SteamUserStats())
 	{
 		const WSTRING holdName = static_cast<const WCHAR *>(this->pCurrentGame->pHold->NameText);

--- a/drodrpg/DRODLib/DbHolds.cpp
+++ b/drodrpg/DRODLib/DbHolds.cpp
@@ -3402,7 +3402,7 @@ MESSAGE_ID CDbHold::SetProperty(
 		case P_Status:
 			this->status = static_cast<HoldStatus>(convertToInt(str));
 #if defined(STEAMBUILD) && !defined(DEV_BUILD)
-			if ((this->status == CDbHold::Main || this->status == CDbHold::Official) &&
+			if (CDbHold::IsOfficialHold(this->status) &&
 					info.typeBeingImported == CImportInfo::Hold)
 				return MID_SteamErrorAttemptingToImportOfficialHold;
 #endif


### PR DESCRIPTION
The hold status enum had been previously refactored to change the value Main to two other values, Tendry and ACR. Two instances of Main still existed inside some code that wasn't built or analysed due to be wrapped inside a STEAMBUILD ifdef, which will have caused an issue when trying to produce a Steam build.