### PR TITLE
Fix stun effect disappearing

### DIFF
--- a/DROD/StunEffect.cpp
+++ b/DROD/StunEffect.cpp
@@ -56,13 +56,13 @@ CStunEffect::CStunEffect(
 		++turnDuration;
 	}
 
-	this->wExpiresOnTurn = pRoom ? pRoom->GetCurrentGame()->wTurnNo + (turnDuration-1) : 0;
+	this->wExpiresOnTurn = pRoom ? pRoom->GetCurrentGame()->wPlayerTurn + (turnDuration-1) : 0;
 }
 
 //********************************************************************************
 bool CStunEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
 {
-	const UINT wTurnNow = this->pRoomWidget->GetRoom()->GetCurrentGame()->wTurnNo;
+	const UINT wTurnNow = this->pRoomWidget->GetRoom()->GetCurrentGame()->wPlayerTurn;
 	if (wTurnNow >= this->wExpiresOnTurn)
 		return false;
 

--- a/DRODLib/CurrentGame.h
+++ b/DRODLib/CurrentGame.h
@@ -344,10 +344,16 @@ public:
 	bool     bIsDemoRecording;
 	bool     bIsLeavingLevel;
 	bool     bIsGameActive;
+	// Increments on all meaningful actions including: placing a double, switching
+	// clones, ending Temporal Clone recording, answering question. Can be out
+	// of sync with wPlayerTurn.
 	UINT     wTurnNo;
+	// Increments on all actions which cause room processing to happen.
 	UINT     wPlayerTurn;      //player move #
+	// Current cycle count value. Can be out of sync with wPlayerTurn when
+	// temporal clone recording comes into play.
 	UINT     wSpawnCycleCount; //monster move #
-	bool     bHalfTurn;        //half a turn taken 
+	bool     bHalfTurn;        //half a turn taken
 	bool     bBrainSensesSwordsman;
 	UINT     wLastCheckpointX, wLastCheckpointY;
 	vector<UINT> checkpointTurns; //turn #s a checkpoint was activated


### PR DESCRIPTION
It disappeared when:
 - Placing double
 - Answering question
 - Changing selected clone

 This happened because it depended on `wTurnNo` which increases each time player inputs a move but some inputs don't cause processing to happen.

 Also updated the documentation for the various turn variables