### PR TITLE
Fix setting Set var at command values for text operations

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -7233,12 +7233,9 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 			this->pCommand->w = 0; //default
 
 			const bool bTextVar =
-				(c == CCharacterCommand::CC_VarSet &&
+				((c == CCharacterCommand::CC_VarSet || c == CCharacterCommand::CC_VarSetAt) &&
 					(this->pCommand->y == ScriptVars::AssignText ||
 					this->pCommand->y == ScriptVars::AppendText)) ||
-				(c == CCharacterCommand::CC_VarSetAt &&
-					(this->pCommand->h == ScriptVars::AssignText ||
-						this->pCommand->h == ScriptVars::AppendText)) ||
 				(c == CCharacterCommand::CC_WaitForVar &&
 					this->pCommand->y == ScriptVars::EqualsText);
 			if (bTextVar)


### PR DESCRIPTION
Small issue with how all these var commands are sharing code when setting command values from widgets. For `CC_VarSetAt` we look at the command's `h` value to decide if it's going to be a text operation, but at that point in the process the command type is still in the `y` value.