### PR TITLE
Don't apply lighting to tarstuff if alpha blending is disabled

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -4659,7 +4659,9 @@ void CRoomWidget::DrawTLayerTile(
 		} else if (ti.t != TI_TEMPTY) {
 			DrawRoomTile(ti.t);
 		}
-		AddLight(pDestSurface, nX, nY, psL, fDark, ti.t);
+
+		if (bAddLight)
+			AddLight(pDestSurface, nX, nY, psL, fDark, ti.t);
 	}
 }
 #undef DrawRoomTile


### PR DESCRIPTION
Quick visual fix. The logic to not apply light was missing from the tarstuff rending code.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47094