### PR TITLE
RPG: Clean up strings containing !!translate

### DIFF
--- a/drodrpg/Texts/Buttons.uni
+++ b/drodrpg/Texts/Buttons.uni
@@ -85,7 +85,7 @@ Mort!
 [eng]
 Copy
 [fra]
-!!translate
+Copier
 [rus]
 Копия
 
@@ -93,7 +93,7 @@ Copy
 [eng]
 Delete
 [fra]
-!!translate
+Effacer
 [rus]
 Стереть
 
@@ -117,9 +117,9 @@ Delete
 [eng]
 Export
 [fra]
-!!translate
+Exporter
 [rus]
-!!translate
+Экспорт
 
 [MID_BuyNow]
 [eng]

--- a/drodrpg/Texts/DemosMessages.uni
+++ b/drodrpg/Texts/DemosMessages.uni
@@ -101,7 +101,7 @@ Please give the path to save this demo to
 [eng]
 This demo is corrupted or from another version of DROD with different gameplay behavior.
 [fra]
-!!translate
+Cette démo est corrompue ou provient d'une autre version de DROD comportant des éléments de jeu différents.
 [rus]
 Демонстрация либо сломанная либо от другой версии ДРОДа с другими правилами.
 
@@ -109,33 +109,33 @@ This demo is corrupted or from another version of DROD with different gameplay b
 [eng]
 Beethro gets himself killed pretty quickly.
 [fra]
-!!translate
+Le joueur se fait rapidement tuer.
 [rus]
-!!translate
+Игрок погибает довольно быстро.
 
 [MID_DemoDescKilled2]
 [eng]
 Beethro dies, and the monsters live.
 [fra]
-!!translate
+Le joueur meurt, les monstres vivent.
 [rus]
-!!translate
+Игрок погибает, чудовища остаются в живых.
 
 [MID_DemoDescKilled3]
 [eng]
 Beethro dies horribly, but kills a monster first.
 [fra]
-!!translate
+Le joueur meurt horriblement, mais pas sans avoir tué un monstre auparavant.
 [rus]
-!!translate
+Игрок погибает ужасной смертью, сперва убив чудовище.
 
 [MID_DemoDescKilled4]
 [eng]
 Beethro goes screaming to his death and takes some monsters with him.
 [fra]
-!!translate
+Le joueur meurt en hurlant mais emporte quelques monstres avec lui.
 [rus]
-!!translate
+Игрок истошно вопит и, умирая, захватывает с собой несколько чудовищ.
 
 [MID_DemoDescHalphKilled]
 [eng]
@@ -145,110 +145,110 @@ Halph gets killed.
 [eng]
 Beethro conquers the room after slaying just one monster
 [fra]
-!!translate
+Le joueur conquiert cette pièce après n'avoir tué qu'un seul monstre
 [rus]
-!!translate
+Игрок проходит комнату, уничтожив всего одно чудовище,
 
 [MID_DemoDescConquers2]
 [eng]
 and it takes little time.
 [fra]
-!!translate
+et ça ne traîne pas.
 [rus]
-!!translate
+и на это уходит некоторое время.
 
 [MID_DemoDescConquers3]
 [eng]
 but it takes forever.
 [fra]
-!!translate
+mais ça dure une éternité.
 [rus]
-!!translate
+но на это уходит вечность.
 
 [MID_DemoDescConquers4]
 [eng]
 Beethro kills off a handful of monsters and conquers the room.
 [fra]
-!!translate
+Le joueur tue une poignée de monstres et conquiert la pièce.
 [rus]
-!!translate
+Игрок убивает тучу чудовищ и проходит комнату.
 
 [MID_DemoDescConquers5]
 [eng]
 After destroying a group of monsters, Beethro conquers the room.
 [fra]
-!!translate
+Après avoir détruit un groupe de monstres, le joueur conquiert la pièce.
 [rus]
-!!translate
+Уничтожив группу чудовищ, игрок проходит комнату.
 
 [MID_DemoDescConquers6]
 [eng]
 Beethro lays waste to a sprawling horde of vermin and conquers the room!
 [fra]
-!!translate
+Le joueur massacre une immense horde de vermines et conquiert la pièce !
 [rus]
-!!translate
+Игрок в щепки разносит орду кровожадных хищников и проходит комнату!
 
 [MID_DemoDescLeaves1]
 [eng]
 Then he leaves.
 [fra]
-!!translate
+Puis il s'en va.
 [rus]
