### PR TITLE
RPG: Fix copying of invisible characters in editor

### DIFF
--- a/drodrpg/DROD/EditRoomScreen.cpp
+++ b/drodrpg/DROD/EditRoomScreen.cpp
@@ -3138,7 +3138,7 @@ void CEditRoomScreen::OnKeyDown(
 					CImportInfo info;
 					const UINT roomDataID = this->pRoom->dwDataID;
 					this->pRoom->dwDataID = 0; //don't copy room media data
-					this->pCopyRoom = this->pRoom->MakeCopy(info, 0); //same hold
+					this->pCopyRoom = this->pRoom->MakeCopy(info, 0, true); //same hold
 					this->pRoom->dwDataID = roomDataID;
 				}
 

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -9436,12 +9436,13 @@ bool CDbRoom::UpdateNew()
 }
 
 //*****************************************************************************
-CDbRoom* CDbRoom::MakeCopy(CImportInfo& info, const UINT newHoldID) const
+CDbRoom* CDbRoom::MakeCopy(
+	CImportInfo& info, const UINT newHoldID, const bool bCopyForEditor) const
 //Replicates room data for new record entry in DB.
 {
 	CDbRoom *pCopy = g_pTheDB->Rooms.GetNew();
 	if (!pCopy) return NULL;
-	pCopy->SetMembers(*this, false);
+	pCopy->SetMembers(*this, false, true, bCopyForEditor);
 
 	//Copy custom room media, if needed.
 	if (newHoldID) {

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -92,7 +92,7 @@ public:
 		return *this;
 	}
 	void MakeCopy(const CDbRoom &Src) {SetMembers(Src, false);}
-	CDbRoom* MakeCopy(CImportInfo& info, const UINT newHoldID) const;
+	CDbRoom* MakeCopy(CImportInfo& info, const UINT newHoldID, const bool bCopyForEditor = false) const;
 
 	virtual ~CDbRoom();
 


### PR DESCRIPTION
In #968 I missed a that the copy for editor flag needed to be wired into `CDbRoom::MakeCopy`. This PR fixes this.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46983