### PR TITLE
RPG: Fix assert when highlighting bomb

### DIFF
--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -6777,7 +6777,7 @@ void CEditRoomScreen::Changing(
 			changes.push_back(new CDbHold(*(this->pHold)));
 			//NO BREAK
 		case Room:
-			changes.push_back(new CDbRoom(*(this->pRoom)));
+			changes.push_back(new CDbRoom(*(this->pRoom), true, true));
 		break;
 		case Hold:
 			changes.push_back(new CDbHold(*(this->pHold)));

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -842,7 +842,7 @@ CDbRoom::CDbRoom(const CDbRoom &Src)
 }
 
 //*****************************************************************************
-CDbRoom::CDbRoom(const CDbRoom& Src, const bool copyGame)
+CDbRoom::CDbRoom(const CDbRoom& Src, const bool copyGame, const bool copyForEditor)
 //Set pointers to NULL so Clear() won't try to delete them.
 	: CDbBase()
 	, pszOSquares(NULL), pszFSquares(NULL), pszTSquares(NULL), pszTParams(NULL)
@@ -851,7 +851,7 @@ CDbRoom::CDbRoom(const CDbRoom& Src, const bool copyGame)
 	, pCurrentGame(NULL)
 	//Constructor.
 {
-	SetMembers(Src, true, copyGame);
+	SetMembers(Src, true, copyGame, copyForEditor);
 }
 
 //
@@ -9458,7 +9458,8 @@ bool CDbRoom::SetMembers(
 //Params:
 	const CDbRoom &Src,        //(in)
 	const bool bCopyLocalInfo, //(in) default = true
-	const bool bCopyGame)      //(in) default = true
+	const bool bCopyGame,      //(in) default = true
+	const bool bCopyForEditor) //[default=false]
 {
 	try {
 	
@@ -9570,7 +9571,7 @@ bool CDbRoom::SetMembers(
 		//When not in play, always add monsters to the monster layer.
 		//When making a room copy during play, only place monsters in the monster
 		//layer when they are visible.
-		LinkMonster(pMonster, !this->pCurrentGame || pMonster->IsVisible());
+		LinkMonster(pMonster, bCopyForEditor || pMonster->IsVisible());
 		pMonster->wProcessSequence = wProcessSequence; //restore value
 
 		//Copy monster pieces.

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -86,7 +86,7 @@ protected:
 
 public:
 	CDbRoom(const CDbRoom &Src);
-	CDbRoom(const CDbRoom &Src, const bool copyGame);
+	CDbRoom(const CDbRoom &Src, const bool copyGame, const bool copyForEditor=false);
 	CDbRoom &operator= (const CDbRoom &Src) {
 		SetMembers(Src);
 		return *this;
@@ -489,7 +489,8 @@ private:
 	void           SaveExits(c4_View &ExitsView) const;
 	void           SetCurrentGameForMonsters(const CCurrentGame *pSetCurrentGame);
 	void           SetExtraVarsFromMembers();
-	bool           SetMembers(const CDbRoom &Src, const bool bCopyLocalInfo=true, const bool bCopyGame=true);
+	bool           SetMembers(
+		const CDbRoom &Src, const bool bCopyLocalInfo=true, const bool bCopyGame=true, const bool bCopyForEditor = false);
 	void           SetMembersFromExtraVars();
 
 	bool           UnpackTileLights(const BYTE *pSrc, const UINT dwSrcSize);


### PR DESCRIPTION
A little bit of a weird one. When a room is copied without a current game, invisible monsters are linked, which isn't usually done. Previously, this could only happen in the editor. However, bomb highlighting also creates a gameless room copy. The special linking should only happen for room copying in the editor. This fix requires some changes to `DbRoom` methods so they match how they work in TSS.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46969