### PR TITLE
Add event for character using tunnel

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5182,6 +5182,7 @@ void CCharacterDialogWidget::PopulateEventListBox()
 	this->pEventListBox->AddItem(CID_TokenToggled, g_pTheDB->GetMessageText(MID_TokenToggled));
 	this->pEventListBox->AddItem(CID_TrapDoorRemoved, g_pTheDB->GetMessageText(MID_TrapDoorRemoved));
 	this->pEventListBox->AddItem(CID_Tunnel, g_pTheDB->GetMessageText(MID_Tunnel));
+	this->pEventListBox->AddItem(CID_MonsterTunnel, g_pTheDB->GetMessageText(MID_MonsterTunnel));
 	this->pEventListBox->AddItem(CID_WispOnPlayer, g_pTheDB->GetMessageText(MID_WispOnPlayer));
 	this->pEventListBox->AddItem(CID_WubbaStabbed, g_pTheDB->GetMessageText(MID_WubbaStabbed));
 	

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3902,7 +3902,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 			pObj = CueEvents.GetNextPrivateData();
 		}
 	}
-	if (CueEvents.HasOccurred(CID_Tunnel))
+	if (CueEvents.HasOccurred(CID_Tunnel) || CueEvents.HasOccurred(CID_MonsterTunnel))
 		PlaySoundEffect(SEID_TUNNEL);
 	if (CueEvents.HasOccurred(CID_Horn_Squad))
 		PlaySoundEffect(SEID_HORN_SQUAD);

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -7879,7 +7879,7 @@ void CCharacter::PushInDirection(int dx, int dy, bool bStun, CCueEvents &CueEven
 
 	if (bEnteredTunnel) {
 		UINT destX, destY;
-		CueEvents.Add(CID_Tunnel);
+		CueEvents.Add(CID_MonsterTunnel);
 		if (this->pCurrentGame->TunnelGetExit(this->wX, this->wY, dx, dy, destX, destY, this)) {
 			Move(destX, destY, &CueEvents);
 
@@ -7934,7 +7934,7 @@ void CCharacter::MoveCharacter(
 		if (!this->pCurrentGame->TunnelGetExit(this->wX, this->wY, dx, dy, destX, destY, this)) {
 			return;
 		}
-		CueEvents.Add(CID_Tunnel);
+		CueEvents.Add(CID_MonsterTunnel);
 	}	else {
 		destX = this->wX + dx;
 		destY = this->wY + dy;

--- a/DRODLib/CueEvents.h
+++ b/DRODLib/CueEvents.h
@@ -858,6 +858,11 @@ enum CUEEVENT_ID
 	//Private data: NONE
 	CID_AddedRoomToMap,
 
+	//Monster walked through a tunnel.
+	//
+	//Private data: NONE
+	CID_MonsterTunnel,
+
 #ifdef TEST_SPIDER
 	//Custom CueEvent to cause failure in test spider
 	//Make sure this is always the last CueEvent defined

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -1050,6 +1050,7 @@ const WCHAR* CDbBase::GetMessageText(
 	case MID_VarMonsterHue: strText = "_MyHue"; break;
 	case MID_VarMonsterSaturation: strText = "_MySaturation"; break;
 	case MID_NoBrowserToRequestKey: strText = "Failed to open web browser to https://forum.caravelgames.com/member.php?Action=editcaravelnet"; break;
+	case MID_MonsterTunnel: strText = "Monster used tunnel"; break;
 //		case MID_DRODUpgradingDataFiles: strText = "DROD is upgrading your data files." NEWLINE "This could take a moment.  Please be patient..."; break;
 //		case MID_No: strText = "&No"; break;
 		default: break;

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1931,6 +1931,7 @@ enum MID_CONSTANT {
   MID_CanKillNonTargetPlayer = 2157,
   MID_WakesEvilEyes = 2158,
   MID_AppearOnWeapons = 2159,
+  MID_MonsterTunnel = 2165,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/Texts/Speech.uni
+++ b/Texts/Speech.uni
@@ -3346,3 +3346,7 @@ Wakes Evil Eyes
 [MID_AppearOnWeapons]
 [eng]
 Can Appear On Weapons
+
+[MID_MonsterTunnel]
+[eng]
+Monster used tunnel


### PR DESCRIPTION
When a character that can use tunnels uses a tunnel, a `CID_Tunnel` event is sent out. However, Slayers check for this event to make it more difficult to ambush them using tunnels. This makes a tunnel-using character disruptive to Slayers in a non-obvious way.

To fix this, a new event for monsters going through tunnels has been added. It makes the sound effect, and can be checked for in scripts, but won't bother Slayers.