### PR TITLE
RPG: Allow compilation with /permissive- flag

### DIFF
--- a/BackEndLib/Assert.h
+++ b/BackEndLib/Assert.h
@@ -79,8 +79,8 @@ using std::string;
 #define _ASSERT_VOID_CAST(exp)   static_cast<void>(exp)
 #ifdef _DEBUG
 # if defined(WIN32) && !defined(__GNUC__)
-#   define ASSERT(exp)          _ASSERT_VOID_CAST( (exp) ? 0 : AssertErr(__FILENAME__,__LINE__,#exp) )
-#   define ASSERTP(exp, desc)   _ASSERT_VOID_CAST( (exp) ? 0 : AssertErr(__FILENAME__,__LINE__,(desc)) )
+#   define ASSERT(exp)          _ASSERT_VOID_CAST( (exp) ? void() : AssertErr(__FILENAME__,__LINE__,#exp) )
+#   define ASSERTP(exp, desc)   _ASSERT_VOID_CAST( (exp) ? void() : AssertErr(__FILENAME__,__LINE__,(desc)) )
 # else
 #   define ASSERT(exp)          do { if (!(exp)) { AssertErr(__FILENAME__,__LINE__,#exp); MY_BREAKPOINT(); }} while (0)
 #   define ASSERTP(exp, desc)   do { if (!(exp)) { AssertErr(__FILENAME__,__LINE__,(desc)); MY_BREAKPOINT(); }} while (0)

--- a/drodrpg/DROD/DROD.2019.vcxproj
+++ b/drodrpg/DROD/DROD.2019.vcxproj
@@ -359,6 +359,7 @@
       </BrowseInformationFile>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;WIN32;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3492,7 +3492,7 @@ void CCharacter::Process(
 				UINT varId = command.x;
 				ScriptArrayMap& scriptArrays = pGame->scriptArrays;
 
-				ScriptArrayMap::iterator& array = scriptArrays.find(varId);
+				const ScriptArrayMap::iterator& array = scriptArrays.find(varId);
 				if (array != scriptArrays.end()) {
 					//Only clear a script array that is initialized
 					array->second.clear();

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -1664,7 +1664,7 @@ WSTRING CCurrentGame::GetArrayVarAsString(const UINT varID)
 void CCurrentGame::SetArrayVarFromString(const UINT varID, const WSTRING& wstr)
 {
 	if (wstr.empty()) {
-		ScriptArrayMap::iterator& array = scriptArrays.find(varID);
+		const ScriptArrayMap::iterator& array = scriptArrays.find(varID);
 		if (array != scriptArrays.end()) {
 			//Clear a script array that is initialized
 			array->second.clear();
@@ -6208,6 +6208,7 @@ void CCurrentGame::ProcessPlayer(
 	bool bMovingPlatform = false;
 	bool bDigging = false;
 	bool bJumping=false, bSwimming=false;
+	const bool bPrevTileIsElevated = bIsElevatedTile(wOTileNo);
 
 	//Look for obstacles and set dx/dy accordingly.
 	const UINT wMoveO = nGetO(dx, dy);
@@ -6285,7 +6286,6 @@ void CCurrentGame::ProcessPlayer(
 */
 
 	//Check for obstacles in destination square.
-	const bool bPrevTileIsElevated = bIsElevatedTile(wOTileNo);
 	if (room.DoesSquareContainPlayerObstacle(
 			wOldX + dx, wOldY + dy, wMoveO, bPrevTileIsElevated))
 	{

--- a/drodrpg/DRODLib/DRODLib.2019.vcxproj
+++ b/drodrpg/DRODLib/DRODLib.2019.vcxproj
@@ -270,6 +270,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
#952 for the RPG code. The fixes are:

- The fix for the assert macros
- Fixes for the strange template error, on line 1667 of `CurrentGame.cpp` and line 3495 of `Character.cpp`
- Various gotos in `CCurrentGame::ProcessPlayer` were skipping over the initialisation of `bPrevTileIsElevated` which I've fixed by moving the definition and initialisation above the first goto.