### PR TITLE
Speech sound issues

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -2467,7 +2467,6 @@ void CCharacterDialogWidget::OnClick(
 			} else {
 				//Command addition was canceled.
 				//Clear any data generated for the command.
-				ASSERT(!this->pSound || !this->pSound->dwDataID);	//should be fresh (not added to DB yet)
 				delete this->pSound;
 				this->pSound = NULL;
 			}

--- a/DRODLib/DbSpeech.cpp
+++ b/DRODLib/DbSpeech.cpp
@@ -284,7 +284,6 @@ bool CDbSpeech::UpdateNew()
 	//Save new sound clip, if set.
 	if (this->pSound)
 	{
-		ASSERT(!this->dwDataID);   //no sound data should be associated with this speech object yet
 		ASSERT(this->bDirtySound); //dirty bit for sound should be set
 		if (this->pSound->Update())
 			this->dwDataID = this->pSound->dwDataID;
@@ -378,7 +377,7 @@ MESSAGE_ID CDbSpeech::SetProperty(
 
 //*****************************************************************************
 MESSAGE_ID CDbSpeech::SetProperty(
-//Used during XML data import.                      
+//Used during XML data import.
 //According to pType, convert string to proper datatype and member
 //
 //Returns: whether operation was successful


### PR DESCRIPTION
Remove obsolete assert with adding sound to speech in custom character.
    
**ISSUE:** When you add a new speech command to a custom hold character and select a voice line for it then return to edit level screen you get an assertion.
    
**DIAGNOSIS:** In the previous DROD versions adding sound to speech would immediately open the file dialog to chose the file. This would attach the data without saving it. From 5.2 we use a Sound management dialog and now sounds are immediately stored in the database meaning that the assertion will always trigger because the sound will always have data ID.
    
**SOLUTION:** Removed the obsolete assertion.

----


Remove obsolete assert with speech cancelling.
    
**ISSUE:** When you add a new speech command and select a voice line for it but press "Cancel" instead of "Add" you get a beep.
    
**DIAGNOSIS:** In the previous DROD versions adding sound to speech would immediately open the file dialog to chose the file. This would attach the data without saving it. From 5.2 we use a Sound management dialog and now sounds are immediately stored in the database meaning that the assertion will always trigger with sound attached.

----

Reference (this fixes issue 1 and 3 from this thread): https://forum.caravelgames.com/viewtopic.php?TopicID=47353