### PR TITLE
RPG: Correctly update damage previews after serpent fight

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -6375,6 +6375,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		if (this->pCurrentGame->pRoom->IsMonsterOfTypeAt(M_ROCKGOLEM, pCoord->wX, pCoord->wY))
 			wMonsterType = M_ROCKGIANT;
 		AddKillEffect(wMonsterType, *pCoord);
+		this->pRoomWidget->RedrawDamagePreview(); //killing a piece is a fight
 	}
 	if (CueEvents.HasOccurred(CID_OrbActivated))
 	{
@@ -6604,6 +6605,7 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 		const CMonster *pMonster = DYN_CAST(const CMonster*, const CAttachableObject*, pObj);
 		const CMoveCoord coord(pMonster->wX,pMonster->wY,pMonster->wO);
 		AddKillEffect(pMonster->GetIdentity(), coord);
+		this->pRoomWidget->RedrawDamagePreview(); //update view for remaining enemies
 	}
 	if (CueEvents.HasOccurred(CID_EvilEyeWoke))
 		g_pTheSound->PlaySoundEffect(SEID_EVILEYEWOKE, this->fPos);


### PR DESCRIPTION
Serpents use their own types of cue event when defeated in combat, so the flag to redraw previews isn't set after fighting one. The flag should also be set if either `CID_SnakeDiedFromTruncation` or `CID_MonsterPieceStabbed` have occured.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47060