### PR TITLE
RPG: Enable right-clicking room previews

### DIFF
--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -156,6 +156,7 @@ private:
 //	void           HandleEventsForHoldExit();
 	SCREENTYPE     HandleEventsForLevelExit();
 	bool           HandleEventsForPlayerDeath(CCueEvents &CueEvents);
+	bool           HandlePreviewClick(const SDL_MouseButtonEvent &Button, const UINT& originalRoomID, UINT& newShowRoomID);
 	void           HideBigMap();
 	bool           IsOpenMove(const int dx, const int dy) const;
 	SCREENTYPE     LevelExit_OnKeydown(const SDL_KeyboardEvent &KeyboardEvent);

--- a/drodrpg/DROD/RoomScreen.h
+++ b/drodrpg/DROD/RoomScreen.h
@@ -40,6 +40,7 @@
 
 static const UINT TAG_ROOM = 2000;
 static const UINT TAG_MAP = 2001;
+static const UINT TAG_TEMPROOM = 2002;
 
 static const UINT TAG_HP  = 2010;
 static const UINT TAG_ATK = 2011;


### PR DESCRIPTION
Routes click handling through a new function when a room is being previewed. This allows us to do things when the temporary room widget is clicked.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47209