### PR TITLE
RPG: Add additional array variable utility script commands

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -5372,6 +5372,7 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_X, g_pTheDB->GetMessageText(MID_VarRoomX));
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_Y, g_pTheDB->GetMessageText(MID_VarRoomY));
 	this->pVarListBox->AddItem(ScriptVars::P_RETURN_X, g_pTheDB->GetMessageText(MID_VarReturnX));
+	this->pVarListBox->AddItem(ScriptVars::P_RETURN_Y, g_pTheDB->GetMessageText(MID_VarReturnY));
 
 	this->pVarListBox->AddItem(ScriptVars::P_TOTALMOVES, g_pTheDB->GetMessageText(MID_TotalMoves));
 //	this->pVarListBox->AddItem(ScriptVars::P_TOTALTIME, g_pTheDB->GetMessageText(MID_TotalTime)); //hidden from script use -- not correctly supported for deterministic move replay

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4053,6 +4053,20 @@ const
 			wstr += command.label;
 		}
 		break;
+		case CCharacterCommand::CC_PushToArrayVar:
+		{
+			const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(command.w);
+			wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
+			wstr += wszSpace;
+			wstr += command.label;
+		}
+		break;
+		case CCharacterCommand::CC_PopFromArrayVar:
+		{
+			const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(command.w);
+			wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
+		}
+		break;
 		case CCharacterCommand::CC_ClearArrayVar:
 		{
 			const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(command.x);
@@ -4446,6 +4460,10 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		case CCharacterCommand::CC_WorldMapIcon:
 		case CCharacterCommand::CC_WorldMapImage:
 		case CCharacterCommand::CC_GoToWorldMap:
+		case CCharacterCommand::CC_CountEntityType:
+		case CCharacterCommand::CC_CountItem:
+		case CCharacterCommand::CC_CountItemGroup:
+		case CCharacterCommand::CC_PopFromArrayVar:
 			if (bLastWasIfCondition || wLogicNestDepth)
 				wstr += wszQuestionMark;	//questionable If condition
 		break;
@@ -4500,6 +4518,7 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		}
 		break;
 		case CCharacterCommand::CC_ArrayVarSet:
+		case CCharacterCommand::CC_PushToArrayVar:
 			if (bLastWasIfCondition || wLogicNestDepth)
 				wstr += wszQuestionMark;	//questionable If condition
 			//no break
@@ -4670,6 +4689,8 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_VarSetAt, g_pTheDB->GetMessageText(MID_VarSetAt));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSet, g_pTheDB->GetMessageText(MID_ArrayVarSet));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarSetAt, g_pTheDB->GetMessageText(MID_ArrayVarSetAt));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_PushToArrayVar, g_pTheDB->GetMessageText(MID_PushToArrayVar));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_PopFromArrayVar, g_pTheDB->GetMessageText(MID_PopFromArrayVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_ClearArrayVar, g_pTheDB->GetMessageText(MID_ClearArrayVar));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_Speech, g_pTheDB->GetMessageText(MID_Speech));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_TurnIntoMonster, g_pTheDB->GetMessageText(MID_TurnIntoMonster));
@@ -5641,6 +5662,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT WORLD_MAP_IMAGE[] = { TAG_IMAGEDISPLAY, TAG_X_COORD, TAG_Y_COORD, 0 };
 	static const UINT ARRAYVARQUERY[] = { TAG_ARRAYVARLIST, TAG_VARCOMPLIST2, TAG_VARVALUE, 0 };
 	static const UINT ENTITY_LIST[] = { TAG_ENTITY_LISTBOX, 0 };
+	static const UINT ARRAYVARPUSH[] = { TAG_GOTOLABELTEXT, TAG_VARADD, TAG_ARRAYVAR_REMOVE, TAG_ARRAYVARLIST, 0 };
 
 	static const UINT* activeWidgets[CCharacterCommand::CC_Count] = {
 		NO_WIDGETS,
@@ -5747,6 +5769,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		ENTITY_LIST,        //CC_CountEntityType
 		ITEMS,              //CC_CountItem
 		WAITFORITEMGROUP,   //CC_CountItemGroup
+		ARRAYVARPUSH,       //CC_PushToArrayVar
+		CLEARARRAYVAR,      //CC_PopFromArrayVar
 	};
 
 	static const UINT NUM_LABELS = 34;
