### PR TITLE
RPG: Freeze room widget effects in CGameScreen::SetForActivate

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -3363,6 +3363,9 @@ bool CGameScreen::SetForActivate()
 	//Eat existing events since early key presses could cause unexpected player movement.
 	ClearEvents();
 
+	//Prevent any effects from animating during a transition
+	this->pRoomWidget->SetEffectsFrozen(true);
+
 	//Set button widget states.
 	CWidget *pButton = GetWidget(TAG_SAVE);
 	pButton->Enable(!this->bPlayTesting);


### PR DESCRIPTION
Effects that start on turn zero currently animate even when level entrance text is displayed. This is prevented in TSS by freezing effects in `CGameScreen::SetForActivate`. This PR ports that fix to RPG.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=46998