### PR TITLE
Use temporary files when updating hold with large number of demos or saved games

### DIFF
--- a/DROD/Main.cpp
+++ b/DROD/Main.cpp
@@ -1881,6 +1881,8 @@ void RepairMissingINIKeys(const bool bFullVersion)
 	AddIfMissing(INISection::Customizing, INIKey::AutoLogin, "0");
 	AddIfMissing(INISection::Customizing, INIKey::CrossfadeDuration, "400");
 	AddIfMissing(INISection::Customizing, INIKey::ExportSpeech, "0");
+	AddIfMissing(INISection::Customizing, INIKey::ExportDemoThreshold, "500");
+	AddIfMissing(INISection::Customizing, INIKey::ExportSavedGamesThreshold, "1000");
 	AddIfMissing(INISection::Customizing, INIKey::FullScoreUpload, "0");
 	AddIfMissing(INISection::Customizing, INIKey::FullScreenMinimize, "0");
 	AddIfMissing(INISection::Customizing, INIKey::FullScreenMode, "0");

--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1269,36 +1269,19 @@ bool CDbXML::ExportSavedGames(
 	bool bSomethingExported = false;
 	CAttachableObject *pSaveCallbackObject = pCallbackObject;   //don't reset this
 
-	//Due to the limits of C++, trying to export a sufficently large number of
-	//demos or saves will cause a crash. We can avoid this by breaking the exports
-	//into smaller groups.
-	const int MAX_EXPORTS = 2000;
-
 	//Compile list of all (non-hidden) demo IDs in hold.
 	//The demo export will include saved game records attached to demos.
 	CIDSet demoIDs = CDb::getDemosInHold(dwHoldID);
-	vector<CIDSet> splitDemoIds = CIDSet::divide(demoIDs, MAX_EXPORTS);
 
-	for (vector<CIDSet>::const_iterator it = splitDemoIds.begin(); it != splitDemoIds.end(); ++it)
-	{
-		string demos;
-		bSomethingExported |= ExportXML(V_Demos, *it, demos);
-		info.exportedDemos.push_back(demos);
-		pCallbackObject = pSaveCallbackObject;
-	}
+	bSomethingExported |= ExportXML(V_Demos, demoIDs, info.exportedDemos);
+	pCallbackObject = pSaveCallbackObject;
 
 	//Compile list of all saved game IDs in hold.
 	//The saved game export will exclude saved game records attached to demos.
 	CIDSet savedGameIDs = CDb::getSavedGamesInHold(dwHoldID);
-	vector<CIDSet> splitSaveIds = CIDSet::divide(savedGameIDs, MAX_EXPORTS);
 
-	for (vector<CIDSet>::const_iterator it = splitSaveIds.begin(); it != splitSaveIds.end(); ++it)
-	{
-		string saves;
-		bSomethingExported |= ExportXML(V_SavedGames, *it, saves);
-		info.exportedSavedGames.push_back(saves);
-		pCallbackObject = pSaveCallbackObject;
-	}
+	bSomethingExported |= ExportXML(V_SavedGames, savedGameIDs, info.exportedSavedGames);
+	pCallbackObject = pSaveCallbackObject;
 
 	return bSomethingExported;
 }
@@ -1317,22 +1300,17 @@ void CDbXML::ImportSavedGames()
 	const CImportInfo::ImportType importType = info.typeBeingImported;
 	const MESSAGE_ID importState = info.ImportStatus;
 	info.typeBeingImported = CImportInfo::Demo;