@@ -5790,6 +5814,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT ARRAYSET_L[] =               { TAG_ARRAYINDEX_LABEL, TAG_ARRAYVAR_TEXTLABEL, 0 };
 	static const UINT OPENTILE_L[] =               { TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, 0 };
 	static const UINT ATTACKTILE_L[] =             { TAG_NO_DEF_LABEL, 0 };
+	static const UINT ARRAYPUSH_L[] =              { TAG_ARRAYVAR_TEXTLABEL, 0 };
 
 	static const UINT* activeLabels[CCharacterCommand::CC_Count] = {
 		NO_LABELS,
@@ -5896,6 +5921,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_CountEntityType
 		NO_LABELS,          //CC_CountItem
 		NO_LABELS,          //CC_CountItemType
+		ARRAYPUSH_L,        //CC_PushToArrayVar
+		NO_LABELS,          //CC_PopFromArrayVar
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -6853,6 +6880,23 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		}
 		break;
 
+		case CCharacterCommand::CC_PushToArrayVar:
+		{
+			this->pCommand->w = this->pArrayVarListBox->GetSelectedItem();
+			CTextBoxWidget* pVarText = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_GOTOLABELTEXT));
+			ASSERT(pVarText);
+			this->pCommand->label = pVarText->GetText();
+			AddCommand();
+		}
+		break;
+		case CCharacterCommand::CC_PopFromArrayVar:
+		{
+			this->pCommand->w = this->pArrayVarListBox->GetSelectedItem();
+			AddCommand();
+		}
+		break;
+
 		case CCharacterCommand::CC_ClearArrayVar:
 		{
 			this->pCommand->x = this->pArrayVarListBox->GetSelectedItem();
@@ -7423,6 +7467,20 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 			ASSERT(pVarText);
 			pVarOperand->SetText(_itoW(this->pCommand->flags, temp, 10));
 			pVarText->SetText(this->pCommand->label.c_str());
+		}
+		break;
+		case CCharacterCommand::CC_PushToArrayVar:
+		{
+			this->pArrayVarListBox->SelectItem(this->pCommand->w);
+			CTextBoxWidget* pVarText = DYN_CAST(CTextBoxWidget*, CWidget*,
+				this->pAddCommandDialog->GetWidget(TAG_GOTOLABELTEXT));
+			ASSERT(pVarText);
+			pVarText->SetText(this->pCommand->label.c_str());
+		}
+		break;
+		case CCharacterCommand::CC_PopFromArrayVar:
+		{
+			this->pArrayVarListBox->SelectItem(this->pCommand->w);
 		}
 		break;
 		case CCharacterCommand::CC_ClearArrayVar:
@@ -8422,6 +8480,57 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 	}
 	break;
 
