### PR TITLE
RPG: Fix issues with screenshot and full screen inputs

### DIFF
--- a/FrontEndLib/DialogWidget.cpp
+++ b/FrontEndLib/DialogWidget.cpp
@@ -364,6 +364,9 @@ void CDialogWidget::OnKeyDown(
 	const UINT /*dwTagNo*/,         //(in)   Widget that event applied to.
 	const SDL_KeyboardEvent &Key) //(in)   Event.
 {
+	if (ProcessScreenCommandInput(Key))
+		return;
+
 	switch (Key.keysym.sym)
 	{
 		case SDLK_KP_ENTER:
@@ -384,9 +387,7 @@ void CDialogWidget::OnKeyDown(
 			}
 
 			if ((Key.keysym.mod & KMOD_ALT) == 0) break;
-		//NO BREAK
 
-		case SDLK_F10:
 			if (this->pParent && this->pParent->GetType() == WT_Screen)
 			{
 				CScreen *const pScreen = static_cast<CScreen *const>(this->pParent);
@@ -474,6 +475,29 @@ void CDialogWidget::OnWindowEvent_LoseFocus()
 		pParent->OnWindowEvent_LoseFocus();
 	else
 		CEventHandlerWidget::OnWindowEvent_LoseFocus();
+}
+
+//*****************************************************************************
+bool CDialogWidget::ProcessScreenCommandInput(const SDL_KeyboardEvent& Key)
+{
+	if (this->pParent && this->pParent->GetType() == WT_Screen) {
+		InputKey inputKey = BuildInputKey(Key);
+		if (inputKey == CScreen::inputKeyFullScreen)
+		{
+			CScreen* const pScreen = static_cast<CScreen* const>(this->pParent);
+			pScreen->ToggleScreenSize();
+			RequestPaint();
+			return true;
+		}
+		else if (inputKey == CScreen::inputKeyScreenshot)
+		{
+			CScreen* const pScreen = static_cast<CScreen* const>(this->pParent);
+			pScreen->SaveSurface();
+			return true;
+		}
+	}
+
+	return false;
 }
 
 //*****************************************************************************

--- a/FrontEndLib/DialogWidget.h
+++ b/FrontEndLib/DialogWidget.h
@@ -94,6 +94,8 @@ protected:
 	virtual void      OnWindowEvent_GetFocus();
 	virtual void      OnWindowEvent_LoseFocus();
 
+	bool              ProcessScreenCommandInput(const SDL_KeyboardEvent& Key);
+
 	UINT          dwDeactivateValue;
 
 private:

--- a/drodrpg/DROD/TitleScreen.cpp
+++ b/drodrpg/DROD/TitleScreen.cpp
@@ -528,6 +528,20 @@ void CTitleScreen::OnKeyDown(
 	const UINT /*dwTagNo*/,         //(in)   Widget that event applied to.
 	const SDL_KeyboardEvent &Key) //(in)   Key event.
 {
+	{
+		InputKey inputKey = BuildInputKey(Key);
+		if (inputKey == CScreen::inputKeyFullScreen)
+		{
+			ToggleScreenSize();
+			return;
+		}
+		else if (inputKey == CScreen::inputKeyScreenshot)
+		{
+			SaveSurface();
+			return;
+		}
+	}
+
 	TitleSelection wSetPos;
 	switch (Key.keysym.sym)
 	{
@@ -536,12 +550,7 @@ void CTitleScreen::OnKeyDown(
 			{
 				wSetPos = MNU_CONTINUE; break;
 			}
-			//else going to next case
-		case SDLK_F10:
 			ToggleScreenSize();
-		return;
-		case SDLK_F11:
-			SaveSurface();
 		return;
 
 		case SDLK_F4:


### PR DESCRIPTION
Couple of issues related to taking screenshots and switching fullscreen mode:

- These commands get blocked by dialogs, because the dialog will "eat" the input. `CDialogWidget::OnKeyDown` is written to avoid that, but now that the commands can have their controls rebound, it doesn't always work. I've made it so that dialog will check for the controls that have been set.
- `CTitleScreen::OnKeyDown` also doesn't respect rebound controls, so I've updated it to do that.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47248