### PR TITLE
Add preprocessor controls for including Cloud Sync functionality

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -6825,8 +6825,10 @@ void CGameScreen::WaitToUploadDemos()
 		HideStatusMessage();
 	}
 
+#ifdef ENABLE_CLOUDSYNC
 	if (this->pCurrentGame)
 		UploadPlayerProgressToCloud(this->pCurrentGame->pHold->dwHoldID);
+#endif
 }
 
 //*****************************************************************************

--- a/DROD/HoldSelectScreen.cpp
+++ b/DROD/HoldSelectScreen.cpp
@@ -703,6 +703,7 @@ void CHoldSelectScreen::DeleteSelectedHolds()
 
 		const UINT holdID = *id;
 
+#ifdef ENABLE_CLOUDSYNC
 		if (g_pTheNet->IsEnabled()) {
 			const CDbPackedVars settings = g_pTheDB->GetCurrentPlayerSettings();
 			if (settings.GetVar(Settings::CloudActivated, false)) {
@@ -711,6 +712,7 @@ void CHoldSelectScreen::DeleteSelectedHolds()
 				g_pTheNet->CloudSetHoldInstalled(holdID, false);
 			}
 		}
+#endif // ENABLE_CLOUDSYNC
 
 		CDbHold *pHold = g_pTheDB->Holds.GetByID(holdID, true);
 		ASSERT(pHold);