+	case CCharacterCommand::CC_PushToArrayVar:
+	{
+		parseChar('"');
+		WSTRING varName;
+		const bool bRes = getTextToLastQuote(pText, pos, varName);
+		if (!bRes)
+		{
+			delete pCommand;
+			return NULL;
+		}
+
+		UINT tempIndex = 0;
+		pCommand->w = findTextMatch(this->pArrayVarListBox, varName.c_str(), tempIndex, bFound);
+		if (!bFound)
+		{
+			pCommand->w = AddVar(varName.c_str());
+			if (!pCommand->w)
+			{
+				delete pCommand;
+				return NULL;
+			}
+		}
+		skipWhitespace;
+		pCommand->label = pText + pos;
+	}
+	break;
+	case CCharacterCommand::CC_PopFromArrayVar:
+	{
+		parseChar('"');
+		WSTRING varName;
+		const bool bRes = getTextToLastQuote(pText, pos, varName);
+		if (!bRes)
+		{
+			delete pCommand;
+			return NULL;
+		}
+
+		UINT tempIndex = 0;
+		pCommand->w = findTextMatch(this->pArrayVarListBox, varName.c_str(), tempIndex, bFound);
+		if (!bFound)
+		{
+			pCommand->w = AddVar(varName.c_str());
+			if (!pCommand->w)
+			{
+				delete pCommand;
+				return NULL;
+			}
+		}
+	}
+	break;
+
 	case CCharacterCommand::CC_ClearArrayVar:
 	{
 		parseChar('"');
@@ -9176,6 +9285,27 @@ WSTRING CCharacterDialogWidget::toText(
 		}
 		wstr += wszSpace;
 		wstr += c.label;
+	}
+	break;
+
+	case CCharacterCommand::CC_PushToArrayVar:
+	{
+		UINT varId = c.w;
+		const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(varId);
+		wstr += wszQuote;
+		wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
+		wstr += wszQuote;
+		wstr += wszSpace;
+		wstr += c.label;
+	}
+	break;
+	case CCharacterCommand::CC_PopFromArrayVar:
+	{
+		UINT varId = c.w;
+		const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(varId);
+		wstr += wszQuote;
+		wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
+		wstr += wszQuote;
 	}
 	break;
 

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4062,6 +4062,7 @@ const
 		}
 		break;
 		case CCharacterCommand::CC_PopFromArrayVar:
+		case CCharacterCommand::CC_ArrayVarRange:
 		{
 			const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(command.w);
 			wstr += WCSlen(wszVarName) ? wszVarName : wszQuestionMark;
@@ -4464,6 +4465,7 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 		case CCharacterCommand::CC_CountItem:
 		case CCharacterCommand::CC_CountItemGroup:
 		case CCharacterCommand::CC_PopFromArrayVar:
+		case CCharacterCommand::CC_ArrayVarRange:
 			if (bLastWasIfCondition || wLogicNestDepth)
 				wstr += wszQuestionMark;	//questionable If condition
 		break;
@@ -4728,6 +4730,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 	this->pActionListBox->AddItem(CCharacterCommand::CC_CountEntityType, g_pTheDB->GetMessageText(MID_CountEntityType));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_CountItem, g_pTheDB->GetMessageText(MID_CountItem));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_CountItemGroup, g_pTheDB->GetMessageText(MID_CountItemGroup));
+	this->pActionListBox->AddItem(CCharacterCommand::CC_ArrayVarRange, g_pTheDB->GetMessageText(MID_ArrayVarRange));
 
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetDarkness, g_pTheDB->GetMessageText(MID_SetDarkness));
 	this->pActionListBox->AddItem(CCharacterCommand::CC_SetCeilingLight, g_pTheDB->GetMessageText(MID_SetCeilingLight));
@@ -5771,6 +5774,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		WAITFORITEMGROUP,   //CC_CountItemGroup
 		ARRAYVARPUSH,       //CC_PushToArrayVar
 		CLEARARRAYVAR,      //CC_PopFromArrayVar
+		CLEARARRAYVAR,      //CC_ArrayVarRange
 	};
 
 	static const UINT NUM_LABELS = 34;
@@ -5923,6 +5927,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_LABELS,          //CC_CountItemType
 		ARRAYPUSH_L,        //CC_PushToArrayVar
 		NO_LABELS,          //CC_PopFromArrayVar
+		NO_LABELS,          //CC_ArrayVarRange
 	};
 	ASSERT(this->pActionListBox->GetSelectedItem() < CCharacterCommand::CC_Count);
 
@@ -6891,6 +6896,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		}
 		break;
 		case CCharacterCommand::CC_PopFromArrayVar:
+		case CCharacterCommand::CC_ArrayVarRange:
 		{
 			this->pCommand->w = this->pArrayVarListBox->GetSelectedItem();
 			AddCommand();
@@ -7479,6 +7485,7 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 		}
 		break;
 		case CCharacterCommand::CC_PopFromArrayVar:
+		case CCharacterCommand::CC_ArrayVarRange:
 		{
 			this->pArrayVarListBox->SelectItem(this->pCommand->w);
 		}
@@ -8507,6 +8514,7 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 	}
 	break;
 	case CCharacterCommand::CC_PopFromArrayVar:
