### PR TITLE
Fix uses of min/max to work with standard functions

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -7461,7 +7461,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 				this->pAddCommandDialog->GetWidget(TAG_WAIT));
 			ASSERT(pDarkLevel);
 			UINT wDarkness = _Wtoi(pDarkLevel->GetText());
-			this->pCommand->flags = max(0, min(wDarkness, NUM_DARK_TYPES));
+			this->pCommand->flags = max(0U, min(wDarkness, UINT(NUM_DARK_TYPES)));
 			QueryRect();
 		}
 		break;
@@ -7477,7 +7477,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 				this->pAddCommandDialog->GetWidget(TAG_WAIT));
 			ASSERT(pLightLevel);
 			UINT wLight = _Wtoi(pLightLevel->GetText());
-			this->pCommand->w = max(0, min(wLight, MAX_LIGHT_DISTANCE));
+			this->pCommand->w = max(0U, min(wLight, UINT(MAX_LIGHT_DISTANCE)));
 			this->pCommand->flags = this->pColorListBox->GetSelectedItem();
 			QueryXY();
 		}

--- a/DROD/CharacterOptionsWidget.cpp
+++ b/DROD/CharacterOptionsWidget.cpp
@@ -136,9 +136,9 @@ void CCharacterOptionsDialog::SetSpeechColorTexts(UINT color)
 //*****************************************************************************
 UINT CCharacterOptionsDialog::GetSpeechColor()
 {
-	UINT r = min((UINT)this->pSpeechColorRedTextBox->GetNumber(), 255);
-	UINT g = min((UINT)this->pSpeechColorGreenTextBox->GetNumber(), 255);
-	UINT b = min((UINT)this->pSpeechColorBlueTextBox->GetNumber(), 255);
+	UINT r = min((UINT)this->pSpeechColorRedTextBox->GetNumber(), 255U);
+	UINT g = min((UINT)this->pSpeechColorGreenTextBox->GetNumber(), 255U);
+	UINT b = min((UINT)this->pSpeechColorBlueTextBox->GetNumber(), 255U);
 
 	UINT value = (r << 16) + (g << 8) + b;
 

--- a/DROD/DemoScreen.cpp
+++ b/DROD/DemoScreen.cpp
@@ -237,7 +237,7 @@ void CDemoScreen::OnKeyDown(
 
 	// The longer forward/backwards key is pressed the faster frames should pass
 	UINT wMovesToDo = static_cast<UINT>(max(
-		1,
+		1.0,
 		ceil(GetKeyRepeatDuration() / NAVIGATION_SPEED_INCREASE)
 	));
 

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -565,10 +565,10 @@ void CCharacter::setPredefinedVarInt(
 			this->nColor = val;
 		break;
 		case (UINT)ScriptVars::P_MONSTER_HUE:
-			this->nHue = max(0, min(val, MAX_HUE));
+			this->nHue = max(0U, min(val, MAX_HUE));
 		break;
 		case (UINT)ScriptVars::P_MONSTER_SATURATION:
-			this->nSaturation = max(0, min(val, MAX_SATURATION));
+			this->nSaturation = max(0U, min(val, MAX_SATURATION));
 		break;
 		//Room position.
 		case (UINT)ScriptVars::P_MONSTER_X:
@@ -3872,7 +3872,7 @@ void CCharacter::Process(
 				bool bCeilingLightChanged = false;
 
 				//clamp pflag to lighting type range
-				pflags = max(0, min(pflags, NUM_DARK_TYPES));
+				pflags = max(0U, min(pflags, UINT(NUM_DARK_TYPES)));
 
 				if (pflags == 0) {
 					//Remove tile lights
@@ -3930,7 +3930,7 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_SetWallLight: {
 				bProcessNextCommand = true;
 				getCommandParams(command, px, py, pw, ph, pflags);
-				pw = max(0, min(pw, MAX_LIGHT_DISTANCE));
+				pw = max(0U, min(pw, UINT(MAX_LIGHT_DISTANCE)));
 
 				if (!room.IsValidColRow(px, py) || !(bIsLightTileValue(pflags) || pflags == 0))
 					break;

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -1256,25 +1256,25 @@ void CCurrentGame::ProcessCommandSetVar(
 		break;
 		case (UINT)ScriptVars::P_ROOM_DARKNESS:
 		{
-			UINT wLight = max(0, min(newVal, MAX_ROOM_LIGHT));
+			UINT wLight = max(0U, min(newVal, MAX_ROOM_LIGHT));
 			this->pRoom->weather.wLight = wLight;
 		}
 		break;
 		case (UINT)ScriptVars::P_ROOM_FOG:
 		{
-			UINT wFog = max(0, min(newVal, MAX_ROOM_FOG));
+			UINT wFog = max(0U, min(newVal, MAX_ROOM_FOG));
 			this->pRoom->weather.wFog = wFog;
 		}
 		break;
 		case (UINT)ScriptVars::P_ROOM_SNOW:
 		{
-			UINT wSnow = max(0, min(newVal, MAX_ROOM_SNOW));
+			UINT wSnow = max(0U, min(newVal, MAX_ROOM_SNOW));
 			this->pRoom->weather.wSnow = wSnow;
 		}
 		break;
 		case (UINT)ScriptVars::P_ROOM_RAIN:
 		{
-			UINT wRain = max(0, min(newVal, MAX_ROOM_RAIN));
+			UINT wRain = max(0U, min(newVal, MAX_ROOM_RAIN));
 			this->pRoom->weather.rain = wRain;
 		}
 		break;

--- a/DRODLib/GameConstants.h
+++ b/DRODLib/GameConstants.h
@@ -169,10 +169,10 @@ static const UINT NO_ORIENTATION = 4;
 static const UINT ORIENTATION_COUNT = 9;
 
 //Max weather values.
-#define MAX_ROOM_LIGHT (6)
-#define MAX_ROOM_FOG (3)
-#define MAX_ROOM_SNOW (9)
-#define MAX_ROOM_RAIN (19)
+#define MAX_ROOM_LIGHT (6U)
+#define MAX_ROOM_FOG (3U)
+#define MAX_ROOM_SNOW (9U)
+#define MAX_ROOM_RAIN (19U)
 
 //******************************************************************************************
 namespace InputCommands


### PR DESCRIPTION
There are several places in the code where `min` and `max` take arguments that aren't the same type. These don't work if they're defined as `std::min` and `std::max`. This is generally happening when one of the values is a constant.

I've gone through and fixed up all the ones that aren't using the same type, generally by adding the special indicators that mark a constant as not being an `int`.

(In theory we might be able to remove the weird hack in `Ports.h` by now but I haven't done that for the sake of avoiding more problems later.)