### PR TITLE
RPG: Fix some UI issues with array variables

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -1683,7 +1683,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 			F_Small, g_pTheDB->GetMessageText(MID_VarNameText)));
 
 	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_ARRAYVAR_TEXTLABEL,
-		X_VARTEXTLABEL, Y_VARTEXTLABEL, CX_VARTEXTLABEL, CY_VARTEXTLABEL,
+		X_VARTEXTLABEL, Y_VARTEXTLABEL, CX_VARTEXTLABEL * 2, CY_VARTEXTLABEL,
 		F_Small, g_pTheDB->GetMessageText(MID_ArrayVarNameExpression)));
 
 	this->pVarListBox = new CListBoxWidget(TAG_VARLIST,


### PR DESCRIPTION
Two problems:

1. `CCharacterDialogWidget::fromText` and `CCharacterDialogWidget::toText` are using the regular variable list for checking variable names. They should be using the array variable list.
2. The label for array expressions is cut off. It should be wider so that doesn't happen.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47190