+	case CCharacterCommand::CC_ArrayVarRange:
 	{
 		parseChar('"');
 		WSTRING varName;
@@ -9300,6 +9308,7 @@ WSTRING CCharacterDialogWidget::toText(
 	}
 	break;
 	case CCharacterCommand::CC_PopFromArrayVar:
+	case CCharacterCommand::CC_ArrayVarRange:
 	{
 		UINT varId = c.w;
 		const WCHAR* wszVarName = this->pArrayVarListBox->GetTextForKey(varId);

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -952,6 +952,7 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 					case (UINT)ScriptVars::P_TAR_SWAP:
 					case (UINT)ScriptVars::P_GEL_SWAP:
 					case (UINT)ScriptVars::P_RETURN_X:
+					case (UINT)ScriptVars::P_RETURN_Y:
 						//display nothing
 					break;
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3582,6 +3582,28 @@ void CCharacter::Process(
 				bProcessNextCommand = true;
 			}
 			break;
+			case CCharacterCommand::CC_PushToArrayVar:
+			{
+				PushToArrayVar(command, pGame, CueEvents);
+
+				//When a var is set, this might get it out of an otherwise infinite loop.
+				++wVarSets;
+				wTurnCount = 0;
+
+				bProcessNextCommand = true;
+			}
+			break;
+			case CCharacterCommand::CC_PopFromArrayVar:
+			{
+				int value = PopFromArrayVar(command, pGame);
+				pGame->ProcessCommandSetVar(CueEvents, ScriptVars::P_RETURN_X, value);
+				//When a var is set, this might get it out of an otherwise infinite loop.
+				++wVarSets;
+				wTurnCount = 0;
+
+				bProcessNextCommand = true;
+			}
+			break;
 			case CCharacterCommand::CC_WaitForArrayEntry:
 			{
 				if (!DoesArrayVarSatisfy(command, pGame))
@@ -4221,6 +4243,71 @@ void CCharacter::SetArrayVariable(
 		scriptArrays[varIndex][arrayIndex] = x;
 		++arrayIndex;
 	}
+}
+
+//*****************************************************************************
+void CCharacter::PushToArrayVar(
+	const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents)
+{
+	int arrayIndex = 0;
+	UINT varIndex = command.w;
+	if (pGame->pHold && !pGame->pHold->IsArrayVar(varIndex))
+		return; //Don't set normal var as an array var
+
+	ScriptArrayMap& scriptArrays = pGame->scriptArrays;
+	const ScriptArrayMap::iterator& finder = scriptArrays.find(varIndex);
+
+	//Array vars are stored as ordered maps, so the value with the highest key
+	//can always be found with the reverse iterator.
+	if (finder != scriptArrays.end()) {
+		map<int, int>& array = finder->second;
+		if (!array.empty()) {
+			int finalIndex = array.rbegin()->first;
+			arrayIndex = finalIndex + 1;
+		}
+	}
+
+	vector<WSTRING> expressions = WCSExplode(command.label, *wszSemicolon);
+	for (vector<WSTRING>::const_iterator expression = expressions.begin();
+		expression != expressions.end(); ++expression) {
+		if (!ScriptVars::IsIndexInArrayRange(arrayIndex)) {
+			break;
+		}
+
+		UINT index = 0;
+		int operand = parseExpression(expression->c_str(), index, pGame, this);
+		scriptArrays[varIndex][arrayIndex] = operand;
+		++arrayIndex;
+	}
+}
+
+//*****************************************************************************
+int CCharacter::PopFromArrayVar(
+	const CCharacterCommand& command, CCurrentGame* pGame)
+{
+	UINT varId = command.w;
+	if (pGame->pHold && !pGame->pHold->IsArrayVar(varId))
+		return 0;
+
+	ScriptArrayMap& scriptArrays = pGame->scriptArrays;
+	const ScriptArrayMap::iterator& finder = scriptArrays.find(varId);
+
+	if (finder == scriptArrays.end()) {
+		return 0;
+	}
+
+	map<int, int>& array = finder->second;
+	if (array.empty()) {
+		return 0;
+	}
+
+	//Array vars are stored as ordered maps, so the value with the highest key
+	//can always be found with the reverse iterator.
+	map<int, int>::const_reverse_iterator iter = array.rbegin();
+	int value = iter->second;
+	array.erase(iter->first);
+
+	return value;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -5193,11 +5193,11 @@ int CCharacter::CountArrayVarEntries(const CCharacterCommand& command, CCurrentG
 
 //*****************************************************************************
 //Returns: highest and lower indices in an array var. If the array is empty or
-//not initialized, return otherwise impossible (-1, 1) pair.
+//not initialized, return otherwise impossible (1, -1) pair.
 std::pair<int, int> CCharacter::GetArrayRange(
 	const CCharacterCommand& command, CCurrentGame* pGame) const
 {
-	std::pair<int, int> range = std::make_pair<int, int>(-1, 1);
+	std::pair<int, int> range = std::make_pair<int, int>(1, -1);
 
 	const UINT varId = command.w;
 	if (pGame->pHold && !pGame->pHold->IsArrayVar(varId))
@@ -5216,8 +5216,8 @@ std::pair<int, int> CCharacter::GetArrayRange(
 
 	//As array vars are stored as ordered maps, we can use iterator and reverse
 	//iterator to end the first and last indices.
-	range.first = array.rbegin()->first;
-	range.second = array.begin()->first;
+	range.first = array.begin()->first;
+	range.second = array.rbegin()->first;
 
 	return range;
 }

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3618,6 +3618,18 @@ void CCharacter::Process(
 				bProcessNextCommand = true;
 			}
 			break;
+			case CCharacterCommand::CC_ArrayVarRange:
+			{
+				std::pair<int, int> range = GetArrayRange(command, pGame);
+				pGame->ProcessCommandSetVar(CueEvents, ScriptVars::P_RETURN_X, range.first);
+				pGame->ProcessCommandSetVar(CueEvents, ScriptVars::P_RETURN_Y, range.second);
+				//When a var is set, this might get it out of an otherwise infinite loop.
+				++wVarSets;
+				wTurnCount = 0;
+
+				bProcessNextCommand = true;
+			}
+			break;
 
 			case CCharacterCommand::CC_SetPlayerAppearance:
 			{
@@ -5177,6 +5189,37 @@ int CCharacter::CountArrayVarEntries(const CCharacterCommand& command, CCurrentG
 	}
 
 	return count;
+}
+
+//*****************************************************************************
+//Returns: highest and lower indices in an array var. If the array is empty or
+//not initialized, return otherwise impossible (-1, 1) pair.
+std::pair<int, int> CCharacter::GetArrayRange(
+	const CCharacterCommand& command, CCurrentGame* pGame) const
+{
+	std::pair<int, int> range = std::make_pair<int, int>(-1, 1);
+
+	const UINT varId = command.w;
+	if (pGame->pHold && !pGame->pHold->IsArrayVar(varId))
+		return range; //Not for non-arrays, but we have to return something
+
+	ScriptArrayMap& scriptArrays = pGame->scriptArrays;
+	ScriptArrayMap::const_iterator finder = scriptArrays.find(varId);
+	if (finder == scriptArrays.end()) {
+		return range;
+	}
+
+	const map<int, int>& array = finder->second;
+	if (array.empty()) {
+		return range;
+	}
+
+	//As array vars are stored as ordered maps, we can use iterator and reverse
+	//iterator to end the first and last indices.
+	range.first = array.rbegin()->first;
+	range.second = array.begin()->first;
+
+	return range;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -262,6 +262,7 @@ public:
 private:
 	bool BuildTiles(const CCharacterCommand& command, CCueEvents &CueEvents);
 	void Disappear();
+	std::pair<int, int> GetArrayRange(const CCharacterCommand& command, CCurrentGame* pGame) const;
 	int  GetIndexOfCommandWithLabel(const int label) const;
 	int  GetIndexOfPreviousIf(const bool bIgnoreElseIf) const;
 	int  GetIndexOfNextElse(const bool bIgnoreElseIf) const;

--- a/drodrpg/DRODLib/Character.h
+++ b/drodrpg/DRODLib/Character.h
@@ -277,6 +277,9 @@ private:
 
 	void PackExtraVars(const bool bSaveScript);
 
+	void PushToArrayVar(const CCharacterCommand& command, CCurrentGame* pGame, CCueEvents& CueEvents);
+	int  PopFromArrayVar(const CCharacterCommand& command, CCurrentGame* pGame);
+
 	void SetDefaultMovementType();
 	bool setPredefinedVarInt(UINT varIndex, const UINT val, CCueEvents& CueEvents);
 	void setPredefinedVarString(UINT varIndex, const WSTRING val, CCueEvents& CueEvents);

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -393,6 +393,8 @@ public:
 		CC_CountEntityType,     //Count how many entities of a specific type in flag are in rect (x,y,w,h)
 		CC_CountItem,           //Count number of game element (flags) that exist in rect (x,y,w,h).
 		CC_CountItemGroup,      //Count number of game elements from group (flags) that exist in rect (x,y,w,h).
+		CC_PushToArrayVar,      //Set array var W starting from the index after the highest set index.
+		CC_PopFromArrayVar,     //Set _ReturnX to the highest set value from array var W, then unset that array entry.
 		CC_Count
 	};
 

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -395,6 +395,7 @@ public:
 		CC_CountItemGroup,      //Count number of game elements from group (flags) that exist in rect (x,y,w,h).
 		CC_PushToArrayVar,      //Set array var W starting from the index after the highest set index.
 		CC_PopFromArrayVar,     //Set _ReturnX to the highest set value from array var W, then unset that array entry.
+		CC_ArrayVarRange,       //Set _ReturnX and _ReturnY to the highest and lowest index of array var W
 		CC_Count
 	};
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -851,6 +851,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_CountEntityType: strText = "Count entity type"; break;
 		case MID_CountItem: strText = "Count item"; break;
 		case MID_CountItemGroup: strText = "Count item group"; break;
+		case MID_VarReturnY: strText = "_ReturnY"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -852,6 +852,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_CountItem: strText = "Count item"; break;
 		case MID_CountItemGroup: strText = "Count item group"; break;
 		case MID_VarReturnY: strText = "_ReturnY"; break;
+		case MID_PushToArrayVar: strText = "Push to array var"; break;
+		case MID_PopFromArrayVar: strText = "Pop from array var"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -854,6 +854,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarReturnY: strText = "_ReturnY"; break;
 		case MID_PushToArrayVar: strText = "Push to array var"; break;
 		case MID_PopFromArrayVar: strText = "Pop from array var"; break;
+		case MID_ArrayVarRange: strText = "Get array var range"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -50,7 +50,7 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][16] =
 	"", "",
 	"_MudSwap", "_TarSwap", "_GelSwap",
 	"", "",
-	"_ReturnX"
+	"_ReturnX", "_ReturnY"
 };
 
 //Message texts corresponding to the above short var texts.
@@ -87,7 +87,7 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarTotalAtk, MID_VarTotalDef,
 	MID_VarMudSwap, MID_VarTarSwap, MID_VarGelSwap,
 	MID_VarMonsterHue, MID_VarMonsterSaturation,
-	MID_VarReturnX
+	MID_VarReturnX, MID_VarReturnY
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call
@@ -544,6 +544,7 @@ UINT PlayerStats::getVar(const Predefined var) const
 		case P_SCORE_SHOVEL: return this->scoreShovels;
 
 		case ScriptVars::P_RETURN_X: return this->scriptReturnX;
+		case ScriptVars::P_RETURN_Y: return this->scriptReturnY;
 
 		case P_NoVar:
 		default: return 0;
@@ -613,6 +614,7 @@ void PlayerStats::setVar(const Predefined var, const UINT val)
 		case P_SCORE_SHOVEL: this->scoreShovels = int(val); break;
 
 		case P_RETURN_X: this->scriptReturnX = int(val); break;
+		case P_RETURN_Y: this->scriptReturnY = int(val); break;
 
 		case P_NoVar:
 		default: break;
@@ -677,7 +679,8 @@ bool PlayerStats::IsGlobalStatIndex(UINT i)
 		case P_PRIOR_X:
 		case P_PRIOR_Y:
 		case P_PRIOR_O:
-		case P_RETURN_X: //globally accessible script return var
+		case P_RETURN_X: //globally accessible script return vars
+		case P_RETURN_Y:
 			return true;
 		default: return false;
 	}
@@ -761,6 +764,7 @@ void PlayerStats::Pack(CDbPackedVars& stats)
 			case 95: val = this->itemShovelMult; break;
 
 			case 106: val = this->scriptReturnX; break;
+			case 107: val = this->scriptReturnY; break;
 
 			default:
 				ASSERT(!"Not a global var index");
@@ -853,6 +857,7 @@ void PlayerStats::Unpack(CDbPackedVars& stats)
 			case 95: this->itemShovelMult = val; break;
 
 			case 106: this->scriptReturnX = val; break;
+			case 107: this->scriptReturnY = val; break;
 
 			default: ASSERT(!"Bad var"); break;
 		}

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -162,7 +162,8 @@ namespace ScriptVars
 		P_MONSTER_HUE = -105,
 		P_MONSTER_SATURATION = -106,
 		P_RETURN_X = -107,
