### PR TITLE
RPG: Reset color values to starting values when restarting script

### DIFF
--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -6322,14 +6322,14 @@ void CCharacter::RestartScript()
 	this->DEF = 0;
 	this->GOLD = 0;
 	this->XP = 0;
-	this->color = 0;
-	this->hue = 0;
-	this->saturation = 0;
 	this->sword = NPC_DEFAULT_SWORD;
 
 	//These values are reloaded as they were on setup.
 	this->wLogicalIdentity = this->ExtraVars.GetVar(idStr, this->wLogicalIdentity);
 	this->bVisible = this->ExtraVars.GetVar(visibleStr, this->bVisible);
+	this->color = this->ExtraVars.GetVar(ColorStr, this->color);
+	this->hue = this->ExtraVars.GetVar(HueStr, this->hue);
+	this->saturation = this->ExtraVars.GetVar(SaturationStr, this->saturation);
 }
 
 //*****************************************************************************


### PR DESCRIPTION
Makes the three values that alter character colours be reloaded when a script is restarted. In _theory_ there's a situation where this will change how things behave. In practice it would require both a script that doesn't set the restart flag on turn zero, and that makes logic decisions using the values of the colour vars.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47120