-!!translate
+После этого он уходит.
 
 [MID_DemoDescLeaves2]
 [eng]
 Beethro is just passing through.
 [fra]
-!!translate
+Le joueur ne fait que passer.
 [rus]
-!!translate
+Игрок просто проходит
 
 [MID_DemoDescLeaves3]
 [eng]
 Beethro exits the room with work left undone.
 [fra]
-!!translate
+Le joueur quitte la pièce alors qu'il reste du pain sur la planche.
 [rus]
-!!translate
+Игрок выходит из комнаты, не завершив свою работу.
 
 [MID_DemoDescLoiters1]
 [eng]
 He came.  He saw.  He didn't do much of anything.
 [fra]
-!!translate
+Le joueur n'a rien foutu.
 [rus]
-!!translate
+Игрок ничего не сделал.
 
 [MID_DemoDescLoiters2]
 [eng]
 Beethro spends some time here without accomplishing much.
 [fra]
-!!translate
+Le joueur passe un peu de temps ici sans accomplir grand-chose.
 [rus]
-!!translate
+Игрок проводит там некоторое время, ничего особо не добившись.
 
 [MID_DemoDescExits1]
 [eng]
 Then he exits the level.
 [fra]
-!!translate
+Puis il quitte le niveau.
 [rus]
-!!translate
+После этого он выходит с уровня.
 
 [MID_DemoDescExits2]
 [eng]
 Beethro exits the level.
 [fra]
-!!translate
+Le jouer quitte le niveau.
 [rus]
-!!translate
+Игрок выходит с уровня.
 
 [MID_DemoDescExits3]
 [eng]
 Beethro exits the level with work left undone.
 [fra]
-!!translate
+Le joueur quitte le niveau alors qu'il reste du travail à abattre.
 [rus]
-!!translate
+Игрок выходит с уровня, не завершив свою работу.

--- a/drodrpg/Texts/DemosScreen.uni
+++ b/drodrpg/Texts/DemosScreen.uni
@@ -58,7 +58,7 @@ Créé:
 [eng]
 Duration:
 [fra]
-!!translate
+Durée :
 [rus]
 Продолжительность:
 
@@ -114,7 +114,7 @@ Montrer l'écran de titre
 [eng]
 Move
 [fra]
-!!translate
+Mouvement
 [rus]
 Ход
 
@@ -122,7 +122,7 @@ Move
 [eng]
 Moves
 [fra]
-!!translate
+Mouvements
 [rus]
 Ходы
 

--- a/drodrpg/Texts/EditScreens.uni
+++ b/drodrpg/Texts/EditScreens.uni
@@ -59,7 +59,8 @@ Le style de Pièce
 This hold and all its levels will be permanently deleted!
 All players' saved games and demos for this hold will also be deleted.  Are you sure you want to remove it?
 [fra]
-Cette oubliette et tous ses niveaux seront supprimés définitivements!  (...!!translate) Êtes-vous sûrs de vouloir les effacer?
+Cet antre et tous ses niveaux seront définitivement supprimés !
+Les sauvegardes de tous les joueurs pour cet antre seront aussi effacées. Êtes-vous sûr de vouloir le supprimer ?
 [rus]
 Крепость со всеми уровнями навсегда стерутся!  Все сохраненные игры и демонстрации в этой крепости тоже стерутся.  Точно продолжать?
 
@@ -261,7 +262,7 @@ Voulez-vous que ce soit la pièce d'entrée de niveau?
 [eng]
 (End hold)
 [fra]
