### PR TITLE
RPG: Fix missing NPCDefeated message

### DIFF
--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -836,6 +836,7 @@ const WCHAR* CDbBase::GetMessageText(
 	string strText;
 	switch (eMessageID)
 	{
+		case MID_NPCDefeated: strText = "NPC defeated"; break;
 		case MID_LogicalWaitAnd: strText = "Wait for All:"; break;
 		default: break;
 	}

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -935,8 +935,8 @@ Answer option
 [eng]
 NPC killed
 
-[eng]
 [MID_NPCDefeated]
+[eng]
 NPC defeated
 
 [MID_RemoveItem]


### PR DESCRIPTION
Another problematic string. Malformed `uni` entry means the string doesn't get written to the `dat` file even though it gets a message id.