-		FirstPredefinedVar = P_RETURN_X, //set this to the last var in the enumeration
+		P_RETURN_Y = -108,
+		FirstPredefinedVar = P_RETURN_Y, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 
@@ -276,7 +277,7 @@ public:
 		priorRoomID = priorX = priorY = priorO = 0;
 		mudSpawnID = tarSpawnID = gelSpawnID = queenSpawnID = mudSwapID = tarSwapID = gelSwapID = UINT(-1); //negative indicates default
 		scoreHP = scoreATK = scoreDEF = scoreYellowKeys = scoreGreenKeys = scoreBlueKeys = scoreSkeletonKeys = scoreGOLD = scoreXP = scoreShovels = 0;
-		scriptReturnX = 0;
+		scriptReturnX = scriptReturnY = 0;
 	}
 
 	UINT getVar(const WSTRING& wstr) const
@@ -311,7 +312,7 @@ public:
 	int mudSpawnID, tarSpawnID, gelSpawnID, queenSpawnID, mudSwapID, tarSwapID, gelSwapID;
 	int scoreHP, scoreATK, scoreDEF, scoreYellowKeys, scoreGreenKeys, scoreBlueKeys, scoreSkeletonKeys, scoreGOLD, scoreXP, scoreShovels;
 
-	int scriptReturnX;
+	int scriptReturnX, scriptReturnY;
 };
 
 //More stats used for various tally operations.

