### PR TITLE
Change how Get entity direction works with multi-tile monsters

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3752,7 +3752,13 @@ void CCharacter::Process(
 				} else {
 					CMonster* pMonster = pGame->pRoom->GetMonsterAtSquare(px, py);
 					if (pMonster != NULL){
-						wOrientation = pMonster->wO;
+						if (pMonster->IsPiece()) {
+							if (!bIsSerpentOrGentryii(pMonster->GetIdentity())) {
+								wOrientation = pMonster->GetOwningMonster()->wO;
+							}
+						} else {
+							wOrientation = pMonster->wO;
+						}
 					}
 				}
 


### PR DESCRIPTION
Based on some discussions, I have changed/fixed how `Get entity direction` works with multi-tile monsters:

1. Snake bodies and Gentryii chains are now considered to have an orientation of 4, aka `NO_ORIENTATION`
2. All Rock Giant pieces are now considered to have the same orientation as the main body part (as they probably always should have)

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47324