-
-	for (vector<string>::const_iterator it = info.exportedDemos.begin();
-		it != info.exportedDemos.end(); ++it)
-	{
-		VERIFY(ImportXML(*it) == MID_ImportSuccessful);
+	if (info.exportedDemos.size()) {
+		VERIFY(ImportXML(info.exportedDemos) == MID_ImportSuccessful);
+		info.exportedDemos.resize(0);
 	}
-	info.exportedDemos.clear();
 
 	info.ImportStatus = importState; //ignore import state changes in saved game restoration
 	info.typeBeingImported = CImportInfo::SavedGame;
-	for (vector<string>::const_iterator it = info.exportedSavedGames.begin();
-		it != info.exportedSavedGames.end(); ++it)
-	{
-		VERIFY(ImportXML(*it) == MID_ImportSuccessful);
+	if (info.exportedSavedGames.size()) {
+		VERIFY(ImportXML(info.exportedSavedGames) == MID_ImportSuccessful);
+		info.exportedSavedGames.resize(0);
 	}
-	info.exportedSavedGames.clear();
 
 	info.typeBeingImported = importType;
 	info.ImportStatus = importState;

--- a/DRODLib/DbXML.h
+++ b/DRODLib/DbXML.h
@@ -157,6 +157,7 @@ private:
 	static void ImportSavedGames();
 	static void VerifySavedGames();
 
+	static WSTRING prepareTemporaryFile(const WCHAR* wszFilename);
 	static gzFile openGZipFile(const WCHAR* wszFilename);
 
 	static vector <CDbBase*> dbRecordStack;   //stack of records being parsed

--- a/DRODLib/DbXML.h
+++ b/DRODLib/DbXML.h
@@ -66,10 +66,12 @@ struct streamingOutParams
 	streamingOutParams()
 		: pOutBuffer(NULL)
 		, pGzf(NULL)
+		, hasFlushed(false)
 	{ }
 	void reset() {
 		pOutBuffer = NULL;
 		pGzf = NULL;
+		hasFlushed = false;
 	}
 	void set(string* str, gzFile* gzf)
 	{
@@ -80,6 +82,7 @@ struct streamingOutParams
 
 	string* pOutBuffer;
 	gzFile* pGzf;
+	bool hasFlushed;
 };
 
 //*****************************************************************************
@@ -153,6 +156,8 @@ private:
 
 	static void ImportSavedGames();
 	static void VerifySavedGames();
+
+	static gzFile openGZipFile(const WCHAR* wszFilename);
 
 	static vector <CDbBase*> dbRecordStack;   //stack of records being parsed
 	static vector <UINT> dbImportedRecordIDs;  //imported record IDs (primary keys)

--- a/DRODLib/ImportInfo.cpp
+++ b/DRODLib/ImportInfo.cpp
@@ -28,6 +28,7 @@
 #include "ImportInfo.h"
 #include "EntranceData.h"
 #include "../Texts/MIDs.h"
+#include <BackEndLib/Files.h>
 
 //*****************************************************************************
 CImportInfo::CImportInfo()
@@ -93,6 +94,8 @@ void CImportInfo::Clear(
 		this->exportedDemos.resize(0);
 		this->exportedSavedGames.resize(0);
 
+		ClearTempFiles();
+
 		this->importWorldMapID = 0;
 	}
 
@@ -112,4 +115,20 @@ void CImportInfo::Clear(
 	pEntrance = NULL;
 	delete pImportEntrance;
 	pImportEntrance = NULL;
+}
+
+//*****************************************************************************
+void CImportInfo::ClearTempFiles()
+{
+	if (!this->exportedDemosFile.empty() &&
+		CFiles::DoesFileExist(this->exportedDemosFile.c_str())) {
+		CFiles::EraseFile(this->exportedDemosFile.c_str());
+	}
+	this->exportedDemosFile.resize(0);
+
+	if (!this->exportedSavedGamesFile.empty() &&
+		CFiles::DoesFileExist(this->exportedSavedGamesFile.c_str())) {
+		CFiles::EraseFile(this->exportedSavedGamesFile.c_str());
+	}
+	this->exportedSavedGamesFile.resize(0);
 }

--- a/DRODLib/ImportInfo.h
+++ b/DRODLib/ImportInfo.h
@@ -73,6 +73,7 @@ public:
 	~CImportInfo();
 
 	void Clear(const bool bPartialClear=false);
+	void ClearTempFiles();
 
 	bool isDemoImport() const { return typeBeingImported == CImportInfo::Demo || typeBeingImported == CImportInfo::DemosAndSavedGames; }
 	bool isSavedGameImport() const { return typeBeingImported == CImportInfo::SavedGame || typeBeingImported == CImportInfo::DemosAndSavedGames; }
@@ -117,6 +118,7 @@ public:
 	std::set<WSTRING> roomStyles; //room style references encountered in import
 
 	string   exportedDemos, exportedSavedGames;  //saved games temporarily exported while hold is being upgraded
+	WSTRING  exportedDemosFile, exportedSavedGamesFile;  //saved games temporarily exported to external file while hold is being upgraded
 	WSTRING  userMessages;     //text messages for the user's convenience
 
 	MESSAGE_ID ImportStatus;   //result of import process

--- a/DRODLib/ImportInfo.h
+++ b/DRODLib/ImportInfo.h
@@ -116,7 +116,7 @@ public:
 	CIDSet localHoldIDs;
 	std::set<WSTRING> roomStyles; //room style references encountered in import
 
-	std::vector<string> exportedDemos, exportedSavedGames;  //saved games temporarily exported while hold is being upgraded
+	string   exportedDemos, exportedSavedGames;  //saved games temporarily exported while hold is being upgraded
 	WSTRING  userMessages;     //text messages for the user's convenience
 
 	MESSAGE_ID ImportStatus;   //result of import process

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -19,6 +19,8 @@ namespace INIKey
 	DEF(AlwaysFullBlit);
 	DEF(AutoLogin);
 	DEF(CrossfadeDuration);
+	DEF(ExportDemoThreshold);
+	DEF(ExportSavedGamesThreshold);
 	DEF(ExportSpeech);
 	DEF(ExportText);
 	DEF(FullScoreUpload);

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -19,6 +19,8 @@ namespace INIKey
 	DEF(AlwaysFullBlit);
 	DEF(AutoLogin);
 	DEF(CrossfadeDuration);
+	DEF(ExportDemoThreshold);
+	DEF(ExportSavedGamesThreshold);
 	DEF(ExportSpeech);
 	DEF(ExportText);
 	DEF(FullScoreUpload);


### PR DESCRIPTION
#924 attempted to fix hold updating when the user had a large amount of data to preserve. Additional testing revealed that this still didn't work. The problem is that eventually there's so much data it can't possibly be held in the program's memory.

Since DROD already supports exporting data an external file, this provides a way to deal with large amounts of data - writing it out to a temporary file, then reading it back. This inevitably slower, since it requires disk operations and for the sake of simplicity, the data is still compressed as it gets written out. But it should solve the problem.

The temporary files are created in the dat directory, since DROD should be guaranteed to have write access to there. I've been fairly aggressive about cleaning them up, since they're intended to be ephemeral.

Exporting to the temporary files happens if the amount of records to export is larger than specific threshold. By default this 500 for demos, and 1000 for saved games (demo threshold is smaller as exporting a demo also exports a save). This can be configured in the `drond.ini` file.