### PR TITLE
Fix command options still visible when filtered out all of them.

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5164,6 +5164,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 
 	this->pActionListBox->SelectLine(0);
 	this->pActionListBox->SetAllowFiltering(true);
+	this->pActionListBox->SetFilterDispatchOnEmpty(true);
 }
 
 //*****************************************************************************

--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -1291,6 +1291,9 @@ void CListBoxWidget::UpdateFilter(WSTRING wstrFilter)
 			CEventHandlerWidget *pEventHandler = GetEventHandlerWidget();
 			if (pEventHandler) pEventHandler->OnSelectChange(GetTagNo());
 		}
+	} else if (this->bFilterDispatchOnEmpty) {
+		CEventHandlerWidget *pEventHandler = GetEventHandlerWidget();
+		if (pEventHandler) pEventHandler->OnSelectChange(GetTagNo());
 	}
 
 }

--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -79,6 +79,7 @@ CListBoxWidget::CListBoxWidget(
 	, wDraggingLineNo(UINT(-1))
 	, bRearranged(false)
 	, bAllowFiltering(false)
+	, bFilterDispatchOnEmpty(false)
 	, wstrActiveFilter(wszEmpty)
 {
 	if (CListBoxWidget::wstrFilterWord.size() == 0)

--- a/FrontEndLib/ListBoxWidget.h
+++ b/FrontEndLib/ListBoxWidget.h
@@ -121,6 +121,7 @@ public:
 	bool           SelectLineWithText(const WCHAR* pText);
 	void           SelectMultipleItems(const bool bVal);
 	void           SetAllowFiltering(const bool bVal) { this->bAllowFiltering = bVal; }
+	void           SetFilterDispatchOnEmpty(const bool bVal) { this->bFilterDispatchOnEmpty = bVal; }
 	void           SetHotkeyItemSelection(const bool bVal=true) {this->bHotkeyItemSelection = bVal;}
 	void           SetItemColor(const UINT dwKey, const SDL_Color& color);
 	void           SetItemColorAtLine(const UINT index, const SDL_Color& color);
@@ -172,6 +173,8 @@ protected:
 	UINT           wDraggingLineNo;  //this line # is being moved in the list
 	bool           bRearranged;      //choices were rearranged on mouse drag
 	bool           bAllowFiltering;  //Allow filtering by typing text
+	/// Dispatch change event when filtering and the list becomes empty
+	bool           bFilterDispatchOnEmpty;
 	WSTRING        wstrActiveFilter;
 
 private:


### PR DESCRIPTION
**ISSUE:** In add/edit command dialog when you type a filter out that hides all entries from the actions list whatever option was last selected its details are still visible on the right making it seem like you are editing it (if you for example forget a space between "go to"). When focus on the list is lost it then auto selects "Appear" while still keeping the right-half of the dialog populated with whatever was there earlier.

**DIAGNOSIS:** The select item event handler is not triggered when the filter empties the list; this prevents the dialog from updating itself.

**SOLUTION:** List Box Widget can now be configured to dispatch the event if the list is emptied to select nothing. I did it as an opt-in option to avoid accidentally breaking something in any other existing list.

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47352&page=0&message=457778#457778