### PR TITLE
Change how temporary files used in hold update are named

### DIFF
--- a/BackEndLib/Wchar.cpp
+++ b/BackEndLib/Wchar.cpp
@@ -53,6 +53,7 @@ const WCHAR wszEqual[] =        { We('='),We(0) };
 const WCHAR wszExclamation[] =  { We('!'),We(0) };
 const WCHAR wszForwardSlash[] = { We('/'),We(0) };
 const WCHAR wszHyphen[] =       { We('-'),We(0) };
+const WCHAR wszTilde[] =        { We('~'),We(0) };
 const WCHAR wszParentDir[] =    { We('.'),We('.'),We(0) };
 const WCHAR wszPercent[] =      { We('%'),We(0) };
 const WCHAR wszPeriod[] =       { We('.'),We(0) };

--- a/BackEndLib/Wchar.h
+++ b/BackEndLib/Wchar.h
@@ -80,7 +80,7 @@ typedef std::basic_string<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR> 
 //Some common small strings.  Larger strings are localizable and should be kept in database.
 extern const WCHAR wszAmpersand[], wszAsterisk[], wszOpenAngle[], wszCloseAngle[], wszColon[],
 	wszComma[], wszCRLF[], wszDollarSign[], wszElipsis[], wszEmpty[], wszEqual[],
-	wszExclamation[], wszForwardSlash[], wszHyphen[], wszParentDir[],
+	wszExclamation[], wszForwardSlash[], wszHyphen[], wszTilde[], wszParentDir[],
 	wszPercent[], wszPeriod[], wszPoundSign[], wszPlus[], wszQuestionMark[], wszQuote[],
 	wszLeftBracket[], wszRightBracket[], wszLeftParen[], wszRightParen[],
 	wszSemicolon[], wszSpace[], wszSlash[], wszUnderscore[], wszZero[], wszOne[], wszTwo[];

--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -2248,6 +2248,7 @@ bool CDrodScreen::ImportConfirm(MESSAGE_ID& result, const WSTRING* pwFilename)
 	{
 		//Not continuing import
 		CDbXML::CleanUp();
+		CDbXML::info.ClearTempFiles();
 		return false;
 	}
 

--- a/DRODLib/DbXML.h
+++ b/DRODLib/DbXML.h
@@ -157,7 +157,7 @@ private:
 	static void ImportSavedGames();
 	static void VerifySavedGames();
 
-	static WSTRING prepareTemporaryFile(const WCHAR* wszFilename);
+	static WSTRING prepareTemporaryFile(const WCHAR* wszFilename, const WSTRING& holdName);
 	static gzFile openGZipFile(const WCHAR* wszFilename);
 
 	static vector <CDbBase*> dbRecordStack;   //stack of records being parsed


### PR DESCRIPTION
The final go at dealing with losing progress due to crashes during updates: make it easy to use the temporary export files to reimport the data if it goes wrong. By integrating the current time into the file names, it also means they won't be inadvertedly erased.

I'd like there to be a more elegant solution, but at this point I don't think there is due to limitations of commiting to metakit storage works.