### PR TITLE
RPG: Disable Replace with Default Script command

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4397,7 +4397,6 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		case CCharacterCommand::CC_SetPlayerSword:
 		case CCharacterCommand::CC_Speech:
 		case CCharacterCommand::CC_TurnIntoMonster:
-		case CCharacterCommand::CC_ReplaceWithDefault:
 		case CCharacterCommand::CC_ClearArrayVar:
 		case CCharacterCommand::CC_ResetOverrides:
 		case CCharacterCommand::CC_SetMapIcon:
@@ -4523,6 +4522,7 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		case CCharacterCommand::CC_WaitForNotMonster:
 		case CCharacterCommand::CC_WaitForCharacter:
 		case CCharacterCommand::CC_WaitForNotCharacter:
+		case CCharacterCommand::CC_ReplaceWithDefault:
 			wstr += wszAsterisk;
 			break;
 		default:
@@ -4637,7 +4637,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ClearArrayVar, g_pTheDB->GetMessageText(MID_ClearArrayVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Speech, g_pTheDB->GetMessageText(MID_Speech));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_TurnIntoMonster, g_pTheDB->GetMessageText(MID_TurnIntoMonster));
-	this->pActionListBox->AddItem(CCharacterCommand::CC_ReplaceWithDefault, g_pTheDB->GetMessageText(MID_ReplaceWithDefault));
+	//this->pActionListBox->AddItem(CCharacterCommand::CC_ReplaceWithDefault, g_pTheDB->GetMessageText(MID_ReplaceWithDefault));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ResetOverrides, g_pTheDB->GetMessageText(MID_ResetOverrides));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Wait, g_pTheDB->GetMessageText(MID_WaitTurns));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForArrayEntry, g_pTheDB->GetMessageText(MID_WaitForArrayEntry));

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3332,18 +3332,19 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_ReplaceWithDefault:
 				//Replace the script with the character's default script if possible.
 				//Nothing will happen for non-custom characters.
-				if (this->pCustomChar) {
-					this->commands.clear();
-					this->wCurrentCommandIndex = 0;
-					wTurnCount = 0;
-					++wVarSets; //Count as setting a variable for loop avoidence
-					const HoldCharacter* initalCharacter = pGame->pHold->GetCharacter(this->wInitialIdentity);
-					LoadCommands(initalCharacter->ExtraVars, commands);
-					bReplacedWithDefault = true;
-				}	else {
-					// Index does not automatically increment after this command is executed
-					++this->wCurrentCommandIndex;
-				}
+				//Currently disabled, as it causes crashes if speech commands are replaced.
+				//if (this->pCustomChar) {
+				//	this->commands.clear();
+				//	this->wCurrentCommandIndex = 0;
+				//	wTurnCount = 0;
+				//	++wVarSets; //Count as setting a variable for loop avoidence
+				//	const HoldCharacter* initalCharacter = pGame->pHold->GetCharacter(this->wInitialIdentity);
+				//	LoadCommands(initalCharacter->ExtraVars, commands);
+				//	bReplacedWithDefault = true;
+				//}	else {
+				//	// Index does not automatically increment after this command is executed
+				//	++this->wCurrentCommandIndex;
+				//}
 				bProcessNextCommand = true;
 			break;
 
@@ -3908,7 +3909,7 @@ void CCharacter::Process(
 			default: ASSERT(!"Bad CCharacter command"); break;
 		}
 
-		if (this->wCurrentCommandIndex < this->commands.size() && command.command != CCharacterCommand::CC_ReplaceWithDefault)
+		if (this->wCurrentCommandIndex < this->commands.size())
 			++this->wCurrentCommandIndex;
 
 		//If MoveRel command was used as an If condition, then reset the relative
@@ -6383,7 +6384,7 @@ void CCharacter::SetCurrentGame(
 
 	//If this NPC is a custom character with no script,
 	//then use the default script for this custom character type.
-	if (this->pCustomChar && (this->commands.empty() || bReplacedWithDefault))
+	if (this->pCustomChar && this->commands.empty())
 	{
 		if (this->wInitialIdentity == M_NONE) {
 			LoadCommands(this->pCustomChar->ExtraVars, this->commands);

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -110,7 +110,6 @@ functions.</p>
 	  turn.  Also used to define certain attributes of the NPC's abilities
 	  (see <a href="#behaviorlist">Behaviors</a>).  Compatible behaviors
 	  may be combined.</li>
-  <li><a name="replacewithdefault"><b>Replace with Default Script</b></a> - If the NPC is a custom NPC type, replaces the script content with that NPC type's default script. That script will then begin executing. Has no effect when used in an NPC with a pre-defined type.</li>
 </ol>
 
 <p><a name="interaction"><b>3.&nbsp;&nbsp;Interaction</b></a> - How the NPC


### PR DESCRIPTION
#1002 for RPG. The reasoning is the same - stopping the crash requires rewriting the speech system, which is not something we want to be doing in a minor release.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47098