### PR TITLE
RPG: Fix string for Wait for All command

### DIFF
--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -836,6 +836,7 @@ const WCHAR* CDbBase::GetMessageText(
 	string strText;
 	switch (eMessageID)
 	{
+		case MID_LogicalWaitAnd: strText = "Wait for All:"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1402,7 +1402,7 @@ Wait until expression
 
 [MID_LogicalWaitAnd]
 [eng]
-"Wait for All:
+Wait for All:
 
 [MID_LogicalWaitOr]
 [eng]


### PR DESCRIPTION
Somehow an errant character ended up in this string, and nobody noticed until now. Adding in a hardcoded override until a release with an updated `dat` is made.