### PR TITLE
RPG: Don't display percent for negative scores

### DIFF
--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -8505,7 +8505,7 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 			pHighScore->Update();
 
 			localScoreMessage = g_pTheDB->GetMessageText(MID_NewLocalHighScore);
-		} else if (pPlayer->Settings.GetVar(Settings::ShowPercentOptimal, true)) {
+		} else if (pPlayer->Settings.GetVar(Settings::ShowPercentOptimal, true) && score >= 0 && pHighScore->score > 0) {
 			double ratio = (double)score / (double)pHighScore->score;
 			int percent = int(ratio * 100);
 			localScoreMessage = WCSReplace(


### PR DESCRIPTION
When you get a lower score than your best for a previously-achieved scorepoint, we try to show your current score as a percentage of the previous. This has issues if the scores are zero or negative, where this percentage is either incalculable or nonsensical. In these scenarios, we now don't display the message.