### PR TITLE
RPG: Add more information to in-room equipment tooltip

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1388,23 +1388,31 @@ void CRoomWidget::DisplayRoomCoordSubtitle(const UINT wX, const UINT wY)
 					WSTRING equipText;
 					bool needComma = false;
 
-					if (diffATK != 0 || tTile == T_SWORD) {
+					if (newATK != 0 || diffATK != 0 || tTile == T_SWORD) {
+						equipText += to_WSTRING(newATK);
+						equipText += wszSpace;
+						equipText += g_pTheDB->GetMessageText(MID_ATKStat);
+						equipText += wszSpace;
+						equipText += wszLeftParen;
 						if (diffATK >= 0)
 							equipText += wszPlus;
 						equipText += _itoW(diffATK, temp, 10);
-						equipText += wszSpace;
-						equipText += g_pTheDB->GetMessageText(MID_ATKStat);
+						equipText += wszRightParen;
 						needComma = true;
 					}
-					if (diffDEF != 0 || tTile == T_SHIELD) {
+					if (newDEF != 0 || diffDEF != 0 || tTile == T_SHIELD) {
 						if (needComma) {
 							equipText += wszCommaSpace;
 						}
+						equipText += to_WSTRING(newDEF);
+						equipText += wszSpace;
+						equipText += g_pTheDB->GetMessageText(MID_DEFStat);
+						equipText += wszSpace;
+						equipText += wszLeftParen;
 						if (diffDEF >= 0)
 							equipText += wszPlus;
 						equipText += _itoW(diffDEF, temp, 10);
-						equipText += wszSpace;
-						equipText += g_pTheDB->GetMessageText(MID_DEFStat);
+						equipText += wszRightParen;
 						needComma = true;
 					}
 					if (!ability.empty()) {


### PR DESCRIPTION
Adds the base ATK and DEF of an in-room equipment to it's tooltip description, with the change it has to the overal stats in parentheses.

<img width="444" height="121" alt="stat-tooltip" src="https://github.com/user-attachments/assets/2d0a273b-826b-451a-bb25-0e69cc771f91" />
