### PR TITLE
Image overlay offsetting

### DIFF
--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -166,7 +166,13 @@ int CImageOverlayEffect::getGroup() const
 	return ImageOverlayCommand::DEFAULT_GROUP;
 }
 
-bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
+bool CImageOverlayEffect::Update(
+// Advances the animation by specified amount of time
+// Return: false if the effect has finished and should be removed
+//
+// Params:
+	const UINT wDeltaTime,      //(in) Time, in ms, by which to advance the effect
+	const Uint32 dwTimeElapsed) //(in) Total duration, in ms, of the effect so far
 {
 	if (!this->pImageSurface)
 		return false;
@@ -186,20 +192,24 @@ bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElaps
 		this->bPrepareAlteredImage = false;
 	}
 
-	PrepareDrawProperties();
+	// Only recalculate jitter in Update() so that it stays consistent
+	// between redraws
+	if (this->jitter) {
+		this->lastJitterX = ROUND(fRAND_MID(this->jitter));
+		this->lastJitterY = ROUND(fRAND_MID(this->jitter));
+	} else {
+		this->lastJitterX = 0;
+		this->lastJitterY = 0;
+	}
 
 	return true;
 }
 
 void CImageOverlayEffect::PrepareDrawProperties()
+// Prepare all the necessary variables for drawing
 {
-	this->drawX = this->x;
-	this->drawY = this->y;
-
-	if (this->jitter) {
-		this->drawX += ROUND(fRAND_MID(this->jitter));
-		this->drawY += ROUND(fRAND_MID(this->jitter));
-	}
+	this->drawX = this->x + this->lastJitterX;
+	this->drawY = this->y + this->lastJitterY;
 
 	this->pOwnerWidget->GetRect(this->drawDestinationRect);
 	this->drawSourceRect = this->sourceClipRect;
@@ -217,6 +227,7 @@ void CImageOverlayEffect::PrepareDrawProperties()
 			this->drawSourceRect.h = pSrcSurface->h;
 		else if (this->drawSourceRect.h > pSrcSurface->h)
 			this->drawSourceRect.h = pSrcSurface->h;
+
 		this->drawX += (int(this->pImageSurface->w) - pSrcSurface->w) / 2; //keep centered
 		this->drawY += (int(this->pImageSurface->h) - pSrcSurface->h) / 2; //keep centered
 	}
