### PR TITLE
Fix crash when importing xml file directly.

### DIFF
--- a/DRODLib/DbXML.cpp
+++ b/DRODLib/DbXML.cpp
@@ -1789,7 +1789,15 @@ MESSAGE_ID CDbXML::ImportXML(const string& xml) //(in) string of XML text
 //*****************************************************************************
 MESSAGE_ID CDbXML::ImportXML()
 {
-	info.ImportStatus = ImportXML(&importBuf);
+	if (importBuf.uncompressedBuffer && !importBuf.compressedBuffer) {
+		//Everything is already uncompressed, so go through the string-based version
+		//of ImportXML.
+		BYTE* bytes = (BYTE*)importBuf.uncompressedBuffer;
+		std::string xml((char*)bytes);
+		info.ImportStatus = ImportXML(xml);
+	} else {
+		info.ImportStatus = ImportXML(&importBuf);
+	}
 
 	//Clean up.
 	//If an import is interrupted in the middle by a request for user input,


### PR DESCRIPTION
Importing a `.xml` file causes a crash. This seems to be a consequence of the changes to importing to allow incremental decompression. I've fixed this by making it so uncompressed xml data gets routed through the string version of `CDbXML::ImportXML`.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47222