### PR TITLE
Allow storing value of zero in script array vars

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -5859,12 +5859,7 @@ void CCharacter::SetArrayVariable(
 			default: break;
 		}
 
-		if (x == 0) {
-			//Save memory by clearing value
-			scriptArrays[varIndex].erase(arrayIndex);
-		} else {
-			scriptArrays[varIndex][arrayIndex] = x;
-		}
+		scriptArrays[varIndex][arrayIndex] = x;
 		++arrayIndex;
 	}
 }

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -2187,7 +2187,6 @@ void CCurrentGame::DeserializeScriptArrays()
 		while (size) {
 			int key = (int)readBpUINT(buffer, index);
 			int value = (int)readBpUINT(buffer, index);
-			ASSERT(value != 0);
 			scriptArray[key] = value;
 			--size;
 		}

--- a/DRODLib/DbSavedGames.cpp
+++ b/DRODLib/DbSavedGames.cpp
@@ -1002,10 +1002,6 @@ void CDbSavedGame::SerializeScriptArrays()
 		UINT size = 0;
 		for (map<int, int>::const_iterator arrayIt = arrayMap.cbegin();
 			arrayIt != arrayMap.cend(); ++arrayIt) {
-			if (arrayIt->second == 0) {
-				continue; //save space by skipping zero-value entries
-			}
-
 			writeBpUINT(buffer, (UINT)arrayIt->first);
 			writeBpUINT(buffer, (UINT)arrayIt->second);
 			++size;

--- a/Data/Help/1/scriptarray.html
+++ b/Data/Help/1/scriptarray.html
@@ -26,7 +26,7 @@
     If an index that has not been set is accessed, a default value of 0 is returned.</p>
 
     <p><u>Querying full arrays</u></p>
-    <p>Two commands operate over an entire array, to provide a concise way to determine its state:
+    <p>Two commands operate over an entire array, checking all set values to provide a concise way to determine its state:
     <ul>
         <li><a name="wait-for-entry"><b>Wait for array entry</b></a> - Waits until the given array contains a value that satisfies the given comparison to a given value.
         As with other variable commands, an expression can be used in place of a constant value.</li>


### PR DESCRIPTION
When script arrays were added, the implementation erased entries set to zero to save some memory. However, I later added some commands that check an entire array, which the no-zero implementation conflicts with. It now matters if a user sets an array value to zero, and it could cause confusion if full-array commands act as if those values don't exist.

I've changed it so setting an array value to zero no longer erases it. Unset indices still return zero, because they have to return something.