### PR TITLE
RPG: Fix face widget getting stuck in dying state

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -5479,6 +5479,9 @@ bool CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 	if (bPlayerFellInPit)
 		this->pRoomWidget->ShowPlayer();
 
+	this->pFaceWidget->SetMood(PlayerRole, Mood_Normal);
+	this->pFaceWidget->SetDying(false);
+
 	if (bUndoDeath)
 	{
 		this->pRoomWidget->DirtyRoom();	//remove fading
@@ -5488,8 +5491,6 @@ bool CGameScreen::HandleEventsForPlayerDeath(CCueEvents &CueEvents)
 
 	StopAmbientSounds();
 	ClearSpeech();
-	this->pFaceWidget->SetMood(PlayerRole, Mood_Normal);
-	this->pFaceWidget->SetDying(false);
 	return true;
 }
 


### PR DESCRIPTION
It was possible to skip the dying state being deactivated by undoing during the death sequence.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46981