### PR TITLE
Fix room lock being unset when updating game from snapshot

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -4710,7 +4710,6 @@ void CCurrentGame::SetTurn(
 		const UINT d_ = this->dwLevelDeaths, k_ = this->dwLevelKills,
 				m_ = this->dwLevelMoves, t_ = this->dwLevelTime,
 				st_ = this->dwStartTime;
-		const bool rl_ = this->bRoomExitLocked;
 		const UINT dwAutoSaveOptions_ = this->dwAutoSaveOptions;
 
 		//Restore game to state of selected snapshot.
@@ -4734,7 +4733,7 @@ void CCurrentGame::SetTurn(
 		this->dwLevelMoves = m_;
 		this->dwLevelTime = t_;
 		this->dwStartTime = st_;
-		this->bRoomExitLocked = rl_;
+		this->bRoomExitLocked = bOldIsRoomLocked;
 		this->dwAutoSaveOptions = dwAutoSaveOptions_;
 
 		return;


### PR DESCRIPTION
There is an oversight in `CCurrentGame::SetTurn` that can cause the room lock state to be changed. When a game snapshot is used, the lock state is recorded in a temporary variable, and then set back. However, #195 made a change so that by the time this happens, `CCurrentGame::bRoomExitLocked` has already been set to false, and it's value recorded in a different variable. If a snapshot is used, the function returns before the lock state is set back.

To fix this, we should reset the lock state using the `bOldIsRoomLocked` value once the game state has been updated from a snapshot.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46295