### PR TITLE
RPG: Fix active room sometimes being drawn unexplored

### DIFF
--- a/drodrpg/DROD/MapWidget.cpp
+++ b/drodrpg/DROD/MapWidget.cpp
@@ -1366,12 +1366,14 @@ void CMapWidget::DrawMapSurfaceFromRoom(
 	if (this->pCurrentGame)
 	{
 		pExpRoom = this->pCurrentGame->getExploredRoom(pRoom->dwRoomID);
-		if (pExpRoom)
-			drawState = max(pExpRoom->mapState, this->pCurrentGame->GetStoredMapStateForRoom(pRoom->dwRoomID));
+		if (this->pCurrentGame->pRoom->dwRoomID == pRoom->dwRoomID)
+		{
+			drawState = MapState::Explored;
+		}
 		else
 		{
-			if (this->pCurrentGame->pRoom->dwRoomID == pRoom->dwRoomID)
-				drawState = MapState::Explored;
+			if (pExpRoom)
+				drawState = max(pExpRoom->mapState, this->pCurrentGame->GetStoredMapStateForRoom(pRoom->dwRoomID));
 			else
 				drawState = this->pCurrentGame->GetStoredMapStateForRoom(pRoom->dwRoomID);
 		}


### PR DESCRIPTION
Adding a map icon for a room during the initial visit to that room can result in the room being drawn on the minimap as if were an unexplored room. This is because in some cases you need to *leave* a room before it is registered as being explored in the current game. Due to how some logic is ordered in `CMapWidget::DrawMapSurfaceFromRoom`, we only check if the room being drawn is the active room isn't in the list of explored rooms. These two quirks combine such that the room is drawn using the preview state.

This can be fixed by reordering the logic to check if the room being drawn is the active room, which should always be drawn as explored (because the player has obviously explored a room if they're in it).

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47150