### PR TITLE
RPG: Reimplement "Replace with Default Script"

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4397,6 +4397,7 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		case CCharacterCommand::CC_SetPlayerSword:
 		case CCharacterCommand::CC_Speech:
 		case CCharacterCommand::CC_TurnIntoMonster:
+		case CCharacterCommand::CC_ReplaceWithDefault:
 		case CCharacterCommand::CC_ClearArrayVar:
 		case CCharacterCommand::CC_ResetOverrides:
 		case CCharacterCommand::CC_SetMapIcon:
@@ -4522,7 +4523,6 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		case CCharacterCommand::CC_WaitForNotMonster:
 		case CCharacterCommand::CC_WaitForCharacter:
 		case CCharacterCommand::CC_WaitForNotCharacter:
-		case CCharacterCommand::CC_ReplaceWithDefault:
 			wstr += wszAsterisk;
 			break;
 		default:
@@ -4637,7 +4637,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ClearArrayVar, g_pTheDB->GetMessageText(MID_ClearArrayVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Speech, g_pTheDB->GetMessageText(MID_Speech));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_TurnIntoMonster, g_pTheDB->GetMessageText(MID_TurnIntoMonster));
-	//this->pActionListBox->AddItem(CCharacterCommand::CC_ReplaceWithDefault, g_pTheDB->GetMessageText(MID_ReplaceWithDefault));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ReplaceWithDefault, g_pTheDB->GetMessageText(MID_ReplaceWithDefault));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ResetOverrides, g_pTheDB->GetMessageText(MID_ResetOverrides));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Wait, g_pTheDB->GetMessageText(MID_WaitTurns));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_WaitForArrayEntry, g_pTheDB->GetMessageText(MID_WaitForArrayEntry));

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -277,6 +277,7 @@ private:
 	bool IsExpressionSatisfied(const CCharacterCommand& command, CCurrentGame* pGame);
 	void MoveCharacter(const int dx, const int dy, const bool bFaceDirection,
 			CCueEvents& CueEvents);
+	void ReplaceWithDefault(const UINT nLastCommand, CCueEvents& CueEvents);
 	void TeleportCharacter(const UINT wDestX, const UINT wDestY, CCueEvents& CueEvents);
 	void TurnIntoMonster(CCueEvents& CueEvents, const bool bSpecial=false);
 
@@ -360,8 +361,6 @@ private:
 	int  eachAttackLabelIndex, eachDefendLabelIndex, eachUseLabelIndex;
 	int  eachVictoryLabelIndex; //if set, jump script execution here on each combat victory
 
-	bool bReplacedWithDefault; //If a local script has been replaced by the NPC's default script
-
 	WSTRING customName; // Custom name for this character, used for any display purpose, empty means use the default character name
 
 	UINT customSpeechColor; //Value to represent custom speech color. empty means use default color
@@ -369,6 +368,8 @@ private:
 	UINT wLastSpeechLineNumber; //used during language import
 
 	vector<UINT> jumpStack; //maintains index of GoTo commands executed, for Return commands
+
+	bool bIsDefaultScript; //is the character running a default script
 
 	//Predefined vars.
 	UINT color, sword, hue, saturation; //cosmetic details

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -5724,6 +5724,8 @@ void CCurrentGame::ProcessMonsters(
 
 		this->pRoom->ClearMovedInfo();
 
+		pMonster->bProcessing = true;
+
 		//Platforms fall when mimics are done moving.
 		const bool bIsMimic = pMonster->wType == M_MIMIC;
 		if (!bMimicsMoved && !bIsMimic)
@@ -5871,6 +5873,8 @@ void CCurrentGame::ProcessMonsters(
 
 		// Kegs stabbed by pushes should explode after each monster
 		this->pRoom->ExplodeStabbedPowderKegs(CueEvents);
+
+		pMonster->bProcessing = false;
 	}
 
 	//Run global scripts.

--- a/drodrpg/DRODLib/DbRooms.h
+++ b/drodrpg/DRODLib/DbRooms.h
@@ -431,6 +431,7 @@ public:
 	void           TurnOffLight(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	void           TurnOnLight(const UINT wX, const UINT wY, CCueEvents& CueEvents);
 	void           UnlinkMonster(CMonster *pMonster);
+	void           ReplaceCharacter(CCharacter* pOldCharacter, CCharacter* pNewCharacter);
 	bool           UnpackSquares(const BYTE *pSrc, const UINT dwSrcSize);
 	virtual bool   Update();
 //	void           UpdatePathMapAt(const UINT wX, const UINT wY);

--- a/drodrpg/DRODLib/Monster.cpp
+++ b/drodrpg/DRODLib/Monster.cpp
@@ -81,6 +81,7 @@ CMonster::CMonster(
 	, wType(wSetType)
 	, wProcessSequence(wSetProcessSequence)
 	, bIsFirstTurn(false)
+	, bProcessing(false)
 	, eMovement(eMovement)
 	, bAlive(true)
 	, HP(0), ATK(0), DEF(0), GOLD(0), XP(0)
@@ -105,7 +106,7 @@ void CMonster::Clear()
 	this->pPrevious=this->pNext=NULL;
 	this->wType=this->wX=this->wY=this->wO=this->wProcessSequence=0;
 	this->wPrevX = this->wPrevY = this->wPrevO = 0;
-	this->bIsFirstTurn=false;
+	this->bIsFirstTurn = this->bProcessing = false;
 	this->bAlive = true;
 	this->ATK = this->DEF = this->GOLD = this->HP = this->XP = 0;
 	this->bEggSpawn = false;

--- a/drodrpg/DRODLib/Monster.h
+++ b/drodrpg/DRODLib/Monster.h
@@ -286,6 +286,7 @@ public:
 	UINT          wType;          //monster type
 	UINT          wProcessSequence;  //priority in movement sequence
 	bool          bIsFirstTurn;
+	bool          bProcessing; //Is the monster currently taking its turn?
 	MovementType  eMovement;   //movement capability
 	bool          bAlive;  //whether monster is alive/active
 

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -110,6 +110,8 @@ functions.</p>
 	  turn.  Also used to define certain attributes of the NPC's abilities
 	  (see <a href="#behaviorlist">Behaviors</a>).  Compatible behaviors
 	  may be combined.</li>
+  <li><a name="replacewithdefault"><b>Replace with Default Script</b></a> - If the NPC is a custom NPC type, replaces the script content with that NPC type's default script.
+      That script will then begin executing. Has no effect when used in an NPC with a pre-defined type, or if a default script is already being run.</li>
 </ol>
 
 <p><a name="interaction"><b>3.&nbsp;&nbsp;Interaction</b></a> - How the NPC


### PR DESCRIPTION
Similar to #1005 but for RPG. Since bad things could happen if this command is executed during combat, I've set things up so like in TSS it can only be run during a character's main processing cycle.

The bits for the old tracking have been removed, as this now generates a new entity which is serialised as part of room data, and the new flag for indicating that a default script is being run is set when `CCharacter::SetCurrentGame` runs, and can therefore be ephemeral. Old saves might get roughed up but it won't effect published holds.