@@ -241,6 +252,8 @@ void CImageOverlayEffect::PrepareDrawProperties()
 
 void CImageOverlayEffect::Draw(SDL_Surface& destSurface)
 {
+	PrepareDrawProperties();
+
 	SDL_Surface* pSrcSurface;
 
 	if (this->pTiledSurface)
@@ -406,7 +419,7 @@ bool CImageOverlayEffect::IsCurrentCommandFinished() const
 {
 	if (IsCommandQueueFinished())
 		return true;
-	
+
 	const ImageOverlayCommand command = this->commands[this->index];
 	if (IsTimeBasedCommand(command.type))
 		return this->executionState.remainingTime == 0;

--- a/DROD/ImageOverlayEffect.h
+++ b/DROD/ImageOverlayEffect.h
@@ -127,6 +127,7 @@ private:
 
 	// Properties used for the drawing
 	int drawX, drawY; // Position to draw image after applying any active effects
+	int lastJitterX, lastJitterY; // Store the jitter to make it consistent across redraws without time advancing
 	Uint8 drawAlpha;
 	SDL_Rect drawSourceRect;
 	SDL_Rect drawDestinationRect;

--- a/DRODLib/GameConstants.cpp
+++ b/DRODLib/GameConstants.cpp
@@ -52,7 +52,7 @@ const UINT NEXT_VERSION_NUMBER = 600;
 const WCHAR wszVersionReleaseNumber[] = WS("5.2.0.") WS(STRFY_EXPAND(DROD_VERSION_REVISION));
 #else
 const WCHAR wszVersionReleaseNumber[] = {
-	We('5'),We('.'),We('2'),We('.'),We('0'),We('.'),We('1'),We('0'),We('8'),We('0'),We(0)   // 5.2.0.*
+	We('5'),We('.'),We('2'),We('.'),We('0'),We('.'),We('1'),We('0'),We('8'),We('1'),We(0)   // 5.2.0.*
 };
 #endif
 
@@ -63,7 +63,7 @@ namespace InputCommands
 	const std::unordered_map<DCMD, KeyDefinition*> BuildKeyDefinitions()
 	{
 		std::unordered_map<DCMD, KeyDefinition*> keyDefinitions;
-		
+
 		keyDefinitions[DCMD_NW] = new KeyDefinition(CMD_NW, "MoveNorthwest", MID_MoveNorthwest, SDLK_KP_7, SDLK_7);
 		keyDefinitions[DCMD_N] = new KeyDefinition(CMD_N, "MoveNorth", MID_MoveNorth, SDLK_KP_8, SDLK_8);
 		keyDefinitions[DCMD_NE] = new KeyDefinition(CMD_NE, "MoveNortheast", MID_MoveNortheast, SDLK_KP_9, SDLK_9);

--- a/Master/Linux/ninjamaker
+++ b/Master/Linux/ninjamaker
@@ -207,7 +207,7 @@ X
 	done
 	cat <<X
 includes = ${idirs[@]} -Istatic-libs/include $(${SDL2_CONFIG} --cflags)
-staticlibs = -Lstatic-libs/lib -lSDL2_mixer -lSDL2_ttf -ltheora -lvorbisfile -lvorbis -logg -ljpeg -lmk4 -lfreetype -lpng16 -lnghttp2 -lcurl -lssl -lcrypto -lexpat -ljsoncpp
+staticlibs = -Lstatic-libs/lib -lSDL2_mixer -lSDL2_ttf -ltheora -lvorbisfile -lvorbis -logg -ljpeg -lmk4 -lfreetype -lpng16 -lcurl -lnghttp2 -lssl -lcrypto -lexpat -ljsoncpp
 dynamiclibs = $(${SDL2_CONFIG} --libs) -lSDL2 -lz -lpthread -lm -lrt -ldl
 build $BUILDDIR/drod: link ${ilibs[@]}
 X

--- a/Scripts/Linux/build.sh
+++ b/Scripts/Linux/build.sh
@@ -19,8 +19,9 @@ Usage: $0 ACTION [OPTIONS]
 
 Actions:
     all               Run docker-up, build-deps, build-drod, build-drod-rpg (in that order)
-    docker-up         Start the docker compose container (detached)
+    docker-build      Build the docker image
     docker-down       Stop and remove the docker compose containers
+    docker-up         Start the docker compose container (detached)
     docker-bash       Open bash in the docker container
     build-deps        Build project dependencies inside the docker container
     build-drod        Build DROD (Master/Linux) inside the docker container
@@ -93,10 +94,16 @@ docker_exec() {
 
 # Action implementations
 action_all() {
+    action_docker_build || return $?
     action_docker_up || return $?
     action_build_deps || return $?
     action_build_drod || return $?
     action_build_drod_rpg || return $?
+}
+
+action_docker_build() {
+    echo "=> docker-build: building container"
+    (cd "$SCRIPT_DIR" && docker compose build)
 }
 
 action_docker_up() {
@@ -143,6 +150,9 @@ action_run_tests() {
 case "$ACTION" in
     all)
         action_all
+        ;;
+    docker-build)
+        action_docker_build
         ;;
     docker-up)
         action_docker_up


### PR DESCRIPTION
During room transition when darkness is changing the code works like this:
1. Snapshot room in previous room's darkess into one surface
2. Render the room with new room's darkness into another surface

The issue was, 2. renders into a surface without an offset but the image overlays are rendered with an offset (offset being the offset of Room Widget from the top-left corner of the screen). This resulted in the image 1. looking fine but image 2. having all overlays offset by (163,40). I would attach here a screenshot but I never made one and I don't want to go back to do it now.

The way this was solved was by making sure each time draw is called the draw properties are recalculated since those properties included the rendering offset.

Also jitter had to be stored in a variable so that we can reset the X/Y position on each draw and we want jitter to be consistent between draw calls without any advance.