### PR TITLE
Allow modifier keys to be pressed on map and room preview

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -6176,6 +6176,7 @@ void CGameScreen::ShowRoom(CCurrentGame *pGame, CCueEvents& CueEvents)
 				break;
 
 				case SDL_KEYDOWN:
+					int nCommand;
 					//Process other commands in the context of the displayed room.
 					switch (event.key.keysym.sym)
 					{
@@ -6187,13 +6188,18 @@ void CGameScreen::ShowRoom(CCurrentGame *pGame, CCueEvents& CueEvents)
 						case SDLK_RALT:
 						case SDLK_LGUI:
 						case SDLK_RGUI:
-							break; // Don't exit the room preview when modifier keys are pressed
-
-						case SDLK_F6:
+							nCommand = -1; // Don't exit the room preview when modifier keys are pressed
+							break;
+						default: nCommand = GetCommandForInputKey(BuildInputKey(event.key)); break;
+					}
+					switch (nCommand)
+					{
+						case CMD_EXTRA_WATCH_DEMOS:
 							bShow = false;
 							bShowDemosForRoom = true;
 							break;
-
+						case -1: // modifier key
+							break;
 						default:
 							bShow = false;
 							break;


### PR DESCRIPTION
This allows for use cases such as:
- Opening the demo screen for a previewed room when its shortcut uses a modifier key
- Taking a screenshot of the map/previewed room with an external tool when its shortcut uses a modifier key