### PR TITLE
Allow replace with default command to execute on turn zero

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3023,9 +3023,6 @@ void CCharacter::Process(
 			break;
 
 			case CCharacterCommand::CC_ReplaceWithDefault:
-				if (bExecuteNoMoveCommands || !this->bProcessing)
-					return; //only replace during actual monster processing
-
 				ReplaceWithDefault(nLastCommand, CueEvents);
 				bProcessNextCommand = !this->bReplaced; //no-op if not replaced
 			break;
@@ -8329,11 +8326,9 @@ void CCharacter::TurnIntoMonster(
 //*****************************************************************************
 //Replaces the character with one running the default script for the character's
 //indentity.
-//Precondition: the character is currently processing its turn.
 void CCharacter::ReplaceWithDefault(
 	const UINT nLastCommand, CCueEvents& CueEvents)
 {
-	ASSERT(this->bProcessing);
 	//Don't do anything if this isn't a custom character, or if it's already
 	//running a default script
 	if (!this->pCustomChar || this->bIsDefaultScript) {

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -5731,6 +5731,11 @@ void CDbRoom::PreprocessMonsters(CCueEvents& CueEvents)
 			pCharacter->SetWeaponSheathed();
 			pCharacter->Process(CMD_WAIT, CueEvents);
 			this->pCurrentGame->PostProcessCharacter(pCharacter, CueEvents);
+
+			//If the replace with default command was executed, we need to unlink.
+			if (pMonster->bUnlink) {
+				UnlinkMonster(pMonster);
+			}
 		}
 		else if (pMonster->wType == M_SPIDER)
 		{


### PR DESCRIPTION
Previous problems with running the command can be solved by unlinking if needed in `CDbRoom::PreprocessMonsters`.