### PR TITLE
Fix assertion beep when using Wait for Open Move with unexpected _MyScriptX

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3620,7 +3620,11 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_WaitForOpenMove:
 				getCommandX(command, px);
 
-				if (!this->IsOpenMove(nGetOX(px), nGetOY(px)))
+				if (
+					px != NO_ORIENTATION
+					&& IsValidOrientation(px)
+					&& !this->IsOpenMove(nGetOX(px), nGetOY(px))
+				)
 					STOP_COMMAND;
 				bProcessNextCommand = true;
 			break;


### PR DESCRIPTION
No more assertion issues when using Wait for open move with No Orientation or invalid value - invalid values are treated as open moves.
