### PR TITLE
RPG: Show beams in room previews

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8531,6 +8531,19 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents) //room to disp
 	this->pTempRoomWidget->Show();
 
 	pTempRoomWidget->DisplayPersistingImageOverlays(CueEvents);
+
+	{
+		//Draw monster beams
+		CMonster* pMonster = pRoom->pFirstMonster;
+		while (pMonster) {
+			if (pMonster->HasRayGun()) {
+				pTempRoomWidget->AddZombieGazeEffect(pMonster);
+			}
+
+			pMonster = pMonster->pNext;
+		}
+	}
+
 	this->pTempRoomWidget->Paint();
 	ShowRoomCoords(this->pTempRoomWidget->pRoom);
 	UpdateRect();
@@ -8633,6 +8646,7 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents) //room to disp
 		//Update music (switch song or continue music fade if one is in progress).
 		g_pTheSound->UpdateMusic();
 		SDL_Delay(1); //be nice to the CPU
+		RequestPaint();
 	}
 
 	this->pTempRoomWidget->Hide();


### PR DESCRIPTION
Since previewed rooms aren't processed beyond the first turn, beam attacks aren't drawn. However, since we're already doing special handling for room previews, we can just find all the monsters with beams, and add their gaze effects.

There's also a small change to make previewed rooms animate, because the statically drawn beams look a little weird, and can disappear if you switch away from the game window.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47138