### PR TITLE
RPG: Improve logical wait interaction with Wait for event 

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -1843,6 +1843,26 @@ bool CCharacter::HasUnansweredQuestion(CCueEvents &CueEvents) const
 }
 
 //*****************************************************************************
+bool CCharacter::IsCommandTypeIn(
+//Returns: If a command of the given type is in the given range (inclusive)
+	const int startIndex,
+	const int endIndex,
+	const CCharacterCommand::CharCommand command
+) const
+{
+	ASSERT(startIndex < commands.size());
+	ASSERT(endIndex < commands.size());
+
+	for (int i = startIndex; i <= endIndex; ++i) {
+		if (this->commands[i].command == command) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//*****************************************************************************
 void CCharacter::Process(
 //Process a character for movement.
 //
@@ -3700,15 +3720,22 @@ void CCharacter::Process(
 
 			case CCharacterCommand::CC_LogicalWaitAnd:
 			{
-				//Wait until all conditions are true.
-				if (!EvaluateLogicalAnd(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents))
-					STOP_COMMAND;
-
 				int wNextIndex = GetIndexOfNextLogicEnd(this->wCurrentCommandIndex + 1);
-
 				//Malformed statement - just stop.
 				if (wNextIndex == NO_LABEL)
 					STOP_COMMAND;
+
+				//Wait until all conditions are true.
+				if (!EvaluateLogicalAnd(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents)) {
+					if (!this->wJumpLabel &&
+						IsCommandTypeIn(this->wCurrentCommandIndex + 1, wNextIndex - 1, CCharacterCommand::CC_WaitForCueEvent)) {
+						//If NPC is waiting, try to catch event at end of game turn in CheckForCueEvent().
+						//!!NOTE: This won't work for conditional "If <late cue event>".
+						bWaitingForCueEvent = true;
+					}
+
+					STOP_COMMAND;
+				}
 
 				//Jump to position after logic end.
 				this->wJumpLabel = wNextIndex + 1;
@@ -3718,15 +3745,22 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_LogicalWaitOr:
 			{
-				//Wait until at least one condition is true.
-				if (!EvaluateLogicalOr(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents))
-					STOP_COMMAND;
-
 				int wNextIndex = GetIndexOfNextLogicEnd(this->wCurrentCommandIndex + 1);
-
 				//Malformed statement - just stop.
 				if (wNextIndex == NO_LABEL)
 					STOP_COMMAND;
+
+				//Wait until at least one condition is true.
+				if (!EvaluateLogicalOr(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents)) {
+					if (!this->wJumpLabel &&
+						IsCommandTypeIn(this->wCurrentCommandIndex + 1, wNextIndex - 1, CCharacterCommand::CC_WaitForCueEvent)) {
+						//If NPC is waiting, try to catch event at end of game turn in CheckForCueEvent().
+						//!!NOTE: This won't work for conditional "If <late cue event>".
+						bWaitingForCueEvent = true;
+					}
+
+					STOP_COMMAND;
+				}
 
 				//Jump to position after logic end.
 				this->wJumpLabel = wNextIndex + 1;
@@ -3736,15 +3770,22 @@ void CCharacter::Process(
 			break;
 			case CCharacterCommand::CC_LogicalWaitXOR:
 			{
-				//Wait until exactly one condition is true.
-				if (!EvaluateLogicalXOR(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents))
-					STOP_COMMAND;
-
 				int wNextIndex = GetIndexOfNextLogicEnd(this->wCurrentCommandIndex + 1);
-
 				//Malformed statement - just stop.
 				if (wNextIndex == NO_LABEL)
 					STOP_COMMAND;
+
+				//Wait until exactly one condition is true.
+				if (!EvaluateLogicalXOR(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents)) {
+					if (!this->wJumpLabel &&
+						IsCommandTypeIn(this->wCurrentCommandIndex + 1, wNextIndex - 1, CCharacterCommand::CC_WaitForCueEvent)) {
+						//If NPC is waiting, try to catch event at end of game turn in CheckForCueEvent().
+						//!!NOTE: This won't work for conditional "If <late cue event>".
+						bWaitingForCueEvent = true;
+					}
+
+					STOP_COMMAND;
+				}
 
 				//Jump to position after logic end.
 				this->wJumpLabel = wNextIndex + 1;
@@ -5262,14 +5303,41 @@ void CCharacter::CheckForCueEvent(CCueEvents &CueEvents) //(in)
 		return;
 	ASSERT(this->wCurrentCommandIndex < this->commands.size());
 	CCharacterCommand& command = this->commands[this->wCurrentCommandIndex];
-	ASSERT(command.command == CCharacterCommand::CC_WaitForCueEvent);
+	ASSERT(command.command == CCharacterCommand::CC_WaitForCueEvent ||
+		command.IsLogicalWaitCommand());
 
-	//Wait for cue event X to fire.
-	const CUEEVENT_ID cid = static_cast<CUEEVENT_ID>(command.x);
-	if (CueEvents.HasOccurred(cid))
-	{
-		++this->wCurrentCommandIndex;
-		this->bWaitingForCueEvent = false; //no longer waiting for the event
+	if (command.IsLogicalWaitCommand()) {
+		//Reprocess logical block
+		CCurrentGame* pGame = const_cast<CCurrentGame*>(this->pCurrentGame);
+		UINT nLastCommand = pGame->lastProcessedCommand;
+		bool passed;
+		switch (command.command) {
+			case CCharacterCommand::CC_LogicalWaitAnd:
+				passed = EvaluateLogicalAnd(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents);
+			break;
+			case CCharacterCommand::CC_LogicalWaitOr:
+				passed = EvaluateLogicalOr(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents);
+			break;
+			case CCharacterCommand::CC_LogicalWaitXOR:
+				passed = EvaluateLogicalXOR(this->wCurrentCommandIndex, pGame, nLastCommand, CueEvents);
+			break;
+			default: passed = false; break;
+		}
+
+		if (passed) {
+			int wNextIndex = GetIndexOfNextLogicEnd(this->wCurrentCommandIndex + 1);
+			ASSERT(wNextIndex != NO_LABEL);
+			this->wCurrentCommandIndex = wNextIndex + 1;
+			this->bWaitingForCueEvent = false; //no longer waiting for the event
+		}
+	} else {
+		//Wait for cue event X to fire.
+		const CUEEVENT_ID cid = static_cast<CUEEVENT_ID>(command.x);
+		if (CueEvents.HasOccurred(cid))
+		{
+			++this->wCurrentCommandIndex;
+			this->bWaitingForCueEvent = false; //no longer waiting for the event
+		}
 	}
 }
 

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -273,6 +273,7 @@ private:
 	int  GetIndexOfNextElse(const bool bIgnoreElseIf) const;
 	int  GetIndexOfNextLogicEnd(const UINT wStartIndex) const;
 	bool HasUnansweredQuestion(CCueEvents &CueEvents) const;
+	bool IsCommandTypeIn(const int startIndex, const int endIndex, const CCharacterCommand::CharCommand command) const;
 	bool IsExpressionSatisfied(const CCharacterCommand& command, CCurrentGame* pGame);
 	void MoveCharacter(const int dx, const int dy, const bool bFaceDirection,
 			CCueEvents& CueEvents);

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -2971,6 +2971,7 @@ void CCurrentGame::ProcessCommand(
 
 //	const UINT dwStart = GetTicks();
 	
+	this->lastProcessedCommand = nCommand;
 	this->pPlayer->bHasTeleported = false;
 
 	const bool bPlayerIsAnsweringQuestion = this->UnansweredQuestions.size() != 0;
@@ -7434,6 +7435,7 @@ void CCurrentGame::SetMembers(const CCurrentGame &Src)
 	this->wPlayerTurn = Src.wPlayerTurn;
 	this->wSpawnCycleCount = Src.wSpawnCycleCount;
 	this->bHalfTurn = Src.bHalfTurn;
+	this->lastProcessedCommand = Src.lastProcessedCommand;
 /*
 	this->bIsDemoRecording = Src.bIsDemoRecording;
 	this->wMonsterKills = Src.wMonsterKills;

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -412,6 +412,7 @@ public:
 	UINT     wPlayerTurn;      //player move #
 	UINT     wSpawnCycleCount; //monster move #
 	bool     bHalfTurn;        //half a turn taken 
+	UINT     lastProcessedCommand; //most recently processed comand, for read-only script access
 //	UINT     wMonsterKills; //total monsters killed in current room
 //	bool     bBrainSensesSwordsman;
 //	UINT     wLastCheckpointX, wLastCheckpointY;

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -360,7 +360,13 @@ the state of the room and wait indefinitely until certain events occur.</p>
       the number of game turns you specify has passed.  <b>Wait 0</b> will stop
       the script at the current point until the next turn.</li>
   <li><a name="waitevent"><b>Wait for event</b></a> - The NPC waits until the
-      specified game event has taken place.</li>
+      specified game event has taken place. If the event has not taken place, and
+      the command is not being used as a condition for an If command, another check
+      will be performed at the end of the turn, and the script will continue on the
+      next turn if the specified event has taken place. This also occurs if it is in a
+      <a href="#logical-wait">multi-expression wait</a>. In this case, be
+      aware that other conditions may have changed between the intial check and
+      end-of-turn check.</li>
   <li><a name="waitentity"><b>Wait for entity</b></a> - The NPC waits for any of
       the selected entity type (or entities) to enter the room region you
       specify.  Hold &lt;Ctrl&gt; while clicking to select and unselect multiple


### PR DESCRIPTION
Makes the three logical wait commands able to perform the delaed event check if they fail while containing one or more `Wait for event` commands. The help for `Wait for event` has also been made more detailed.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47038