--- a/drodrpg/Data/Help/1/scriptarray.html
+++ b/drodrpg/Data/Help/1/scriptarray.html
@@ -32,9 +32,9 @@
         <li><a name="count-entries"><b>Count array entries</b></a> - Counts the number of values in the array that satisfies the given comparison to a given value.
         The result is stored in <b>_ReturnX</b>.</li>
     </ul></p>
-    <p>Additionally, the <a name="array-range"><b>Get array var range</b></a> command can be used to find an array's highest and lowest index. The highest index among set
-    values is stored in <b>_ReturnX</b>, and the lowest index among set values is stored in <b>_ReturnY</b>. If this command is used on an empty array, <b>_ReturnX</b> will be set to -1,
-    and <b>_ReturnY</b> to 1.</p>
+    <p>Additionally, the <a name="array-range"><b>Get array var range</b></a> command can be used to find an array's highest and lowest index. The lowest index among set
+    values is stored in <b>_ReturnX</b>, and the highest index among set values is stored in <b>_ReturnY</b>. If this command is used on an empty array, <b>_ReturnX</b> will be set to 1,
+    and <b>_ReturnY</b> to -1, which is not a possible outcome for non-empty arrays.</p>
 
     <p><u>Pushing and popping</u></p>
     <p>Two commands support dynamic reading and writing to an array, rather than requiring the use of set or cacluated indices:</p>

