### PR TITLE
Made steam builds work:

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -48,6 +48,9 @@ jobs:
           ninja-build \
           libssl-dev \
           libnghttp2-dev \
+          libsdl2-dev \
+          libsdl2-mixer-dev \
+          libsdl2-ttf-dev \
           zlib1g-dev \
           wget \
           unzip \

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ FrontEndLib/CaravelRelease-Temp/
 */BuildDats/
 */SteamBuildDats/
 */*-Temp/
+Master/Linux/steam
 Master/Linux/deps
 Master/Linux/static-libs
 Master/Linux/build.*

--- a/CompilingDrod_Linux.md
+++ b/CompilingDrod_Linux.md
@@ -3,4 +3,17 @@
 1. Install Docker.
 2. Run the script `./Scripts/Linux/build.sh all`
 3. This will build a release version of DROD in `./Master/Linux/builds/custom.release.x86_64/drod` and DROD RPG in `./drodrpg/Master/Linux/builds/custom.release.x86_64/drod`
-6. Copy appropriate `drod5_0.dat` files
+4. Copy appropriate `drod5_0.dat` files
+5. Copy `libSDL2-2.0.so.0` into the game directory for redistribution
+
+# Building Steam DROD
+
+1. Steam SDK needs to be unpacked into Master/Linux/steam
+2. `./Scripts/Linux/build.sh docker-up`
+3. `./Scripts/Linux/build.sh build-deps`
+4. `./Scripts/Linux/build.sh docker-bar` — this will open bash in the docker container in which:
+    1. `cd Master/Linux`
+    2. `./ninjamaker -steam -64` — Generate script for compiling DROD:GATEB
+    3. `./ninjamaker -steam-tss -64` — Generate script for compiling DROD:TSS
+    4. `ninja -f build.steam.release.x86_64.ninja` — Builds DROD:GATEB for Steam
+    4. `ninja -f build.steam-tss.release.x86_64.ninja` — Builds DROD:TSS for Steam

--- a/Master/Linux/ninjamaker
+++ b/Master/Linux/ninjamaker
@@ -6,7 +6,7 @@ die () {
 }
 
 cpucount=$(grep processor /proc/cpuinfo | wc -l)
-steamworks_sdk="${STEAMWORKS_SDK:-}"
+steamworks_sdk="${STEAMWORKS_SDK:-"steam"}"
 
 args=("$@")
 declare -A options
@@ -26,12 +26,20 @@ distflags=(
 	[steam-tss]="-DCARAVELBUILD -DSTEAMBUILD -I${steamworks_sdk}/public/steam -DSTEAMBUILD_TSS_APP"
 )
 
-declare -A distlinkflags
-distlinkflags=(
+declare -A distlinkflags_pre
+distlinkflags_pre=(
 	[custom]=""
 	[caravel]=""
-	[steam]="-L${steamworks_sdk}/redistributable_bin/linux64 -L${steamworks_sdk}/redistributable_bin/linux32 -lsteam_api"
-	[steam-tss]="-L${steamworks_sdk}/redistributable_bin/linux64 -L${steamworks_sdk}/redistributable_bin/linux32 -lsteam_api"
+	[steam]="-L${steamworks_sdk}/redistributable_bin/linux64 -L${steamworks_sdk}/redistributable_bin/linux32"
+	[steam-tss]="-L${steamworks_sdk}/redistributable_bin/linux64 -L${steamworks_sdk}/redistributable_bin/linux32"
+)
+
+declare -A distlinkflags_post
+distlinkflags_post=(
+	[custom]=""
+	[caravel]=""
+	[steam]="-lsteam_api"
+	[steam-tss]="-lsteam_api"
 )
 
 declare -A buildflags
@@ -120,7 +128,7 @@ fi
 BUILDDIR=builds/$NAME
 EXEC="${options[archexec]} ${options[exec]}"
 
-SDL2_CONFIG="$EXEC static-libs/bin/sdl2-config"
+SDL2_CONFIG="$EXEC sdl2-config"
 PKG_CONFIG="$EXEC pkg-config"
 
 declare -a libs
@@ -139,7 +147,8 @@ gen_rules () {
 	echo "archflags = ${archflags[${options[arch]}]}"
 	echo "distflags = ${distflags[${options[dist]}]}"
 	echo "buildflags = ${buildflags[${options[build]}]} -DDROD_AUTODETECT_REVISION"
-	echo "linkflags = ${linkflags[${options[build]}]} ${distlinkflags[${options[dist]}]}"
+	echo "linkflagspre = ${linkflags[${options[build]}]} ${distlinkflags_pre[${options[dist]}]}"
+	echo "linkflagspost = ${distlinkflags_post[${options[dist]}]}"
 	echo "cxxbin = ${options[cxx]}"
 	cat <<'X'
 
@@ -152,7 +161,7 @@ config = $distflags -DUSE_SDL_MIXER
 optflags = -std=c++11 $archflags $buildflags -g
 
 cflags = $optflags -pipe -W -Wall -Wno-unused -Wno-unused-parameter -Wno-uninitialized
-ldflags = $optflags $linkflags -pipe -Wl,-rpath,'$$ORIGIN' -Wl,--as-needed
+ldflags = $optflags $linkflagspre -pipe -Wl,-rpath,'$$ORIGIN' -Wl,--as-needed
 
 revision = $$(git rev-parse --short HEAD)
 debugsuffix = -${arch}-${revision}.dbg
@@ -164,7 +173,7 @@ rule cxx
   description = Compile $out
 
 rule link
-  command = $cxx -o $out $ldflags $in $libs && rm -f ${out}-*.dbg && objcopy --only-keep-debug $out ${out}${debugsuffix} && objcopy --add-gnu-debuglink=${out}${debugsuffix} $out && strip --strip-all $out
+  command = $cxx -o $out $ldflags $in $libs $linkflagspost && rm -f ${out}-*.dbg && objcopy --only-keep-debug $out ${out}${debugsuffix} && objcopy --add-gnu-debuglink=${out}${debugsuffix} $out && strip --strip-all $out
   description = Link $out
 
 rule link-tests
@@ -191,17 +200,23 @@ X
 	local idirs=("-I$BUILDDIR")
 	local ilibs=()
 	for dir in ${libs[@]}; do
+		# Test library are only required for drod_tests target
+	    [[ "$(basename $dir)" == *DRODLibTests ]] && continue
 		idirs+=(-I$(dirname $dir))
 		ilibs+=($BUILDDIR/$(basename $dir).a)
 	done
 	cat <<X
 includes = ${idirs[@]} -Istatic-libs/include $(${SDL2_CONFIG} --cflags)
-staticlibs = -Lstatic-libs/lib -lSDL2_mixer -lSDL2_ttf -lSDL2 -ltheora -lvorbisfile -lvorbis -logg -ljpeg -lmk4 -lfreetype -lpng16 -lcurl -lssl -lcrypto -lexpat -ljsoncpp
-dynamiclibs = $(${SDL2_CONFIG} --libs) -lnghttp2 -lz -lpthread -lm -lrt -ldl
+staticlibs = -Lstatic-libs/lib -lSDL2_mixer -lSDL2_ttf -ltheora -lvorbisfile -lvorbis -logg -ljpeg -lmk4 -lfreetype -lpng16 -lnghttp2 -lcurl -lssl -lcrypto -lexpat -ljsoncpp
+dynamiclibs = $(${SDL2_CONFIG} --libs) -lSDL2 -lz -lpthread -lm -lrt -ldl
 build $BUILDDIR/drod: link ${ilibs[@]}
-# To make sure we rebuild the binary dependency on DRODTestLib.a must be kept here
-build $BUILDDIR/drod_tests: link-tests $BUILDDIR/DRODLib.a $BUILDDIR/BackEndLib.a | $BUILDDIR/DRODLibTests.a
 X
+
+	# There is no point building tests when doing a steam build
+	if [[ ! " ${options[dist]} " =~ "steam" ]]; then
+		# To make sure we rebuild the binary dependency on DRODTestLib.a must be kept here
+		echo "build $BUILDDIR/drod_tests: link-tests $BUILDDIR/DRODLib.a $BUILDDIR/BackEndLib.a | $BUILDDIR/DRODLibTests.a"
+	fi
 	if ${options[nostatic]}; then
 		echo "libs = \$staticlibs \$dynamiclibs"
 	else

--- a/Scripts/Linux/Dockerfile
+++ b/Scripts/Linux/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && apt-get install -y \
     ninja-build \
     libssl-dev \
     libnghttp2-dev \
+    libsdl2-dev \
+    libsdl2-mixer-dev \
+    libsdl2-ttf-dev \
     zlib1g-dev \
     wget \
     unzip \

--- a/Scripts/build-deps-linux.sh
+++ b/Scripts/build-deps-linux.sh
@@ -249,6 +249,8 @@ mkdir -p "$RPG_INSTALL_DIR"
 rsync -a "$DEPS_DIR" "$(dirname "$RPG_DEPS_DIR")"
 rsync -a "$INSTALL_DIR" "$(dirname "$RPG_INSTALL_DIR")"
 
+rm -f "$INSTALL_DIR/lib/libSDL2.a"
+
 echo "=== Build complete ==="
 echo "Static libraries installed in: $INSTALL_DIR"
 echo "Include headers in: $INSTALL_DIR/include"


### PR DESCRIPTION
# Reasonings
1. `-lsteam_api` must be included very late in the list of argument so I had to expand `ninjamaker`to support that
2. Changed linking of SDL2 to be dynamic because otherwise Steam is not able to inject the overlay
3. Had to move `nghttp2` to be a static lib because otherwise Steam injected its own version that was too old and did not work

# Fluff
With these changes I can make Steam builds and non-steam builds and everything seems to be working fine.