### PR TITLE
 "Replace with Default Script" double processing

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -8377,6 +8377,7 @@ void CCharacter::ReplaceWithDefault(
 
 	//New character neeeds to be flagged and given a new id
 	pNewCharacter->bIsFirstTurn = true;
+	pNewCharacter->bNoTurnZeroProcess = true; // Prevent from double processing on 0th turn
 	pNewCharacter->bNewEntity = true;
 	pNewCharacter->bIsDefaultScript = true;
 	pNewCharacter->dwScriptID = this->pCurrentGame->pHold->GetNewScriptID();


### PR DESCRIPTION
ISSUE: On zeroth turn "Replace with Default Script" causes the character to be processed twice.

DIAGNOSIS: This happens because the newly added character (that replaces the current one) is after the current one so it runs once immediately when placed and then when Preprocess continues with the monster list it processes it again.

SOLUTION: Set flag to not do preprocess on 0th turn for those replacement monsters

Referernce: https://forum.caravelgames.com/viewtopic.php?TopicID=47347&page=0