### PR TITLE
RPG: Fix reading map marker on unvisited detailed rooms

### DIFF
--- a/drodrpg/DROD/MapWidget.cpp
+++ b/drodrpg/DROD/MapWidget.cpp
@@ -1130,10 +1130,13 @@ bool CMapWidget::LoadMapSurface(
 			ExploredRoom *pExpRoom = NULL;
 			if (this->pCurrentGame)
 				pExpRoom = this->pCurrentGame->getExploredRoom(pRoom->dwRoomID);
+			
+			if (pExpRoom && pExpRoom->HasDetail())
+				mapMarker = pExpRoom->mapMarker;
+
 			if (pExpRoom && pExpRoom->HasDetail() && pExpRoom->SquaresBytes.Size())
 			{
 				VERIFY(pRoom->UnpackSquares(pExpRoom->SquaresBytes.Contents(), pExpRoom->SquaresBytes.Size()));
-				mapMarker = pExpRoom->mapMarker;
 
 				//Synch monster data to room's current state in this game.
 				pRoom->SetMonstersFromExploredRoomData(pExpRoom, false);


### PR DESCRIPTION
After picking up a full detail map item, you may have unvisited rooms marked as detailed. These would not read the map marker state correctly until visited (map marker is when you right click the room to change its colour).

https://forum.caravelgames.com/viewtopic.php?TopicID=46936