### PR TITLE
Ini option to prevent sound data from deletion when deleting speech.

### DIFF
--- a/DROD/Main.cpp
+++ b/DROD/Main.cpp
@@ -701,6 +701,10 @@ MESSAGE_ID Init(
 				CScreen::eFullScreenMode = SCREENLIB::FULLSCREENMODE(mode);
 			}
 		}
+
+		if (CFiles::GetGameProfileString(INISection::Customizing, INIKey::KeepSoundsFromDeletedSpeech, strIniValue) && atoi(strIniValue.c_str()) == 1) {
+			g_pTheDB->Speech.bKeepSoundsFromDeletedSpeech = true;
+		}
 	}
 
 	//Init the internet interface.
@@ -1924,6 +1928,7 @@ void RepairMissingINIKeys(const bool bFullVersion)
 	AddIfMissing(INISection::Customizing, INIKey::RoomTransitionSpeed, "500");
 	AddIfMissing(INISection::Customizing, INIKey::ValidateSavesOnImport, "1");
 	AddIfMissing(INISection::Customizing, INIKey::Windib, "1");
+	AddIfMissing(INISection::Customizing, INIKey::KeepSoundsFromDeletedSpeech, "0");
 
 	AddIfMissing(INISection::Graphics, "Clock", "Clock");
 	AddIfMissing(INISection::Graphics, "General", "GeneralTiles");

--- a/DRODLib/DbSpeech.cpp
+++ b/DRODLib/DbSpeech.cpp
@@ -53,9 +53,11 @@ void CDbSpeeches::Delete(
 	const UINT dwTextMID = (UINT) (p_MessageID(row));
 	if (dwTextMID)
 		DeleteMessage(static_cast<MESSAGE_ID>(dwTextMID));
-	const UINT dwDataID = (UINT) (p_DataID(row));
-	if (dwDataID)
-		g_pTheDB->Data.Delete(dwDataID);
+	if (!this->bKeepSoundsFromDeletedSpeech) {
+		const UINT dwDataID = (UINT) (p_DataID(row));
+		if (dwDataID)
+			g_pTheDB->Data.Delete(dwDataID);
+	}
 
 	SpeechView.RemoveAt(dwSpeechRowI);
 
@@ -378,7 +380,7 @@ MESSAGE_ID CDbSpeech::SetProperty(
 
 //*****************************************************************************
 MESSAGE_ID CDbSpeech::SetProperty(
-//Used during XML data import.                      
+//Used during XML data import.
 //According to pType, convert string to proper datatype and member
 //
 //Returns: whether operation was successful

--- a/DRODLib/DbSpeech.h
+++ b/DRODLib/DbSpeech.h
@@ -45,13 +45,18 @@ protected:
 	friend class CDb;
 
 	CDbSpeeches()
-		: CDbVDInterface<CDbSpeech>(V_Speech, p_SpeechID)
+		: CDbVDInterface<CDbSpeech>(V_Speech, p_SpeechID),
+		bKeepSoundsFromDeletedSpeech(false)
 	{}
 
 public:
 	void              Delete(const UINT dwSpeechID);
 	virtual bool      ExportText(const UINT dwSpeechID, CDbRefs &dbRefs, CStretchyBuffer &str);
 	virtual void      ExportXML(const UINT dwSpeechID, CDbRefs &dbRefs, string &str, const bool bRef=false);
+
+	/// By default deleting speech deletes associated sound data. With this set
+	/// to true the data is kept and has to be managed manually.
+	bool              bKeepSoundsFromDeletedSpeech;
 };
 
 //*****************************************************************************

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -37,6 +37,7 @@ namespace INIKey
 	DEF(Style);
 	DEF(ValidateSavesOnImport);
 	DEF(Windib);
+	DEF(KeepSoundsFromDeletedSpeech);
 }
 
 namespace Settings

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -37,6 +37,9 @@ namespace INIKey
 	DEF(Style);
 	DEF(ValidateSavesOnImport);
 	DEF(Windib);
+	/// By default deleting Speech also deletes the sound data attached to it.
+	/// With this enabled the sound data will be kept and has to be deleted manually.
+	DEF(KeepSoundsFromDeletedSpeech);
 }
 
 namespace Settings

--- a/Data/Help/1/customizing.html
+++ b/Data/Help/1/customizing.html
@@ -143,6 +143,13 @@ or add additional sound effects to a line (semicolon-separated).</p>
 		<a name="windib"><b>Windib</b></a>: By default, DROD uses Windib drivers under Windows.
 		Set this parameter to 0 to use DirectX drivers instead.
 	</li>
+	<li>
+		<a name="KeepSoundsFromDeletedSpeech"><b>KeepSoundsFromDeletedSpeech</b></a>:
+		By default when you delete a Speech command with attached sound the sound
+		data also gets deleted. Set this to 1 if you want the attached sound data
+		to be retained. This is helpful if you find yourself often copying commands
+		and accidentally losing data.
+	</li>
 </ul>
 
 <p>


### PR DESCRIPTION
**ISSUE:** When deleting speech that has sound data attached to it the data is also removed from the hold. This can be useful if you add basic voice lines but can be really annoying if you do any more complex work or find yourself often copying and deleting scripting commands.

**SOLUTION:** A new ini option was added `KeepSoundsFromDeletedSpeech` that changes this behavior. When set to 1 deleting speech will no longer delete attached data.

Reference bug report: https://forum.caravelgames.com/viewtopic.php?TopicID=47353&page=0#457794
Reference feature request: https://forum.caravelgames.com/viewtopic.php?TopicID=47358&page=0#457793