### PR TITLE
RPG: Fix UI for Go to level entrance command

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -6537,11 +6537,11 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 			CEditRoomScreen *pEditRoomScreen = DYN_CAST(CEditRoomScreen*, CScreen*,
 					g_pTheSM->GetScreen(SCR_EditRoom));
 			ASSERT(pEditRoomScreen->pHold);
-			UINT dwVal = this->pCommand->x;
-			if (pEditRoomScreen->SelectListID(pEditRoomScreen->pEntranceBox, pEditRoomScreen->pHold,
-					dwVal, MID_ExitLevelPrompt) == CEntranceSelectDialogWidget::OK)
+			ExitChoice exitChoice = { ExitType::ET_Entrance, this->pCommand->x };
+			if (pEditRoomScreen->SelectEntrance(pEditRoomScreen->pEntranceBox, pEditRoomScreen->pHold,
+				exitChoice, MID_SelectExitDestination, CEntranceSelectDialogWidget::Entrances) == CEntranceSelectDialogWidget::OK)
 			{
-				this->pCommand->x = dwVal;
+				this->pCommand->x = exitChoice.entrance;
 				this->pCommand->y = this->pOnOffListBox->GetSelectedItem();
 				AddCommand();
 			} else {


### PR DESCRIPTION
The command is still using an older way to get the level entrance ID, which doesn't work. Updated it to use the current way.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46980