### PR TITLE
Allow compilation with /permissive- flag

### DIFF
--- a/BackEndLib/Assert.h
+++ b/BackEndLib/Assert.h
@@ -79,8 +79,8 @@ using std::string;
 #define _ASSERT_VOID_CAST(exp)   static_cast<void>(exp)
 #ifdef _DEBUG
 # if defined(WIN32) && !defined(__GNUC__)
-#   define ASSERT(exp)          _ASSERT_VOID_CAST( (exp) ? 0 : AssertErr(__FILENAME__,__LINE__,#exp) )
-#   define ASSERTP(exp, desc)   _ASSERT_VOID_CAST( (exp) ? 0 : AssertErr(__FILENAME__,__LINE__,(desc)) )
+#   define ASSERT(exp)          _ASSERT_VOID_CAST( (exp) ? void() : AssertErr(__FILENAME__,__LINE__,#exp) )
+#   define ASSERTP(exp, desc)   _ASSERT_VOID_CAST( (exp) ? void() : AssertErr(__FILENAME__,__LINE__,(desc)) )
 # else
 #   define ASSERT(exp)          do { if (!(exp)) { AssertErr(__FILENAME__,__LINE__,#exp); MY_BREAKPOINT(); }} while (0)
 #   define ASSERTP(exp, desc)   do { if (!(exp)) { AssertErr(__FILENAME__,__LINE__,(desc)); MY_BREAKPOINT(); }} while (0)

--- a/DROD/DROD.2019.vcxproj
+++ b/DROD/DROD.2019.vcxproj
@@ -334,6 +334,7 @@
       <CompileAs>Default</CompileAs>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;WIN32;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/DROD/DrodScreen.cpp
+++ b/DROD/DrodScreen.cpp
@@ -1303,7 +1303,7 @@ void CDrodScreen::InitKeysymToCommandMap(
 	//which commands correspond to which keys.
 	//
 	//Params:
-	CDbPackedVars& PlayerSettings)   //(in)   Player settings to load from.
+	const CDbPackedVars& PlayerSettings)   //(in)   Player settings to load from.
 {
 	//Clear the map.
 	this->InputKeyToCommandMap.clear();
@@ -1976,7 +1976,7 @@ void CDrodScreen::ExportSaves(
 		CDbHold* pHold = g_pTheDB->Holds.GetByID(holdID);
 		if (pHold)
 		{
-			WSTRING holdName = pHold->NameText;
+			WSTRING holdName(pHold->NameText);
 			static const UINT MAX_HOLD_NAME = 16;
 			if (holdName.size() <= MAX_HOLD_NAME)
 			{

--- a/DROD/DrodScreen.h
+++ b/DROD/DrodScreen.h
@@ -64,7 +64,7 @@ public:
 
 	virtual bool IsCommandSupported(int command) const;
 	UINT    ImportHoldImage(const UINT holdID, const UINT extensionFlags=EXT_JPEG|EXT_PNG);
-	void    InitKeysymToCommandMap(CDbPackedVars& PlayerSettings);
+	void    InitKeysymToCommandMap(const CDbPackedVars& PlayerSettings);
 
 	virtual int    GetCommandForInputKey(const InputKey inputKey) const;
 	static WSTRING getStatsText(const RoomStats& st);

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3200,7 +3200,7 @@ void CCharacter::Process(
 				ScriptArrayMap& scriptArrays = pGame->pHold->IsLocalVar(varId) ?
 					this->localScriptArrays : pGame->scriptArrays;
 
-				ScriptArrayMap::iterator& array = scriptArrays.find(varId);
+				const ScriptArrayMap::iterator& array = scriptArrays.find(varId);
 				if (array != scriptArrays.end()) {
 					//Only clear a script array that is initialized
 					array->second.clear();

--- a/DRODLib/DRODLib.2019.vcxproj
+++ b/DRODLib/DRODLib.2019.vcxproj
@@ -267,6 +267,7 @@
       <CompileAs>Default</CompileAs>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
The MSVC compiler lets you get away with certain things that other compilers don't. The `/permissive-` compiler flag makes things stricter, which has revealed some problems to fix:

- The ternary expression we use for asserts has two different return types, which is bad. Fixable by replacing the 0 with a `void()`
- `DrodScreen::InitKeysymToCommandMap`'s argument is a non-const ref. This causes issues in certain cases. Since it doesn't need to be non-const I've made it const
- Setting a string to be equal to a char array via `=` operator is apparently bad. Fixed the one place doing this by using the constructor.
- Some weird template error I don't understand on line 3203 of `Character.cpp`. Fixed by adding a `const`.

I've gone ahead and added the `/permissive-` flag to the DROD and DRODLib projects to make sure more of these issues don't creep in.