### PR TITLE
Fix double count of long monsters

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4838,7 +4838,7 @@ int CCharacter::CountEntityType(
 			}
 
 			if (pMonster->wType == pflags) {
-				if (pMonster->IsPiece()) {
+				if (pMonster->IsPiece() || pMonster->IsLongMonster()) {
 					pMonster = pMonster->GetOwningMonsterConst();
 					if (seenHeads.count(pMonster)) {
 						continue;

--- a/DRODLibTests/DRODLibTests.2019.vcxproj
+++ b/DRODLibTests/DRODLibTests.2019.vcxproj
@@ -409,6 +409,7 @@
     <ClCompile Include="src\tests\Scripting\Build\BuildingTarstuff.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildSanityTest.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\RemovingTransparentObjects.cpp" />
+    <ClCompile Include="src\tests\Scripting\CountEntityType.cpp" />
     <ClCompile Include="src\tests\Scripting\GoToLevelEntrance.cpp" />
     <ClCompile Include="src\tests\Scripting\ImperativeFriendly.cpp" />
     <ClCompile Include="src\tests\Scripting\ImperativePushable\PushableByBody.cpp" />

--- a/DRODLibTests/DRODLibTests.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTests.2019.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClCompile Include="src\tests\Scripting\GoToLevelEntrance.cpp">
       <Filter>Tests\Scripting</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Scripting\CountEntityType.cpp">
+      <Filter>Tests\Scripting</Filter>
+    </ClCompile>
     <ClCompile Include="src\tests\Scripting\Imperative_BrainPathmapObstacle.cpp">
       <Filter>Tests\Scripting</Filter>
     </ClCompile>

--- a/DRODLibTests/src/tests/Scripting/CountEntityType.cpp
+++ b/DRODLibTests/src/tests/Scripting/CountEntityType.cpp
@@ -1,0 +1,57 @@
+#include "../../test-include.hpp"
+#include "../../CAssert.h"
+
+TEST_CASE("Scripting: CountEntityType", "[game][scripting][imperative]") {
+	RoomBuilder::ClearRoom();
+	RoomBuilder::PlotRect(T_WALL, 10, 10, 15, 12);
+	RoomBuilder::PlotRect(T_FLOOR, 11, 11, 14, 11);
+	RoomBuilder::Plot(T_FLOOR, 13, 12);
+	RoomBuilder::AddMonster(M_STALWART, 11, 11, E);
+	RoomBuilder::AddMonster(M_EYE, 14, 11, E);
+
+	CCharacter* pScript = RoomBuilder::AddCharacter(1,1);
+	RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_SetPlayerStealth, Stealth_On);
+
+	SECTION("Count roaches") {
+		RoomBuilder::AddMonster(M_ROACH, 15, 15, E);
+		RoomBuilder::AddMonster(M_EYE, 16, 15, E);
+		RoomBuilder::AddMonster(M_GOBLIN, 17, 15, E);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 0, 0, 37, 31, M_ROACH);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+
+	SECTION("Do not double count serpents if area both head and body") {
+		CSerpent* serpent = DYN_CAST(CSerpent*, CMonster*, RoomBuilder::AddMonster(M_SERPENT, 10, 10, E));
+		RoomBuilder::AddSerpentPiece(serpent, 9, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 8, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 7, 10);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 0, 0, 37, 31, M_SERPENT);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+
+	SECTION("Count serpent's head") {
+		CSerpent* serpent = DYN_CAST(CSerpent*, CMonster*, RoomBuilder::AddMonster(M_SERPENT, 10, 10, E));
+		RoomBuilder::AddSerpentPiece(serpent, 9, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 8, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 7, 10);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 10, 10, 0, 0, M_SERPENT);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+
+	SECTION("Count serpent's body") {
+		CSerpent* serpent = DYN_CAST(CSerpent*, CMonster*, RoomBuilder::AddMonster(M_SERPENT, 10, 10, E));
+		RoomBuilder::AddSerpentPiece(serpent, 9, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 8, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 7, 10);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 7, 10, 0, 0, M_SERPENT);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+}


### PR DESCRIPTION
**ISSUE:** Scripting command 'Count entity type' double counts long monsters (serpents, gentryii, rock giants)
**DIAGNOSIS:** The code that is supposed to prevent counting each body part as a separate monsters works correctly, but when the head is encountered it doesn't check for duplicates. Therefore if the area contains only the head or only the body parts it would count correctly.
**SOLUTION:** Heads are now also included in the duplicate-exclusion logic. Plus added a few simple tests to cover this.

REF: https://forum.caravelgames.com/viewtopic.php?TopicID=47350&page=0