--- a/drodrpg/Data/Help/1/scriptarray.html
+++ b/drodrpg/Data/Help/1/scriptarray.html
@@ -31,8 +31,19 @@
         As with other variable commands, an expression can be used in place of a constant value.</li>
         <li><a name="count-entries"><b>Count array entries</b></a> - Counts the number of values in the array that satisfies the given comparison to a given value.
         The result is stored in <b>_ReturnX</b>.</li>
+    </ul></p>
+    <p>Additionally, the <a name="array-range"><b>Get array var range</b></a> command can be used to find an array's highest and lowest index. The highest index among set
+    values is stored in <b>_ReturnX</b>, and the lowest index among set values is stored in <b>_ReturnY</b>. If this command is used on an empty array, <b>_ReturnX</b> will be set to -1,
+    and <b>_ReturnY</b> to 1.</p>
+
+    <p><u>Pushing and popping</u></p>
+    <p>Two commands support dynamic reading and writing to an array, rather than requiring the use of set or cacluated indices:</p>
+    <ul>
+        <li><a name="push-to"><b>Push to array var</b></a> - This command works similarly to <b>Set array var</b>, except it does not use an index argument or operator. Instead, it assigns values starting
+        from the index after the current highest-index entry. If no values in the array are set, it will begin from zero.</li>
+        <li><a name="pop-from"><b>Pop from array var</b></a> - This command will set <b>_ReturnX</b> to the value in the current highest-index entry. Then, it will clear that entry, returning it to an unset state.
+        Popping a value from an empty array will set <b>_ReturnX</b> to zero.</li>
     </ul>
