### PR TITLE
Fix image overlay infinite loop

### DIFF
--- a/DROD/RoomEffectList.cpp
+++ b/DROD/RoomEffectList.cpp
@@ -174,14 +174,14 @@ void CRoomEffectList::RemoveOverlayEffectsInGroup(
 	list<CEffect*>::const_iterator iSeek = this->Effects.begin();
 	while (iSeek != this->Effects.end())
 	{
-		if ((*iSeek)->GetEffectType() == EIMAGEOVERLAY)
+		CEffect* pDelete = *iSeek;
+		++iSeek;
+		if (pDelete->GetEffectType() == EIMAGEOVERLAY)
 		{
 			//Remove from list.
-			CEffect* pDelete = *iSeek;
 			ASSERT(pDelete);
 			if (pDelete->RequestsRetainOnClear() && !bForceClearAll)
 			{
-				++iSeek;
 				continue;
 			}
 
@@ -189,12 +189,9 @@ void CRoomEffectList::RemoveOverlayEffectsInGroup(
 
 			if (pDeleteOverlay->getGroup() == clearGroup) {
 				DirtyTilesForRects(pDelete->dirtyRects);  //touch up area before deleting
-				++iSeek;
 				this->Effects.remove(pDelete);
 				delete pDelete;
 			}
 		}
-		else
-			++iSeek;
 	}
 }


### PR DESCRIPTION
ISSUE: Image Overlay's `CancelGroup` freezes the game.

DIAGNOSIS: This happens if you provide a group ID and there is at least one overlay image that does not belong to this group; this us because the iteration is not continued in this case.

SOLUTION: Reworked the loop to always continue the iteration before doing any processing to ensure the loop will always go on.

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47348&page=0