### PR TITLE
Prevent infinite NPC generation on turn zero

### DIFF
--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -5721,9 +5721,11 @@ void CDbRoom::PreprocessMonsters(CCueEvents& CueEvents)
 //require a turn to execute (e.g. visibility, gotos, speech).
 {
 	CMonster *pMonster;
+	CMonster* pFinal = this->pLastMonster;
+	bool bPassedOriginalLastMonster = false;
 	for (pMonster = this->pFirstMonster; pMonster != NULL; pMonster = pMonster->pNext)
 	{
-		if (pMonster->wType == M_CHARACTER)
+		if (pMonster->wType == M_CHARACTER && !bPassedOriginalLastMonster)
 		{
 			CCharacter *pCharacter = DYN_CAST(CCharacter*, CMonster*, pMonster);
 			pCharacter->SetWeaponSheathed();
@@ -5735,6 +5737,12 @@ void CDbRoom::PreprocessMonsters(CCueEvents& CueEvents)
 			//Spiders far from player always start invisible.
 			CSpider *pSpider = DYN_CAST(CSpider*, CMonster*, pMonster);
 			pSpider->SetVisibility();
+		}
+
+		//Don't process any characters that have been added during this turn.
+		//Not a break since we might need to deal with generated spiders.
+		if (pMonster == pFinal) {
+			bPassedOriginalLastMonster = true;
 		}
 	}
 


### PR DESCRIPTION
`CCurrentGame::AddNewEntity` has a mechanism to prevent the game getting locked due to a script recursively generating new characters. Since `CCurrentGame::ProcessMonster` doesn't process a monster on its first turn of existance, most possible locks are prevented. `CDbRoom::PreprocessMonsters`, which runs on turn zero, does not and cannot have such a check. This means that it will continue to process characters as they are added to the monster list, which could be forever.

To fix this, I've changed `CDbRoom::PreprocessMonsters` so that it won't process any characters that are after whatever monster was last in the monster list when the function was called.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47219