### PR TITLE
RPG: Add missing implementation for Wait for open tile

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -2655,6 +2655,15 @@ void CCharacter::Process(
 				bProcessNextCommand = true;
 			}
 
+			case CCharacterCommand::CC_WaitForOpenTile:
+			{
+				//Wait for target tile to not contain an obstacle (not accounting for movement direction)
+				if (!IsOpenTileAt(command, pGame))
+					STOP_COMMAND;
+
+				bProcessNextCommand = true;
+			}
+
 			case CCharacterCommand::CC_Label:
 				//A comment or destination marker for a GoTo command.
 				bProcessNextCommand = true;

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -401,6 +401,10 @@ the state of the room and wait indefinitely until certain events occur.</p>
 	  wielding NPC would not harm itself by striking a bomb.  Hint: Use this
 	  query to test whether a move may be made before executing a
 	  <a href="#move">Move</a> command in that direction.</li>
+  <li><a name="wait-for-open-tile"><b>Wait for open tile</b></a> - Wait until the
+    tile at the specified location is open, according to the specified movement type.
+    Additionally, this command can be configured to ignore tile-blocking weapons and entities.
+    Hold &lt;Ctrl&gt; while clicking to select and unselect multiple selections for ignorable entities.</li>
   <li><a name="waitforitem"><b>Wait for item</b></a> - Wait until the
       specified element is located in the marked room region.</li>
   <li><a name="waitforitemgroup"><b>Wait for item group</b>


### PR DESCRIPTION
Using `Wait for open tile` outside of a multi-wait block causes an assert, because there's no implementation for the command in `CCharacter::Process`.

I've added the appropriate logic, along with help content for the command that was also missing.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47016