### PR TITLE
Change include type in InputKey.h

### DIFF
--- a/BackEndLib/InputKey.h
+++ b/BackEndLib/InputKey.h
@@ -29,7 +29,7 @@
 
 #include <SDL_syswm.h>
 #include <SDL_events.h>
-#include <BackEndLib/Types.h>
+#include "Types.h"
 
 #define UNKNOWN_INPUT_KEY InputKey(0)
 


### PR DESCRIPTION
For whatever reason, trying to compile a Steam build doesn't work because of the `#include <BackEndLib/Types.h>` line in `InputKey.h`. Every other include of `Types.h` uses quote includes so I've changed the problem line to match.