### PR TITLE
RPG: Fix expansion when assigning text using a character local predef…

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4025,7 +4025,7 @@ void CCharacter::SetVariable(const CCharacterCommand& command, CCurrentGame* pGa
 	case ScriptVars::AppendText:
 	{
 		WSTRING text = stats.GetVar(varName, wszEmpty);
-		text += pGame->ExpandText(command.label.c_str());
+		text += pGame->ExpandText(command.label.c_str(), this);
 		if (bPredefinedVar)
 			setPredefinedVarString(varIndex, text, CueEvents);
 		else

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3386,7 +3386,7 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_VarSet:
 			{
 				//Sets var X (operation Y) W, e.g. X += 5
-				SetVariable(command, pGame, CueEvents);
+				SetVariable(command, pGame, CueEvents, this);
 
 				//When a var is set, this might get it out of an otherwise infinite loop.
 				++wVarSets;
@@ -3936,7 +3936,11 @@ Finish:
 }
 
 //*****************************************************************************
-void CCharacter::SetVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents)
+void CCharacter::SetVariable(
+	const CCharacterCommand& command,
+	CCurrentGame* pGame,
+	CCueEvents& CueEvents,
+	CCharacter* pCharacter) //[default=NULL]
 {
 	const UINT varIndex = command.x;
 	if (pGame->pHold && pGame->pHold->IsArrayVar(varIndex))
@@ -4015,7 +4019,7 @@ void CCharacter::SetVariable(const CCharacterCommand& command, CCurrentGame* pGa
 
 	case ScriptVars::AssignText:
 	{
-		const WSTRING text = pGame->ExpandText(command.label.c_str());
+		const WSTRING text = pGame->ExpandText(command.label.c_str(), pCharacter);
 		if (bPredefinedVar)
 			setPredefinedVarString(varIndex, text, CueEvents);
 		else

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3386,7 +3386,7 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_VarSet:
 			{
 				//Sets var X (operation Y) W, e.g. X += 5
-				SetVariable(command, pGame, CueEvents, this);
+				SetVariable(command, pGame, CueEvents);
 
 				//When a var is set, this might get it out of an otherwise infinite loop.
 				++wVarSets;
@@ -3936,11 +3936,7 @@ Finish:
 }
 
 //*****************************************************************************
-void CCharacter::SetVariable(
-	const CCharacterCommand& command,
-	CCurrentGame* pGame,
-	CCueEvents& CueEvents,
-	CCharacter* pCharacter) //[default=NULL]
+void CCharacter::SetVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents)
 {
 	const UINT varIndex = command.x;
 	if (pGame->pHold && pGame->pHold->IsArrayVar(varIndex))
@@ -4019,7 +4015,7 @@ void CCharacter::SetVariable(
 
 	case ScriptVars::AssignText:
 	{
-		const WSTRING text = pGame->ExpandText(command.label.c_str(), pCharacter);
+		const WSTRING text = pGame->ExpandText(command.label.c_str(), this);
 		if (bPredefinedVar)
 			setPredefinedVarString(varIndex, text, CueEvents);
 		else

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -284,7 +284,7 @@ private:
 	void SetDefaultMovementType();
 	bool setPredefinedVarInt(UINT varIndex, const UINT val, CCueEvents& CueEvents);
 	void setPredefinedVarString(UINT varIndex, const WSTRING val, CCueEvents& CueEvents);
-	void SetVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents, CCharacter* pCharacter=NULL);
+	void SetVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 	void SetArrayVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 	void SetMapIcon(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -284,7 +284,7 @@ private:
 	void SetDefaultMovementType();
 	bool setPredefinedVarInt(UINT varIndex, const UINT val, CCueEvents& CueEvents);
 	void setPredefinedVarString(UINT varIndex, const WSTRING val, CCueEvents& CueEvents);
-	void SetVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
+	void SetVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents, CCharacter* pCharacter=NULL);
 	void SetArrayVariable(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 	void SetMapIcon(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
 


### PR DESCRIPTION
…ined var

If you tried to assign text and it included a reference to a character-local predefined var, such as _MyATK , then this would always return 0 as the value.

https://forum.caravelgames.com/viewtopic.php?TopicID=46963