### PR TITLE
RPG: Fix initial direction of spawned roach egg

### DIFF
--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -1081,7 +1081,9 @@ void CMonster::SpawnEgg(CCueEvents& CueEvents)
 			CueEvents, spawnID, egg->wX, egg->wY, S, true);
 		m->bEggSpawn = true;
 		UINT wType = m->GetIdentity();
-		if (wType != M_REGG && !bMonsterHasDirection(wType)) {
+		if (wType == M_REGG) {
+			m->wO = SW;
+		} else if (!bMonsterHasDirection(wType)) {
 			m->wO = NO_ORIENTATION;
 		}
 		CueEvents.Add(CID_EggSpawned);


### PR DESCRIPTION
Something in the process for making new monsters is now making roach eggs face the wrong way when spawned. Fixing by setting the correct direction in the egg spawning function.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47053