### PR TITLE
RPG: Add descriptor for flying monsters

### DIFF
--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2168,6 +2168,14 @@ WSTRING CRoomWidget::GetMonsterAbility(CMonster* pMonster) const
 		}
 		wstr += g_pTheDB->GetMessageText(MID_WaterSkipperAbility);
 		++count;
+	} else if (pMonster->IsFlying()) {
+		if (count)
+		{
+			wstr += wszComma;
+			wstr += wszSpace;
+		}
+		wstr += g_pTheDB->GetMessageText(MID_FlyingAbility);
+		++count;
 	}
 	if (!pMonster->DamagedByHotTiles())
 	{

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -842,6 +842,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_Command_Script_CharacterOptions: strText = "Show Character Options"; break;
 		case MID_Command_ShowMap: strText = "Show Map"; break;
 		case MID_Briars: strText = "Any briar"; break;
+		case MID_FlyingAbility: strText = "Airborne"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -377,3 +377,7 @@ Used to dig through dirt blocks.
 [eng]
 Level Multiplier
 Multiplies resources gained from health potions, gems and shovels.
+
+[MID_FlyingAbility]
+[eng]
+Airborne

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -684,6 +684,7 @@ enum MID_CONSTANT {
   MID_CombatStalled = 2115,
   MID_ShovelTooltip = 2158,
   MID_LevelMultiplierTooltip = 2159,
+  MID_FlyingAbility = 2164,
 
   //Messages from General.uni:
   MID_SDLInitFailed = 464,


### PR DESCRIPTION
Flying monsters aren't affected by hot tiles, and can't be drowned or pitted. But there's no way to know that a monster flies without seeing one of those consequences. I've added a new descriptor, "Airborne", to indicate that a monster is a flying monster.