### PR TITLE
RPG: Prevent player HP from being set less than zero

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -1005,8 +1005,10 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 			switch (varIndex)
 			{
 				case (UINT)ScriptVars::P_HP:
-					if (int(newVal) <= 0)
+					if (int(newVal) <= 0) {
 						CueEvents.Add(CID_MonsterKilledPlayer); //player died
+						newVal = 0;
+					}
 					st.setVar(ScriptVars::Predefined(varIndex), newVal);
 				break;
 


### PR DESCRIPTION
Reducing the player's health to a negative value will usually kill the player via a `CID_MonsterKilledPlayer` event. However, during combat, the player won't die until the `CCombat` sees that their health is <= zero. But the player's health is stored as an unsigned integer, which can't be negative. This means that changes to the player's HP during combat can lead to unwanted behaviour due to underflow.

To fix, I've made it so any attempt to set `P_HP` to an negative value instead sets it to zero.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47113