### PR TITLE
RPG: Fix No Enemy Defense behaviour on small weapons

### DIFF
--- a/drodrpg/DRODLib/Combat.cpp
+++ b/drodrpg/DRODLib/Combat.cpp
@@ -334,7 +334,7 @@ int CCombat::getPlayerATK()
 		this->bPlayerDoesStrongHit = true;
 	}
 
-	if (player.HasSword() && this->pGame->DoesPlayerItemHaveNoEnemyDefense(ScriptFlag::Weapon))
+	if (PlayerIgnoresEnemyDefense())
 	{
 		//Player is wielding a NoDefense weapon.  Monster cannot protect against it.
 		//if (this->monDEF > 0) this->monDEF = 0; //don't modify stat here, so monster's DEF display will be more useful
@@ -449,6 +449,13 @@ bool CCombat::PlayerDoesStrongHit(const CMonster* pMonster) const
 	}
 
 	return false;
+}
+
+//*****************************************************************************
+bool CCombat::PlayerIgnoresEnemyDefense() const
+//Returns: whether player ignores the enemy's defense
+{
+	return !this->pGame->IsPlayerSwordDisabled() && this->pGame->DoesPlayerItemHaveNoEnemyDefense(ScriptFlag::Weapon);
 }
 
 //*****************************************************************************
@@ -1086,7 +1093,7 @@ bool CCombat::PlayerCanHarmMonster(const CMonster *pMonster) const
 		doubleWithClamp(atk); //doubles effective attack power
 	if (PlayerDoesStrongHit(pMonster))
 		doubleWithClamp(atk); //doubles effective attack power
-	if (player.HasSword() && this->pGame->DoesPlayerItemHaveNoEnemyDefense(ScriptFlag::Weapon))
+	if (PlayerIgnoresEnemyDefense())
 		monDef = 0;
 
 	int dx, dy;

--- a/drodrpg/DRODLib/Combat.h
+++ b/drodrpg/DRODLib/Combat.h
@@ -120,6 +120,7 @@ public:
 	bool PlayerCanHarmQueuedMonster() const;
 	CMonster* PlayerCantHarmAQueuedMonster() const;
 	bool PlayerDoesStrongHit(const CMonster* pMonster) const;
+	bool PlayerIgnoresEnemyDefense() const;
 	bool PlayerHasStrongShield(const CMonster* pMonster) const;
 	bool QueueMonster(CMonster* pMonster, const bool bPlayerHitsFirst,
 			const UINT wFromX, const UINT wFromY,


### PR DESCRIPTION
The no enemy defense behaviour was missed during the refactor of making checks for weapon behaviours properly account for being disabled and being on a small weapon.

https://forum.caravelgames.com/viewtopic.php?TopicID=46925