### PR TITLE
Remove use of Windows-only INT type

### DIFF
--- a/DROD/DemoScreen.cpp
+++ b/DROD/DemoScreen.cpp
@@ -114,8 +114,8 @@ CDemoScreen::CDemoScreen()
 	, bUniformTurnSpeed(false)
 //Constructor.
 {
-	static const INT HELP_DIALOG_W = 800;
-	static const INT HELP_DIALOG_H = 600;
+	static const UINT HELP_DIALOG_W = 800;
+	static const UINT HELP_DIALOG_H = 600;
 
 	{
 		CHtmlDialogWidget *pHtmlDialogWidget = new CHtmlDialogWidget(TAG_HELPDIALOG, HELP_DIALOG_W, HELP_DIALOG_H);


### PR DESCRIPTION
A couple more uses of `INT`, which is a Windows-only type, managed to sneak into the code. Based on context, they should be `UINT` instead.