@@ -912,12 +914,14 @@ void CHoldSelectScreen::DownloadSelectedHolds()
 		if (CDbXML::info.dwHoldImportedID)
 		{
 			//Mark hold as imported.
+#ifdef ENABLE_CLOUDSYNC
 			if (g_pTheNet->IsEnabled()) {
 				const CDbPackedVars settings = g_pTheDB->GetCurrentPlayerSettings();
 				if (settings.GetVar(Settings::CloudActivated, false)) {
 					g_pTheNet->CloudSetHoldInstalled(CDbXML::info.dwHoldImportedID, true);
 				}
 			}
+#endif // ENABLE_CLOUDSYNC
 			importedHoldIDs += CDbXML::info.dwHoldImportedID;
 			for (set<WSTRING>::const_iterator iter = CDbXML::info.roomStyles.begin();
 					iter != CDbXML::info.roomStyles.end(); ++iter)
@@ -1066,6 +1070,7 @@ void CHoldSelectScreen::OnClick(
 			}
 			if (!importedHoldIDs.empty())
 			{
+#ifdef ENABLE_CLOUDSYNC
 				if (g_pTheNet->IsEnabled()) {
 					const CDbPackedVars settings = g_pTheDB->GetCurrentPlayerSettings();
 					if (settings.GetVar(Settings::CloudActivated, false)) {
@@ -1074,6 +1079,7 @@ void CHoldSelectScreen::OnClick(
 						}
 					}
 				}
+#endif // ENABLE_CLOUDSYNC
 				if (!importedStyles.empty())
 				{
 					//Automatically download and import new referenced room styles

--- a/DROD/SelectPlayerScreen.cpp
+++ b/DROD/SelectPlayerScreen.cpp
@@ -112,12 +112,19 @@ CSelectPlayerScreen::CSelectPlayerScreen() : CDrodScreen(SCR_SelectPlayer)
 #endif
 
 	static const int Y_BUTTONS3 = Y_BUTTONS2 + 40;
+#ifdef ENABLE_CLOUDSYNC
 	static const int X_IMPORTBUTTON = 15;
 	static const UINT CX_IMPORTBUTTON = 100;
 	static const int X_CLOUDIMPORTBUTTON = X_IMPORTBUTTON + CX_IMPORTBUTTON + CX_SPACE;
 	static const UINT CX_CLOUDIMPORTBUTTON = 250;
 	static const int X_CANCEL = X_CLOUDIMPORTBUTTON + CX_CLOUDIMPORTBUTTON + CX_SPACE;
 	static const UINT CX_CANCEL = 100;
+#else
+	static const UINT CX_IMPORTBUTTON = 100;
+	static const int X_IMPORTBUTTON = (CX_BOX - CX_SPACE) / 2 - CX_IMPORTBUTTON;
+	static const int X_CANCEL = (CX_BOX + CX_SPACE) / 2;
+	static const UINT CX_CANCEL = 100;
+#endif // ENABLE_CLOUDSYNC
 
 	static const UINT CY_BOX = Y_BUTTONS3 + CY_STANDARD_BUTTON + CY_SPACE;
 
@@ -160,7 +167,7 @@ CSelectPlayerScreen::CSelectPlayerScreen() : CDrodScreen(SCR_SelectPlayer)
 	this->pPlayerBox->AddWidget(new CButtonWidget(TAG_IMPORT,
 			X_IMPORTBUTTON, Y_BUTTONS3, CX_IMPORTBUTTON, CY_STANDARD_BUTTON,
 			g_pTheDB->GetMessageText(MID_Import)));
-#ifndef STEAMBUILD
+#ifdef ENABLE_CLOUDSYNC
 	this->pPlayerBox->AddWidget(new CButtonWidget(TAG_GET_PLAYER_FROM_CLOUD,
 			X_CLOUDIMPORTBUTTON, Y_BUTTONS3, CX_CLOUDIMPORTBUTTON, CY_STANDARD_BUTTON,
 			g_pTheDB->GetMessageText(MID_GetPlayerFromCloud)));

--- a/DROD/SettingsScreen.cpp
+++ b/DROD/SettingsScreen.cpp
@@ -289,7 +289,7 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 	static const int Y_UPLOADSCORES = Y_REQUESTKEY;
 	static const UINT CY_UPLOADSCORES = CY_STANDARD_BUTTON;
 
-#ifdef STEAMBUILD
+#ifndef ENABLE_CLOUDSYNC
 	static const UINT CY_PERSONAL_FRAME = CY_NAME_LABEL + CY_CNETNAME +
 		CY_CNETPASSWORD + CY_CNETCONNECT + CY_REQUESTKEY + CY_SPACE * 6;
 #else
@@ -422,7 +422,7 @@ void CSettingsScreen::SetupPersonalTab(CTabbedMenuWidget* pTabbedMenu)
 		new CButtonWidget(TAG_UPLOADSCORES, X_UPLOADSCORES, Y_UPLOADSCORES,
 			CX_UPLOADSCORES, CY_UPLOADSCORES, g_pTheDB->GetMessageText(MID_UploadScores)));
 
-#ifndef STEAMBUILD
+#ifdef ENABLE_CLOUDSYNC
 	pPersonalFrame->AddWidget(
 		new COptionButtonWidget(TAG_CLOUD_ACTIVATE, X_CLOUD_ACTIVATE, Y_CLOUD_ACTIVATE,
 			CX_CLOUD_ACTIVATE, CY_CLOUD_ACTIVATE, g_pTheDB->GetMessageText(MID_ActivateCloudSync)));
@@ -1616,7 +1616,9 @@ void CSettingsScreen::SetWidgetStates()
 	if (bButtonsVisible)
 		pButton->RequestPaint();
 
+#ifdef ENABLE_CLOUDSYNC
 	SetCloudWidgetStates();
+#endif // ENABLE_CLOUDSYNC
 }
 
 //************************************************************************************

--- a/DROD/TitleScreen.cpp
+++ b/DROD/TitleScreen.cpp
@@ -1062,6 +1062,7 @@ bool CTitleScreen::PollForHoldList()
 			{
 				AddTextToMarquee(g_pTheDB->GetMessageText(MID_UnsentCaravelNetProgress));
 			}
+#ifdef ENABLE_CLOUDSYNC
 			if (pPlayer->Settings.GetVar(Settings::CloudActivated, false)) {
 				pInternetIcon->SetImage(wszSignalCloud);
 				// Get any pending cloud demo updates
@@ -1092,6 +1093,7 @@ bool CTitleScreen::PollForHoldList()
 				ExportCleanup();
 				Paint();
 			}
+#endif // ENABLE_CLOUDSYNC
 		}
 	} else {
 		//Determine whether player is a registered CaravelNet user.


### PR DESCRIPTION
Cloud sync has various issues. This PR makes it so the functionality can be enabled or disabled for a build using a preprocessor definition. For the moment, no configuration builds with cloud sync.

Additionally, I've changed how buttons get arranged on the player select screen if building without cloud sync. This removes a rather unsightly gap.