### PR TITLE
Fix a game crash with bump effect

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3327,6 +3327,9 @@ SCREENTYPE CGameScreen::ProcessCommand(
 
 			bWasCutScene = this->pCurrentGame->dwCutScene != 0;
 			this->pCurrentGame->ProcessCommand(nCommand, this->sCueEvents);
+			// If player left the room then pRoomWidget will have a reference
+			// to a deleted room, sync them to fix it
+			this->pRoomWidget->SynchRoomToCurrentGame();
 
 			bLeftRoom = this->sCueEvents.HasAnyOccurred(IDCOUNT(CIDA_PlayerLeftRoom), CIDA_PlayerLeftRoom);
 			if (bLeftRoom)


### PR DESCRIPTION
Fix a game crash where removing a bump effect caused the game to cras…h. It happened because the effect list asked for CRoomWidget->pRoom->wCols but it was possible for widget's `pRoom` variable to refer to a deleted room object if the player had left the room but the effect was still playing.

Fixed it by forcibly syncing the room object because between the room being deleted and the sync happening there was a lot of code which, depending on invoked CueEvents, could cause the same issue.