### PR TITLE
Fix and refactor setting NPC properties when generated

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -7170,24 +7170,7 @@ void CCharacter::SetCurrentGame(
 	//Assign these when room play is first starting.
 	if (pSetCurrentGame->wTurnNo == 0)
 	{
-		switch (GetIdentity())
-		{
-			case M_CITIZEN: case M_ARCHITECT:
-			case M_WUBBA:
-				SetImperative(ScriptFlag::Invulnerable);
-			break;
-			case M_BEETHRO: case M_BEETHRO_IN_DISGUISE: case M_GUNTHRO:
-			case M_CLONE:
-			case M_TEMPORALCLONE:
-			case M_HALPH: case M_HALPH2:
-				SetImperative(ScriptFlag::MissionCritical);
-				bFriendly = true;
-			break;
-			default: break;
-		}
-
-		SetDefaultMovementType();
-		SetDefaultBehaviors();
+		SetDefaultProperties();
 	}
 
 	//If this NPC is a custom character with no script,
@@ -7201,6 +7184,14 @@ void CCharacter::SetCurrentGame(
 	//and removed on room exit
 	if (this->bGlobal && this->commands.empty())
 		this->bScriptDone = true;
+}
+
+//*****************************************************************************
+void CCharacter::SetDefaultProperties()
+{
+	SetDefaultImperatives();
+	SetDefaultBehaviors();
+	SetDefaultMovementType();
 }
 
 //*****************************************************************************
@@ -7264,6 +7255,27 @@ void CCharacter::SetDefaultBehaviors()
 	}
 	if (!bCanFluffKill(wResolvedIdentity)) {
 		behaviorFlags.insert(ScriptFlag::PuffImmune);
+	}
+}
+
+//*****************************************************************************
+void CCharacter::SetDefaultImperatives()
+// Certain character types have default imperatives.
+{
+	switch (GetIdentity())
+	{
+		case M_CITIZEN: case M_ARCHITECT:
+		case M_WUBBA:
+			SetImperative(ScriptFlag::Invulnerable);
+			break;
+		case M_BEETHRO: case M_BEETHRO_IN_DISGUISE: case M_GUNTHRO:
+		case M_CLONE:
+		case M_TEMPORALCLONE:
+		case M_HALPH: case M_HALPH2:
+			SetImperative(ScriptFlag::MissionCritical);
+			bFriendly = true;
+			break;
+		default: break;
 	}
 }
 

--- a/DRODLib/Character.h
+++ b/DRODLib/Character.h
@@ -242,8 +242,7 @@ public:
 	void           ResolveLogicalIdentity(CDbHold *pHold);
 	virtual void   SetCurrentGame(const CCurrentGame *pSetCurrentGame);
 	virtual void   SetCustomSpeechColor(const UINT color) { this->customSpeechColor = color; }
-	void           SetDefaultBehaviors();
-	void           SetDefaultMovementType();
+	void           SetDefaultProperties();
 	void   SetImperative(const ScriptFlag::Imperative eVal) {this->eImperative = eVal;}
 	virtual void   SetExtraVarsFromMembers(const bool bHoldChar=false);
 	void           SetExtraVarsFromMembersWithoutScript(const bool bHoldChar=false);
@@ -322,6 +321,10 @@ private:
 	void SetVariable(const CCharacterCommand& command, CCurrentGame *pGame, CCueEvents& CueEvents);
 	void SetArrayVariable(const CCharacterCommand& command, CCurrentGame *pGame, CCueEvents& CueEvents);
 	void SetLocalVar(const WSTRING& varName, const WSTRING& val);
+
+	void SetDefaultBehaviors();
+	void SetDefaultImperatives();
+	void SetDefaultMovementType();
 
 	void GenerateEntity(const UINT identity, const UINT wX, const UINT wY, const UINT wO, CCueEvents& CueEvents);
 

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -263,8 +263,7 @@ CMonster* CCurrentGame::AddNewEntity(
 	CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pNew);
 	pCharacter->wLogicalIdentity = identity;
 	pCharacter->SetCurrentGame(this); //will assign the default script for custom NPCs
-	pCharacter->SetDefaultMovementType();
-	pCharacter->SetDefaultBehaviors();
+	pCharacter->SetDefaultProperties();
 	pCharacter->dwScriptID = this->pHold->GetNewScriptID();
 	pCharacter->bNewEntity = true;
 


### PR DESCRIPTION
Another problem with non-turn zero generation, where default imperatives don't get set even if they should be. I've made a new function for setting them up, then made another function to call the three functions that set various default properties. They could be combined but I think it's a little cleaner this way.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47213