### PR TITLE
Prevent ctrl from changing selected item in list.

### DIFF
--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -1183,7 +1183,11 @@ void CListBoxWidget::HandleKeyDown(
 			break;
 
 		default:
-			if (this->bAllowFiltering && !(KeyboardEvent.keysym.mod & KMOD_SHIFT)) {
+			if (
+				this->bAllowFiltering
+				&& !(KeyboardEvent.keysym.mod & KMOD_SHIFT)
+				&& !(KeyboardEvent.keysym.mod & KMOD_CTRL)
+			) {
 				const WCHAR character = KeyboardEvent.keysym.sym == SDLK_SPACE ? We(' ') : TranslateUnicodeKeysym(KeyboardEvent.keysym);
 
 				if (IsValidFilterCharacter(character)) {
@@ -1199,7 +1203,7 @@ void CListBoxWidget::HandleKeyDown(
 				if (KeyboardEvent.keysym.mod & KMOD_CTRL)
 				{
 					const WCHAR wc = TranslateUnicodeKeysym(KeyboardEvent.keysym);
-					if (SelectLineStartingWith(wc))
+					if (wc != 0 && SelectLineStartingWith(wc))
 						wNewCursorLine = this->wCursorLine;
 				}
 			}


### PR DESCRIPTION
ISSUE: When focus is on the list of commands in the editor pressing Ctrl alone will cause the topmost command to be selected.

DIAGNOSIS: It's the hotkey item selection that causes this. There was no logic that checked if the input character is non-empty and so it selected the line that started with 0 byte, which I guess is any line which means the first line matched it.

SOLUTION: Added a check to exclude null character from that logic. I also made it so that filtering does not respond to ctrl characters at all so there are no issues using both filtering AND hotkeys.

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47351&page=0