### PR TITLE
RPG: Add support for custom weapon animation

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -323,7 +323,7 @@ UINT CGameScreen::CalcTileImageForEquipment(const UINT type) const
 	if (pCharacter)
 	{
 		UINT tile = this->pRoomWidget->GetCustomEntityTile(
-				pCharacter->wLogicalIdentity, NO_ORIENTATION, 0);
+				pCharacter->wLogicalIdentity, NO_ORIENTATION, 0, false);
 		if (tile == TI_UNSPECIFIED)
 		{
 			//Show a predefined sword if no custom images for custom equipment exist.
@@ -6290,7 +6290,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 					const UINT tParam = this->pRoomWidget->pRoom->GetTParam(pCoord->wX, pCoord->wY);
 					if (bIsCustomEquipment(tParam))
 					{
-						wTileNo = this->pRoomWidget->GetCustomEntityTile(tParam, NO_ORIENTATION, 0);
+						wTileNo = this->pRoomWidget->GetCustomEntityTile(tParam, NO_ORIENTATION, 0, false);
 						if (wTileNo == TI_UNSPECIFIED)
 							wTileNo = TI_GENERIC_EQUIPMENT;
 					}

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2465,8 +2465,10 @@ const
 		HoldCharacter *pCustomChar = this->pCurrentGame->pHold->GetCharacter(sword);
 		if (pCustomChar)
 		{
+			bool animated = pCustomChar->animationSpeed != 0;
+			UINT yFrame = animated ? SDL_GetTicks() / pCustomChar->animationSpeed : 0U;
 			const UINT tile = g_pTheBM->GetCustomTileNo(pCustomChar->dwDataID_Tiles,
-					GetCustomTileIndex(wO), 0);
+					GetCustomTileIndex(wO), yFrame, animated);
 			if (tile != TI_UNSPECIFIED)
 				return tile;
 		}

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -1691,7 +1691,8 @@ UINT CRoomWidget::GetCustomEntityTile(
 //
 //Params:
 	const UINT wLogicalIdentity,      //role's logical ID
-	const UINT wO, const UINT wFrame) //orientation and frame number
+	const UINT wO, const UINT wFrame, //orientation and frame number
+	bool bAllowAnimation) //can animation frames be used if the character has animation speed [default=true]
 const
 {
 	//Check for a custom character tileset.
@@ -1717,7 +1718,7 @@ const
 		{
 			//This indicates to display the tiles in the corresponding custom tileset in sequence,
 			//ignoring the frame# passed in above.
-			const UINT animationFrame = SDL_GetTicks() / pCustomChar->animationSpeed;
+			const UINT animationFrame = bAllowAnimation ? SDL_GetTicks() / pCustomChar->animationSpeed : 0U;
 			wCustomTileImageNo = g_pTheBM->GetCustomTileNo(pCustomChar->dwDataID_Tiles, wIndex, animationFrame, true);
 			if (wCustomTileImageNo == TI_UNSPECIFIED && wIndex > 0) //get first orientation frame if this one is unavailable
 				wCustomTileImageNo = g_pTheBM->GetCustomTileNo(pCustomChar->dwDataID_Tiles, 0, animationFrame, true);
@@ -9605,7 +9606,7 @@ bool CRoomWidget::UpdateDrawSquareInfo(
 						if (bIsCustomEquipment(tParam))
 						{
 							//Display custom equipment's image.
-							wTileImage = GetCustomEntityTile(tParam, NO_ORIENTATION, 0);
+							wTileImage = GetCustomEntityTile(tParam, NO_ORIENTATION, 0, false);
 							if (wTileImage == TI_UNSPECIFIED)
 								wTileImage = TI_GENERIC_EQUIPMENT;
 							break;

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -267,7 +267,7 @@ public:
 	UINT           GetTextureIndexForTile(const UINT tileNo, const bool bForceBaseImage) const;
 	static UINT    GetTokenMID(const UINT param);
 	UINT           GetCustomEntityTile(const UINT wLogicalIdentity,
-			const UINT wO, const UINT wFrame) const;
+			const UINT wO, const UINT wFrame, bool bAllowAnimation=true) const;
 	static UINT    GetCustomTileIndex(const UINT wO);
 	UINT           GetEntityTile(const UINT wApparentIdentity,
 			const UINT wLogicalIdentity, const UINT wO, const UINT wFrame) const;


### PR DESCRIPTION
Two changes:

- Allows custom weapons to be drawn using animation frames if available and the character has an animation speed.
- Fixes custom equipment with multiple rows and a set animation speed using frames other than the first row in the inventory and when in an equipment slot. Due to the way drawing works, it's not feasible to have them animate.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47062