### PR TITLE
Fix a bug with boxes being added on new-line on Linux

### DIFF
--- a/FrontEndLib/TextBoxWidget.cpp
+++ b/FrontEndLib/TextBoxWidget.cpp
@@ -861,7 +861,7 @@ void CTextBoxWidget::DrawCursor(
 //******************************************************************************
 void CTextBoxWidget::TypeCharacters(const WCHAR* wcs, size_t length)
 {
-	WSTRING inputText(wcs);
+	WSTRING inputText(wcs, length);
 
 	SanitizeText(inputText);
 	length = inputText.length();
@@ -871,7 +871,7 @@ void CTextBoxWidget::TypeCharacters(const WCHAR* wcs, size_t length)
 	if (HasSelection())
 		DeleteSelected(); //replace selection with typed char
 	bool ok = false;
-	
+
 	for (size_t i = 0; i < length && (ok = InsertAtCursor(inputText[i])); ++i) {}
 	if (ok)
 	{


### PR DESCRIPTION
Fix a bug where `CTextBoxWidget::TypeCharacters()` could receive a pointer to a single character with specified length 1, then treat it like a null-terminated string and expand itself to a longer string.

This was noticed on Linux builds where pressing enter on multiline boxes would add a new line preceded by a bunch of square characters.

Fixes #1067 