### PR TITLE
RPG: Add build restrictions for mist

### DIFF
--- a/drodrpg/DRODLib/BuildUtil.cpp
+++ b/drodrpg/DRODLib/BuildUtil.cpp
@@ -194,6 +194,11 @@ bool BuildUtil::CanBuildAt(CDbRoom& room, const UINT tile, const UINT x, const U
 		if (tile == T_ORB && room.GetOSquare(x, y) == T_PRESSPLATE)
 			bValid = false;
 
+		//Can't build mist on solid tiles or hot tiles
+		if (tile == T_MIST &&
+			(bIsSolidOTile(room.GetOSquare(x, y)) || room.GetOSquare(x, y) == T_HOT))
+			bValid = false;
+
 		//Most items can be replaced.
 		if (wTTile == T_EMPTY || wTTile == T_BOMB || wTTile == T_FUSE ||
 			bIsPowerUp(wTTile) || bIsBriar(wTTile) || wTTile == T_MIRROR ||


### PR DESCRIPTION
It shouldn't be possible to build mist on walls, closed doors, dirt blocks or hot tiles, since it can't be placed on those kinds of tiles or expand onto them during gameplay.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47057