### PR TITLE
Fix deleted memory access with killed speaker

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -805,6 +805,12 @@ CSubtitleEffect* CRoomWidget::AddSubtitle(
 		}
 	}
 
+	//Make sure the speaker is not deleted if it dies
+	CMonster* pMonster = dynamic_cast<CMonster*>(pCoord);
+	if (pMonster) {
+		pMonster->bSafeToDelete = false;
+	}
+
 	//Speaker text effect.
 	CSubtitleEffect *pSubtitle = new CSubtitleEffect(this, pCoord,
 			wStr.c_str(), Black, color, dwDuration);


### PR DESCRIPTION
**ISSUE:** When Speech is spoken by a monster that gets killed then subtitle effect starts moving randomly (usually to the top-left corner)

**DIAGNOSIS:** Due to memory optimizations introduced in 5.2 dead monsters get deleted at the end of a turn which causes the subtitle effect to watch coordinates that are now unused memory which results in random values being read for speaker's position.

**SOLUTION:** The speaker now gets marked as not safe to delete so the issue is no more. This was partially implemented before but now is fully implemented.