### PR TITLE
Multiline-cutting last command line caused errors.

### DIFF
--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -659,6 +659,8 @@ bool CListBoxWidget::RemoveItem(const void* pKey)
 			//Update set of selected lines to their new list positions.
 			CIDSet remainingSelectedKeys = GetSelectedItems();
 			this->Items.erase(iSeek);
+			// Must rerun the filter before `SelectItems()` as it uses the filtered list
+			UpdateFilter(this->wstrActiveFilter);
 			SelectItems(remainingSelectedKeys);
 
 			if (!this->Items.empty())
@@ -675,8 +677,6 @@ bool CListBoxWidget::RemoveItem(const void* pKey)
 			break;
 		}
 	}
-
-	UpdateFilter(this->wstrActiveFilter);
 
 	//Recalc areas of widget since they may have changed.
 	CalcAreas();
@@ -818,10 +818,10 @@ bool CListBoxWidget::SelectLineStartingWith(const WCHAR wc)
 	UINT wLineNo;
 	for (wLineNo = 0; wLineNo < this->filteredItems.size(); ++wLineNo)
 	{
-		const WCHAR line_wc = this->bIgnoreLeadingArticlesInSort ? 
+		const WCHAR line_wc = this->bIgnoreLeadingArticlesInSort ?
 			towlower(StripLeadingArticle(this->filteredItems[wLineNo]->text)[0]) :
 			towlower(this->filteredItems[wLineNo]->text[0]);
-		
+
 		if (line_wc == wc)
 			break; //found one
 		if (this->bSortAlphabetically &&
@@ -939,7 +939,7 @@ void CListBoxWidget::Paint(
 		drawY = this->y + TEXT_DRAW_Y_OFFSET + this->h - CY_LBOX_ITEM - 1;
 
 		const SURFACECOLOR FilterSeparatorColor = GetSurfaceColor(GetDestSurface(), 102, 102, 102);
-		
+
 		WSTRING message = this->wstrFilterWord;
 		message += wszColon;
 		message += wszSpace;


### PR DESCRIPTION
**ISSUE:** When you have a script with more than one command and cut multiple lines, including the last line, there is an assertion beep, the paste pastes gibberish and there can be a segfault
**DIAGNOSIS:** This was because when removing item we reselect items; but because we only remove the item from `Items` and `SelectItems()` uses `filteredItems` it caused issues with reselecting the items. There likely were also issues with cutting even without the final line but that's where I noticed it
**SOLUTION:** We run the UpdateFilter immediately after the item is removed but before we reselect the remaining items. The function was always called anyway, just outside the loop out of which we would break out anyway