-    </p>
 
     <p><u>Examples of valid array expressions</u></p>
     <ul>
@@ -43,7 +54,7 @@
     </ul>
 
     <p><u>Clearing arrays</u></p>
-    <p>The <b>Clear array var</b> command can be used to reset all values in an array variable to zero.</p>
+    <p>The <b>Clear array var</b> command can be used to clear all entries in an array variable.</p>
 <hr />
 <a href="script.html">Command list</a><br />
 <a href="character.html">Character Scripting</a><br />

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1818,6 +1818,7 @@ enum MID_CONSTANT {
   MID_CountItemGroup = 2172,
   MID_PushToArrayVar = 2174,
   MID_PopFromArrayVar = 2175,
+  MID_ArrayVarRange = 2176,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1920,6 +1920,7 @@ enum MID_CONSTANT {
   MID_VarMonsterHue = 2077,
   MID_VarMonsterSaturation = 2078,
   MID_VarReturnX = 2107,
+  MID_VarReturnY = 2173,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1816,6 +1816,8 @@ enum MID_CONSTANT {
   MID_CountEntityType = 2170,
   MID_CountItem = 2171,
   MID_CountItemGroup = 2172,
+  MID_PushToArrayVar = 2174,
+  MID_PopFromArrayVar = 2175,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1859,3 +1859,7 @@ Push to array var
 [MID_PopFromArrayVar]
 [eng]
 Pop from array var
+
+[MID_ArrayVarRange]
+[eng]
+Get array var range

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1851,3 +1851,11 @@ Count item
 [MID_CountItemGroup]
 [eng]
 Count item group
+
+[MID_PushToArrayVar]
+[eng]
+Push to array var
+
+[MID_PopFromArrayVar]
+[eng]
+Pop from array var

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -405,3 +405,7 @@ _MySaturation
 [MID_VarReturnX]
 [eng]
 _ReturnX
+
+[MID_VarReturnY]
+[eng]
+_ReturnY


### PR DESCRIPTION
A few script commands to make working with arrays a little smoother. It also adds `_ReturnY` so that one of them works.

- `Push to array var` allows values to be appending onto the end of an array without having to track where it currently ends. Like `Set array var`, multiple values can be added with a single command.
- `Pop from array var` gets the value on the end of an array and moves it to `_ReturnX`. Then it erases the entry.
- `Get array range` finds the highest and lowest indices in the array, and puts them in `_ReturnX` and `_ReturnY` respectively.

Help content has also been updated.