### PR TITLE
RPG: Fix character option preview for non-oriented characters

### DIFF
--- a/drodrpg/DROD/CharacterOptionsWidget.cpp
+++ b/drodrpg/DROD/CharacterOptionsWidget.cpp
@@ -154,7 +154,7 @@ void CCharacterOptionsDialog::SetCharacter(
 		CalculatePreviewTile(pHoldCharacter);
 	} else {
 		const UINT wIdentity = pCharacter->wLogicalIdentity;
-		this->previewTileNumber = GetTileImageForEntity(wIdentity == M_NONE ?
+		this->previewTileNumber = GetTileImageForEntityOrDefault(wIdentity == M_NONE ?
 			static_cast<UINT>(CHARACTER_FIRST) : wIdentity, S, 0);
 	}
 	UpdatePreview();
@@ -197,7 +197,7 @@ void CCharacterOptionsDialog::CalculatePreviewTile(const HoldCharacter* pCharact
 	if (this->previewTileNumber == TI_UNSPECIFIED) {
 		this->previewTileNumber = g_pTheBM->GetCustomTileNo(pCharacter->dwDataID_Tiles, 0, 0);
 		if (this->previewTileNumber == TI_UNSPECIFIED) {
-			this->previewTileNumber = GetTileImageForEntity(pCharacter->wType == M_NONE ?
+			this->previewTileNumber = GetTileImageForEntityOrDefault(pCharacter->wType == M_NONE ?
 				static_cast<UINT>(CHARACTER_FIRST) : pCharacter->wType, S, 0);
 		}
 	}


### PR DESCRIPTION
Monsters that don't face a direction didn't get previewed, as they don't have south-facing images. This problem can be fixed by using `GetTileImageForEntityOrDefault` rather than `GetTileImageForEntity`, as the former function will look to see if the entity type has a valid tile image value for `NO_ORIENTATION` if the given direction (south in this case) doesn't.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47001