-(End hold)!!translate
+(Fin de l'antre)
 [rus]
 (Конец крепосты)
 
@@ -269,7 +270,7 @@ Voulez-vous que ce soit la pièce d'entrée de niveau?
 [eng]
 Show levels from all holds.
 [fra]
-Show levels from all holds.!!translate
+Afficher les niveaux de tous les antres.
 [rus]
 Показывать уровни из всех крепостей.
 
@@ -277,7 +278,7 @@ Show levels from all holds.!!translate
 [eng]
 Please select a new level entrance destination for the stairs that went to this level.
 [fra]
-Please select a new level entrance destination for the stairs that went to this level.!!translate
+Veuillez choisir une nouvelle destination d'entrée de niveau pour les escaliers qui menaient à ce niveau.
 [rus]
 Укажите куда все лесницы, предже ведущие в этот уровень, теперь пойдут.
 
@@ -348,7 +349,7 @@ Fermé
 [eng]
 Required Room
 [fra]
-Required Room!!translate
+Pièce Obligatoire
 [rus]
 Победа требуется в комнате
 
@@ -356,7 +357,7 @@ Required Room!!translate
 [eng]
 Hidden Room
 [fra]
-Hidden Room!!translate
+Pièce Secrète
 [rus]
 Тайная комната
 
@@ -364,7 +365,7 @@ Hidden Room!!translate
 [eng]
 Would you like to create a new hold that will contain levels you can edit?
 [fra]
-Would you like to create a new hold that will contain levels you can edit?!!translate
+Voulez-vous créer un nouvel antre qui contiendra des niveaux que vous pourrez éditer ?
 [rus]
 Хотите ли Вы создать новую крепость, содержашуюся комнаты, которые Вы можете строить?
 
@@ -372,23 +373,23 @@ Would you like to create a new hold that will contain levels you can edit?!!tran
 [eng]
 Undo
 [fra]
-Undo!!translate
+Annuler
 [rus]
-!!translate
+Annuler
 
 [MID_Redo]
 [eng]
 Redo
 [fra]
-Redo!!translate
+Rétablir
 [rus]
-!!translate
+Повт.
 
 [MID_WhoCanEdit]
 [eng]
 Who can edit?
 [fra]
-!!translate
+Qui a le droit d'éditer ?
 [rus]
 Кто может менять?
 
@@ -396,7 +397,7 @@ Who can edit?
 [eng]
 Only You
 [fra]
-!!translate
+Vous seulement
 [rus]
 Только Вы
 
@@ -404,7 +405,7 @@ Only You
 [eng]
 You and Masters
 [fra]
-!!translate
+Vous et les Maîtres
 [rus]
 Вы с экспертами
 
@@ -412,7 +413,7 @@ You and Masters
 [eng]
 You and Conquerors
 [fra]
-!!translate
+Vous et les Conquérants
 [rus]
 Вы с победительями
 
@@ -420,7 +421,7 @@ You and Conquerors
 [eng]
 Anyone
 [fra]
-!!translate
+Tout le Monde
 [rus]
 Любой
 
@@ -428,7 +429,7 @@ Anyone
 [eng]
 You have modified a room in a hold authored by another player.  Do you want to make a modified copy of the hold for yourself?  (No discards changes)
 [fra]
-!!translate
+Vous avez modifié une pièce dans un antre créé par un autre joueur. Voulez-vous faire une copie de cet antre pour vous-même ? ('Non' annule les changements)
 [rus]
 Вы измените чужую комнату.  Хотите ли Вы скопировать крепость и сделать новую своей?  ("Нет" оставит комнату в старом виде.)
 
@@ -436,7 +437,7 @@ You have modified a room in a hold authored by another player.  Do you want to m
 [eng]
 Do you want to make a copy of this hold that you can edit?
 [fra]
-!!translate
+Voulez-vous créer une copie de cet antre que vous pourrez éditer ?
 [rus]
 Хотите ли Вы скопировать крепость, чтобы изменять ее?
 
@@ -444,7 +445,7 @@ Do you want to make a copy of this hold that you can edit?
 [eng]
 Ending
 [fra]
-!!translate
+Final
 [rus]
 Прошание
 
@@ -452,7 +453,7 @@ Ending
 [eng]
 Please enter what the player will see upon completing your hold.
 [fra]
-!!translate
+Veuillez indiquer ce que le joueur verra après avoir terminé votre oubliette.
 [rus]
 Напишите что иргок увидит при окончании вашей крепости.
 

--- a/drodrpg/Texts/EditScreens.uni
+++ b/drodrpg/Texts/EditScreens.uni
@@ -10,7 +10,7 @@ Editeur
 [eng]
 Choose Hold:
 [fra]
-Choisir l'Oubliette
+Choisissez l'Antre :
 [rus]
 Выберите крепость
 
@@ -18,7 +18,7 @@ Choisir l'Oubliette
 [eng]
 New H&old
 [fra]
-Nouvelle Oubliette
+N&ouvel Antre
 [rus]
 Новую &крепость
 
@@ -114,7 +114,7 @@ Décrire
 [eng]
 Hold Settings
 [fra]
-Réglages de Oubliette
+Paramètres de l'Antre
 [rus]
 Настройки крепости
 
@@ -182,7 +182,7 @@ Entrez un texte déroulant
 [eng]
 The hold was not saved.
 [fra]
-L'oubliette n'a pas été sauvée.
+L'antre n'a pas été enregistré.
 [rus]
 Крепость не была сохранена.
 
@@ -206,7 +206,7 @@ La pièce n'a pas été sauvée.
 [eng]
 Please name this hold.
 [fra]
-Nommez s'il vous plaît cette oubliette.
+Veuillez nommer cet antre.
 [rus]
 Пожалуйста, назовите свою крепость.
 
@@ -214,7 +214,7 @@ Nommez s'il vous plaît cette oubliette.
 [eng]
 Please describe this hold.
 [fra]
-Décrivez s'il vous plaît cette oubliette.
+Veuillez décrire cet antre.
 [rus]
 Пожалуйста, опишите свою крепость.
 
@@ -453,7 +453,7 @@ Final
 [eng]
 Please enter what the player will see upon completing your hold.
 [fra]
-Veuillez indiquer ce que le joueur verra après avoir terminé votre oubliette.
+Veuillez entrer ce que le joueur verra après avoir terminé votre antre.
 [rus]
 Напишите что иргок увидит при окончании вашей крепости.
 

--- a/drodrpg/Texts/Export.uni
+++ b/drodrpg/Texts/Export.uni
@@ -2,7 +2,7 @@
 [eng]
 Please give the filename to save your player and progress to.
 [fra]
-Please give the filename to save your player and progress to.!!translate
+Veuillez indiquer l'emplacement où sauvegarder ce joueur
 [rus]
 Наберите название файла, куда сохранить этого героя.
 
@@ -10,7 +10,7 @@ Please give the filename to save your player and progress to.!!translate
 [eng]
 Player successfully saved.
 [fra]
-Player successfully saved.!!translate
+Le joueur a bien été sauvegardé.
 [rus]
 Герой удачно сохранен.
 
@@ -18,7 +18,7 @@ Player successfully saved.!!translate
 [eng]
 DROD failed to save this player's data.  Possibly there is not enough space on the drive where it is being saved.
 [fra]
-!!translate
+DROD n'a pas pu sauvegarder ce joueur. Vous n'avez peut-être pas de droit d'écriture ou bien il n'y a pas assez d'espace sur le disque que vous avez choisi.
 [rus]
 ДРОД не смог сохранить героя.  Наверно, места не хватает на диске.
 
@@ -26,7 +26,7 @@ DROD failed to save this player's data.  Possibly there is not enough space on t
 [eng]
 Please give the path to save this hold data to.
 [fra]
-Please give the path to save this hold data to.!!translate
+Veuillez indiquer l'emplacement où sauvegarder les données de cet antre
 [rus]
 Наберите название файла, куда сохранить эту крепость.
 
@@ -34,7 +34,7 @@ Please give the path to save this hold data to.!!translate
 [eng]
 Hold successfully saved.
 [fra]
-Hold successfully saved.!!translate
+L'antre a bien été sauvegardé.
 [rus]
 Крепость удачно сохранена.
 
@@ -46,7 +46,7 @@ DROD failed to save this hold.  Possibly there is not enough space on the drive 
 [eng]
 Exporting data...
 [fra]
-Exporting data...!!translate
+Exportation des données…
 [rus]
 Сохраняя данные...
 
@@ -54,7 +54,7 @@ Exporting data...!!translate
 [eng]
 hold originally authored by
 [fra]
-!!translate
+Antre initialement créé par
 [rus]
 крепость впервые сделано (кем)
 
@@ -62,25 +62,25 @@ hold originally authored by
 [eng]
 Do you want to export hold speech texts?
 [fra]
-!!translate
+Voulez-vous exporter les doublages de l'antre ?
 [rus]
-!!translate
+Вы хотите экспортировать тексты диалогов катакомбы?
 
 [MID_HoldScriptsSaved]
 [eng]
 Hold speech script saved.
 [fra]
-!!translate
+Script des doublages d el'antre sauvegardé.
 [rus]
-!!translate
+Сценарий диалогов катакомбы сохранен
 
 [MID_ExportSavedProgress]
 [eng]
 Export &Saves Only
 [fra]
-!!translate
+N'exporter que les &Sauvegardes
 [rus]
-!!translate
+Экспорт &сохраненных игр
 
 [MID_Saves]
 [eng]
@@ -94,9 +94,9 @@ saves
 [eng]
 Progress saved.
 [fra]
-!!translate
+Les sauvegardes ont bien été exportées.
 [rus]
-!!translate
+Результаты сохраненной игры успешно записаны.
 
 [MID_Manage]
 [eng]

--- a/drodrpg/Texts/FileAccess.uni
+++ b/drodrpg/Texts/FileAccess.uni
@@ -2,7 +2,7 @@
 [eng]
 Current directory
 [fra]
-Current directory!!translate
+Adresse
 [rus]
 Подкаталог
 
@@ -10,7 +10,7 @@ Current directory!!translate
 [eng]
 File name
 [fra]
-File name!!translate
+Nom du fichier
 [rus]
 Название файла
 
@@ -18,7 +18,7 @@ File name!!translate
 [eng]
 File type
 [fra]
-File type!!translate
+Type du fichier
 [rus]
 Тип файла
 
@@ -26,7 +26,7 @@ File type!!translate
 [eng]
 Do you really want to overwrite this file?
 [fra]
-Do you really want to overwrite this file?!!translate
+Voulez-vous écraser ce fichier ?
 [rus]
 Вы точно хотите переписать над этим файлом?
 

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -10,7 +10,7 @@ Sortir du niveau!
 [eng]
 Current game info
 [fra]
-Current game info!!translate
+Infos de jeu
 [rus]
 Текушие данные игры
 
@@ -18,7 +18,7 @@ Current game info!!translate
 [eng]
 Moves made
 [fra]
-Moves made!!translate
+Nombre de mouvements
 [rus]
 Ходы сделаны
 
@@ -26,7 +26,7 @@ Moves made!!translate
 [eng]
 Monsters killed
 [fra]
-Monsters killed!!translate
+Monstres tués.
 [rus]
 Монстры убиты
 

--- a/drodrpg/Texts/Import.uni
+++ b/drodrpg/Texts/Import.uni
@@ -2,7 +2,7 @@
 [eng]
 &Import
 [fra]
-&Import!!translate
+&Importer
 [rus]
 Ввести файл
 
@@ -10,7 +10,7 @@
 [eng]
 Please select the file you want to import
 [fra]
-Please select the file you want to import!!translate
+Veuillez indiquer le nom du fichier que vous voulez importer
 [rus]
 Дайте имя файла, который Вы хотите ввести в игру.
 
@@ -18,7 +18,7 @@ Please select the file you want to import!!translate
 [eng]
 Importing
 [fra]
-Importing!!translate
+Importation
 [rus]
 Читая
 
@@ -38,7 +38,7 @@ Checking saved game integrity...
 [eng]
 Data imported successfully.
 [fra]
-Data imported successfully.!!translate
+Les données ont bien été importées.
 [rus]
 Файл удачно импортирован.
 
@@ -46,7 +46,7 @@ Data imported successfully.!!translate
 [eng]
 ERROR: File not found.
 [fra]
-ERROR: File not found.!!translate
+ERREUR : Fichier introuvable
 [rus]
 Внимание!  Файл не найден.
 
@@ -54,7 +54,7 @@ ERROR: File not found.!!translate
 [eng]
 ERROR: File corrupted.
 [fra]
-ERROR: File corrupted.!!translate
+ERREUR : Fichier corrompu.
 [rus]
 Внимание!  Файл испорчен.
 
@@ -62,7 +62,7 @@ ERROR: File corrupted.!!translate
 [eng]
 ERROR: Hold not found.
 [fra]
-ERROR: Hold not found.!!translate
+ERREUR : Antre introuvable.
 [rus]
 Внимание!  Крепость не найдена.
 
@@ -70,7 +70,7 @@ ERROR: Hold not found.!!translate
 [eng]
 ERROR: Level not found.
 [fra]
-ERROR: Level not found.!!translate
+ERREUR : Niveau introuvablee
 [rus]
 Внимание!  Уровень не найден.
 
@@ -78,31 +78,31 @@ ERROR: Level not found.!!translate
 [eng]
 The hold data being imported was ignored.
 [fra]
-!!translate
+Les données de l'antre importé ont été ignorées.
 [rus]
-!!translate
+Данные импортируемой катакомбы были отклонены.
 
 [MID_HoldIdenticalIgnored]
 [eng]
 This hold is the same as a hold already installed and was ignored.
 [fra]
-!!translate
+Cet antre est le même qu'un autre déjà installé et a été ignoré.
 [rus]
-!!translate
+Эта катакомба идентична ранее установленной; катакомба отклонена.
 
 [MID_HoldNotIdenticalIgnored]
 [eng]
 This hold does not match any installed hold and was ignored.
 [fra]
-!!translate
+Cet antre ne correspond à aucun antre installé et a été ignoré.
 [rus]
-!!translate
+Эта катакомба не соответствует ни одной из ранее установленных; катакомба отклонена.
 
 [MID_PlayerIgnored]
 [eng]
 The player being imported is the same as or an older version of an existing player and was ignored.
 [fra]
-!!translate
+Le fichier de joueur importé est d'une version similaire ou plus vieille qu'un fichier déjà existant et a été ignoré.
 [rus]
 Игрок в файле является более старым, чем тот, который уже в памяти и был пропушен.
 
@@ -110,7 +110,7 @@ The player being imported is the same as or an older version of an existing play
 [eng]
 A demo being imported belongs to a hold that you don't have and was ignored.
 [fra]
-!!translate
+Une ou plusieurs démos importés appartiennent à un antre, un niveau ou une pièce que vous ne possédez pas et ont été ignorés.
 [rus]
 Демонстрация в файле принадлежит отсутствуюшей крепости и была пропушена.
 
@@ -118,23 +118,23 @@ A demo being imported belongs to a hold that you don't have and was ignored.
 [eng]
 The saved games in this file could not be imported into an active player.
 [fra]
-!!translate
+Les parties sauvegardées dans ce fichier n'ont pas pu être importées pour un joueur actif.
 [rus]
-!!translate
+Сохраненные игры из этого файла не могут быть импортированы активному игроку.
 
 [MID_OverwriteHoldPrompt]
 [eng]
 This hold replaces an earlier version of the same hold. After importing the new version, only saved games compatible with the new version will be left intact. Is this okay?
 [fra]
-!!translate
+Ce fichier remplace une version plus ancienne du même antre. Après avoir importé la nouvelle version, seules les parties sauvegardées compatibles avec la nouvelle version seront accessibles. D'accord ?
 [rus]
-Крепость в файле изменит более старую версию той же крепости. Импортируя новую версия, !!translate.  Продолжать?
+Данная катакомба заменит ее предыдущую версию. После осуществления импорта новой версии доступными останутся лишь сохраненные игры, совместимые с ней. Желаете продолжить?
 
 [MID_OverwritePlayerPrompt]
 [eng]
 You are importing a newer version of a current player. Doing this will replace all your current player's data with the player data being imported.  Is this okay?
 [fra]
-!!translate
+Vous êtes en train d'importer une version plus récente d'un joueur existant. Ceci remplacera toutes les données du joueur existant par celle de celui importé. D'accord ?
 [rus]
 Игрок в файле изменит более старую версию того же игрока.  Импортируя новую версия, Вы смените все сохраненные игры от старого игрока теми, которые от нового.  Продолжать?
 
@@ -142,7 +142,7 @@ You are importing a newer version of a current player. Doing this will replace a
 [eng]
 The player was successfully imported, but certain saved games were created from a different version of a hold in memory.  Only saved games compatible with the current hold version will be retained.
 [fra]
-!!translate
+Le joueur a bien été importé, mais certaines parties sauvegardées avaient été créées sous une version différente d'un antre installé. Seules les parties sauvegardées compatibles avec la version actuelle de l'antre seront conservées.
 [rus]
 Игрок импортирован, однако некоторые игры были сделаны в крепости другой версии, чем имеется у Вас на данный момент.  В таких крепостей, только игры в начле уровня были приняты.
 
@@ -150,9 +150,9 @@ The player was successfully imported, but certain saved games were created from 
 [eng]
 This file was created by a newer version of DROD and isn't supported in this earlier version.
 [fra]
-!!translate
+Ce fichier a été créé par une version plus récente de DROD et n'est pas pris en charge dans cette version plus ancienne.
 [rus]
-!!translate
+Этот файл был создан в более поздней версии ДРОДа и не поддерживается в этой, более ранней.
 
 [MID_NotConnected]
 [eng]

--- a/drodrpg/Texts/KeyDescriptions.uni
+++ b/drodrpg/Texts/KeyDescriptions.uni
@@ -825,182 +825,182 @@ F15
 [eng]
 Num Lock
 [fra]
-Num Lock!!translate
+Verr. Num
 [rus]
-"Num Lock"
+Num Lock
 
 [MID_KEY_CAPSLOCK]
 [eng]
 Caps Lock
 [fra]
-Caps Lock!!translate
+Verr. Maj
 [rus]
-"Caps Lock"
+Caps Lock
 
 [MID_KEY_SCROLLOCK]
 [eng]
 Scroll Lock
 [fra]
-Scroll Lock!!translate
+Arrêt Défil
 [rus]
-"Scroll Lock"
+Scroll Lock
 
 [MID_KEY_RSHIFT]
 [eng]
 Right Shift
 [fra]
-Right Shift!!translate
+Maj Droit
 [rus]
-"Right Shift"
+Правый Shift
 
 [MID_KEY_LSHIFT]
 [eng]
 Left Shift
 [fra]
-Left Shift!!translate
+Maj Gauche
 [rus]
-"Left Shift"
+Левый Shift
 
 [MID_KEY_RCTRL]
 [eng]
 Right Ctrl
 [fra]
-Right Ctrl!!translate
+Ctrl Droit
 [rus]
-"Right Ctrl"
+Правый Ctrl
 
 [MID_KEY_LCTRL]
 [eng]
 Left Ctrl
 [fra]
-Left Ctrl!!translate
+Ctrl Gauche
 [rus]
-"Left Ctrl"
+Левый Ctrl
 
 [MID_KEY_RALT]
 [eng]
 Right Alt
 [fra]
-Right Alt!!translate
+Alt Droit
 [rus]
-"Right Alt"
+Правый Alt
 
 [MID_KEY_LALT]
 [eng]
 Left Alt
 [fra]
-Left Alt!!translate
+Alt Gauche
 [rus]
-"Left Alt"
+Левый Alt
 
 [MID_KEY_RMETA]
 [eng]
 Right Meta
 [fra]
-Right Meta!!translate
+Méta Droit
 [rus]
-"Right Meta"
+Правая Meta
 
 [MID_KEY_LMETA]
 [eng]
 Left Meta
 [fra]
-Left Meta!!translate
+Méta Gauche
 [rus]
-"Left Meta"
+Левая Meta
 
 [MID_KEY_LSUPER]
 [eng]
 Left Windows key
 [fra]
-Left Windows key!!translate
+Touche Windows Gauche
 [rus]
-"Left Windows key"
+Левая клавиша Windows
 
 [MID_KEY_RSUPER]
 [eng]
 Right Windows key
 [fra]
-Right Windows key!!translate
+Touche Windows Droite
 [rus]
-"Right Windows key"
+Правая клавиша Windows
 
 [MID_KEY_MODE]
 [eng]
 Alt Gr key
 [fra]
-Alt Gr key!!translate
+Touche Alt Gr
 [rus]
-"Alt Gr key"
+Alt Gr
 
 [MID_KEY_COMPOSE]
 [eng]
 Multi-key compose key
 [fra]
-Multi-key compose key!!translate
+Touche compose
 [rus]
-"Multi-key compose key"
+Составная мультиклавиша
 
 [MID_KEY_HELP]
 [eng]
 Help
 [fra]
-Help!!translate
+Aide
 [rus]
-"Помощь"
+Помощь
 
 [MID_KEY_PRINT]
 [eng]
 Print
 [fra]
-Print!!translate
+Imprimer
 [rus]
-"Печатать"
+Печатать
 
 [MID_KEY_SYSREQ]
 [eng]
 SysReq
 [fra]
-SysReq!!translate
+SysReq
 [rus]
-"SysReq"
+SysReq
 
 [MID_KEY_BREAK]
 [eng]
 Break
 [fra]
-Break!!translate
+Pause
 [rus]
-"Break"
+Пауза
 
 [MID_KEY_MENU]
 [eng]
 Menu
 [fra]
-Menu!!translate
+Menu
 [rus]
-"Менью"
+Менью
 
 [MID_KEY_POWER]
 [eng]
 Power
 [fra]
-Power!!translate
+Power
 [rus]
-"Power"
+Питание
 
 [MID_KEY_EURO]
 [eng]
 Euro
 [fra]
-Euro!!translate
+Euro
 [rus]
-"Euro"
+Евро
 
 [MID_KEY_UNDO]
 [eng]
 Undo
 [fra]
-Undo!!translate
+Annuler
 [rus]
-"Undo"
+Отменить

--- a/drodrpg/Texts/RestoreScreen.uni
+++ b/drodrpg/Texts/RestoreScreen.uni
@@ -34,7 +34,7 @@ Début de &Niveau
 [eng]
 H&old Start
 [fra]
-Début de l'&Oubliette
+Début de l'antre
 [rus]
 Начало крепости
 

--- a/drodrpg/Texts/SelectScreens.uni
+++ b/drodrpg/Texts/SelectScreens.uni
@@ -2,9 +2,9 @@
 [eng]
 Hold Management
 [fra]
-!!translate
+Gestion des Antres
 [rus]
-!!translate
+Управление Катакомбами
 
 [MID_SelectPlayerPrompt]
 [eng]
@@ -20,9 +20,13 @@ Welcome to DROD RPG!
 
 Enter your name below or click "Import" if you have a player profile on disk from which you would like to import existing information.
 [fra]
-!!translate
+Bienvenue dans DROD !
+
+Entrez votre nom ci-dessous ou cliquez "Importer" si vous avez un profil joueur dont vous voulez importer les données.
 [rus]
-!!translate
+Добро пожаловать в ДРОД!
+
+Введите внизу свое имя или щелкните на кнопке "Импорт", если хотите загрузить информацию из профиля игрока, сохраненного на диске.
 
 [MID_DeletePlayerPrompt]
 [eng]
@@ -60,7 +64,7 @@ Supprimer Joueur
 [eng]
 Delete Hold
 [fra]
-!!translate
+Effacer Antre
 [rus]
 &Удалить Крепость
 
@@ -68,7 +72,7 @@ Delete Hold
 [eng]
 Download
 [fra]
-!!translate
+Télécharger
 [rus]
 Скачать
 

--- a/drodrpg/Texts/SettingsScreen.uni
+++ b/drodrpg/Texts/SettingsScreen.uni
@@ -206,9 +206,9 @@ Musique
 [eng]
 Play Voices
 [fra]
-!!translate
+Activer Voix
 [rus]
-!!translate
+Громкость голоса
 
 [MID_Quiet]
 [eng]
@@ -234,7 +234,7 @@ Show subtitles when voices play
 [eng]
 Alpha blending
 [fra]
-Alpha blending!!translate
+Alpha blending
 [rus]
 Алфа
 
@@ -322,41 +322,41 @@ CaravelNet Key
 [eng]
 Requesting CaravelNet Key
 [fra]
-!!translate
+Demande de clef CaravelNet
 [rus]
-!!translate
+Запрашивается ключ CaravelNet
 
 [MID_KeySent]
 [eng]
 A new CaravelNet Key has been sent to your registered e-mail address.
 [fra]
-!!translate
+Une nouvelle clef CaravelNet a été envoyée à l'adresse e-mail que vous avez indiquée.
 [rus]
-!!translate
+Новый ключ CaravelNet был отправлен на ваш зарегистрированный электронный ящик
 
 [MID_NotRegistered]
 [eng]
 You are not a registered user of CaravelNet.
 [fra]
-!!translate
+Vous n'êtes pas un utilisateur enregistré de CaravelNet.
 [rus]
-!!translate
+Вы - незарегистрированный пользователь CaravelNet
 
 [MID_RegistrationExpired]
 [eng]
 Your CaravelNet registration has expired.
 [fra]
-!!translate
+Votre inscription CaravelNet a expiré.
 [rus]
-!!translate
+Ваш регистрационный период CaravelNet истек
 
 [MID_CaravelNetUnreachable]
 [eng]
 Could not contact CaravelNet.
 [fra]
-!!translate
+Impossible de contacter CaravelNet.
 [rus]
-!!translate
+Невозможно соединиться с CaravelNet
 
 [MID_GetKeyCommand]
 [eng]
@@ -386,25 +386,25 @@ Cette touche ne peut pas être employée. "Echap" et "F1 à F12" sont des touche
 [eng]
 Please enter a player name.
 [fra]
-!!translate
+Veuillez entrer un nom de joueur.
 [rus]
-!!translate
+Введите, пожалуйста, имя игрока.
 
 [MID_RequestNewKey]
 [eng]
 Request New Key
 [fra]
-!!translate
+Demander une Nouvelle Clef
 [rus]
-!!translate
+Запрос новой клавиши
 
 [MID_UploadScores]
 [eng]
 Report my Progress
 [fra]
-!!translate
+Signaler mes progrès
 [rus]
-!!translate
+Сообщить о моем прогрессе
 
 [MID_ConnectToInternet]
 [eng]


### PR DESCRIPTION
Like #845 but for RPG. Things were even worse in some places - the `!!translate` tag was the entire entry for some strings. Usefully, all the strings with these tags in the RPG `.uni` files had translations available in the TSS files, so I could reuse the translations as needed.

The one difference I noticed was that the French translations for TSS and RPG translate 'hold' differently. TSS uses 'antre', while RPG used 'oubliette'. To make things easier I've made RPG consistent with TSS.