### PR TITLE
Fix problems with player behavior enum declaration

### DIFF
--- a/DRODLib/DbSavedGames.h
+++ b/DRODLib/DbSavedGames.h
@@ -63,8 +63,8 @@ enum SAVETYPE
 class CDbSavedGames;
 class CCurrentGame;
 class CDbRoom;
-enum PlayerBehavior;
-enum PlayerBehaviorState;
+enum PlayerBehavior : int;
+enum PlayerBehaviorState : int;
 class CDbSavedGame : public CDbBase
 {
 protected:

--- a/DRODLib/Swordsman.h
+++ b/DRODLib/Swordsman.h
@@ -57,7 +57,7 @@ enum WaterTraversal
 	WTrv_CanHide=3			//Can hide in Shallow Water (sheathes sword)
 };
 
-enum PlayerBehaviorState
+enum PlayerBehaviorState : int
 {
 	PBS_Default = 0,	//User Player Role properties
 	PBS_On = 1,				//Always active
@@ -66,7 +66,7 @@ enum PlayerBehaviorState
 	PBS_Unpowered = 4	//Active for non-powered player
 };
 
-enum PlayerBehavior
+enum PlayerBehavior : int
 {
 	PB_Null = 0, //Not used
 	PB_BumpActivateOrb = 1,


### PR DESCRIPTION
We forward declare the `PlayerBehavior` and `PlayerBehaviorState` enums in `DbSavedGames.h`. However, this causes problems when compiling on Linux, as you aren't actually allowed to forward declare enums like that. I have no idea why it works on other platforms.

However, you can forward declare enums if you specify their size via inheritance, so I've done that for those two enums.