### PR TITLE
RPG: Fix two issues with room preview states

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -4372,7 +4372,7 @@ void CGameScreen::SearchForPathToNextRoom(
 		const UINT newRoomID = pRoom->dwRoomID;
 		delete pRoom;
 		if (!this->pCurrentGame->IsRoomExplored(newRoomID) &&
-			CDbSavedGames::IsMoreDetailedMapState(this->pCurrentGame->GetStoredMapStateForRoom(newRoomID), MapState::Invisible))
+			!CDbSavedGames::IsMoreDetailedMapState(this->pCurrentGame->GetStoredMapStateForRoom(newRoomID), MapState::Invisible))
 		{
 			this->pRoomWidget->DisplaySubtitle(
 					g_pTheDB->GetMessageText(MID_QuickPathNotAvailable), wPX, wPY, true);

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -8635,5 +8635,5 @@ void CCurrentGame::InitializeTotalMapStates(const bool forceLoading) // (in) def
 //Initialize TotalMapStates
 {
 	if (forceLoading || !this->bNoSaves)
-		TotalMapStates.Load(this->dwPlayerID, this->pLevel->dwLevelID);
+		TotalMapStates.Load(g_pTheDB->GetPlayerID(), this->pLevel->dwLevelID);
 }


### PR DESCRIPTION
Fixes two bugs:
1) Introduced a regression that stopped you from pathfinding to a preview room, (this was caused by an accidental flipping of the logic):
https://forum.caravelgames.com/viewtopic.php?TopicID=46935

2) When loading or starting a new game, the preview room states were only loaded from the default player id, as it happens before the members are set on the current game object:
https://forum.caravelgames.com/viewtopic.php?TopicID=46943