### PR TITLE
Fix timing with clearing of import temporary files

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1345,6 +1345,7 @@ void CDbXML::ImportSavedGames()
 		VERIFY(ImportXML(info.exportedSavedGamesFile.c_str(), CImportInfo::SavedGame) == MID_ImportSuccessful);
 	}
 
+	info.ClearTempFiles();
 	info.typeBeingImported = importType;
 	info.ImportStatus = importState;
 	info.bImportingSavedGames = false;
@@ -1615,7 +1616,6 @@ void CDbXML::CleanUp()
 	importBuf.clear();
 
 	info.Clear(true);
-	info.ClearTempFiles();
 	pCallbackObject = NULL; //release hook
 }
 


### PR DESCRIPTION
Deleting the temp files as part of `CDbXML::CleanUp()` means they can get deleted between importing demos and importing saves. Which is bad because it means saves won't get preserved. Moved the call to fix this.