### PR TITLE
RPG: Port fixes from TSS to RPG

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -2275,7 +2275,6 @@ void CCharacterDialogWidget::OnClick(
 			} else {
 				//Command addition was canceled.
 				//Clear any data generated for the command.
-				ASSERT(!this->pSound || !this->pSound->dwDataID);	//should be fresh (not added to DB yet)
 				delete this->pSound;
 				this->pSound = NULL;
 			}

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -9120,6 +9120,7 @@ void CGameScreen::UpdateUIAfterMoveUndo(bool bReloadEntireMap) //[default=false]
 
 	StopAmbientSounds();
 	ClearSpeech(false);  //retain speech that started before the previous turn
+	this->pRoomWidget->RetainImageOverlay(true);
 
 	this->pRoomWidget->ClearEffects();
 	this->pRoomWidget->RenderRoomLighting();
@@ -9137,6 +9138,7 @@ void CGameScreen::UpdateUIAfterMoveUndo(bool bReloadEntireMap) //[default=false]
 	DrawCurrentTurn();
 
 	RetainSubtitleCleanup();
+	this->pRoomWidget->RetainImageOverlay(false);
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/ImageOverlayEffect.cpp
+++ b/drodrpg/DROD/ImageOverlayEffect.cpp
@@ -93,6 +93,7 @@ CImageOverlayEffect::CImageOverlayEffect(
 	, alpha(255), drawAlpha(255)
 	, angle(0), scale(ORIGINAL_SCALE)
 	, jitter(0)
+	, lastJitterX(0), lastJitterY(0)
 	, xTile(0), yTile(0)
 	, repetitions(0), xRepeatOffset(0), yRepeatOffset(0)
 	, index(UINT(-1))
@@ -166,7 +167,13 @@ int CImageOverlayEffect::getGroup() const
 	return ImageOverlayCommand::DEFAULT_GROUP;
 }
 
-bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElapsed)
+bool CImageOverlayEffect::Update(
+	// Advances the animation by specified amount of time
+	// Return: false if the effect has finished and should be removed
+	//
+	// Params:
+	const UINT wDeltaTime,      //(in) Time, in ms, by which to advance the effect
+	const Uint32 dwTimeElapsed) //(in) Total duration, in ms, of the effect so far
 {
 	if (!this->pImageSurface)
 		return false;
@@ -186,15 +193,25 @@ bool CImageOverlayEffect::Update(const UINT wDeltaTime, const Uint32 dwTimeElaps
 		this->bPrepareAlteredImage = false;
 	}
 
-	PrepareDrawProperties();
+	// Only recalculate jitter in Update() so that it stays consistent
+	// between redraws
+	if (this->jitter) {
+		this->lastJitterX = ROUND(fRAND_MID(this->jitter));
+		this->lastJitterY = ROUND(fRAND_MID(this->jitter));
+	}
+	else {
+		this->lastJitterX = 0;
+		this->lastJitterY = 0;
+	}
 
 	return true;
 }
 
 void CImageOverlayEffect::PrepareDrawProperties()
+// Prepare all the necessary variables for drawing
 {
-	this->drawX = this->x;
-	this->drawY = this->y;
+	this->drawX = this->x + this->lastJitterX;
+	this->drawY = this->y + this->lastJitterY;
 
 	if (this->jitter) {
 		this->drawX += ROUND(fRAND_MID(this->jitter));
@@ -242,6 +259,8 @@ void CImageOverlayEffect::PrepareDrawProperties()
 
 void CImageOverlayEffect::Draw(SDL_Surface& destSurface)
 {
+	PrepareDrawProperties();
+
 	SDL_Surface* pSrcSurface;
 
 	if (this->pTiledSurface)

--- a/drodrpg/DROD/ImageOverlayEffect.h
+++ b/drodrpg/DROD/ImageOverlayEffect.h
@@ -127,6 +127,7 @@ private:
 
 	// Properties used for the drawing
 	int drawX, drawY; // Position to draw image after applying any active effects
+	int lastJitterX, lastJitterY; // Store the jitter to make it consistent across redraws without time advancing
 	Uint8 drawAlpha;
 	SDL_Rect drawSourceRect;
 	SDL_Rect drawDestinationRect;

--- a/drodrpg/DROD/RoomEffectList.cpp
+++ b/drodrpg/DROD/RoomEffectList.cpp
@@ -180,14 +180,14 @@ void CRoomEffectList::RemoveOverlayEffectsInGroup(
 	list<CEffect*>::const_iterator iSeek = this->Effects.begin();
 	while (iSeek != this->Effects.end())
 	{
-		if ((*iSeek)->GetEffectType() == EIMAGEOVERLAY)
+		CEffect* pDelete = *iSeek;
+		++iSeek;
+		if (pDelete->GetEffectType() == EIMAGEOVERLAY)
 		{
 			//Remove from list.
-			CEffect* pDelete = *iSeek;
 			ASSERT(pDelete);
 			if (pDelete->RequestsRetainOnClear() && !bForceClearAll)
 			{
-				++iSeek;
 				continue;
 			}
 
@@ -195,12 +195,9 @@ void CRoomEffectList::RemoveOverlayEffectsInGroup(
 
 			if (pDeleteOverlay->getGroup() == clearGroup) {
 				DirtyTilesForRects(pDelete->dirtyRects);  //touch up area before deleting
-				++iSeek;
 				this->Effects.remove(pDelete);
 				delete pDelete;
 			}
 		}
-		else
-			++iSeek;
 	}
 }

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -2647,6 +2647,11 @@ bool CRoomWidget::LoadFromCurrentGame(
 //True if successful, false if not.
 {
 	ASSERT(pSetCurrentGame);
+	if (this->pCurrentGame == pSetCurrentGame) {
+		// Otherwise if we open settings in-game or leave to main menu and
+		// continue the effects will be unloaded
+		RetainImageOverlay(true);
+	}
 	this->pCurrentGame = pSetCurrentGame;
 	return LoadFromRoom(pSetCurrentGame->pRoom, bLoad);
 }
@@ -4669,6 +4674,39 @@ void CRoomWidget::RerenderRoomCeilingLight(CCueEvents& CueEvents)
 		this->ceilingLightChanges.removeAfter(currentTurn);
 		this->bCeilingLightsRendered = false;
 		ProcessLightmap();
+	}
+}
+
+//*****************************************************************************
+void CRoomWidget::RetainImageOverlay(const bool bVal)
+//Mark image overlays to be retained - usen when undoing a move or when
+//reactivating a game screen, ensures overlays are retained between the
+//changes
+{
+	RetainImageOverlay(this->pOLayerEffects, bVal);
+	RetainImageOverlay(this->pTLayerEffects, bVal);
+	RetainImageOverlay(this->pMLayerEffects, bVal);
+	RetainImageOverlay(this->pLastLayerEffects, bVal);
+}
+
+void CRoomWidget::RetainImageOverlay(CRoomEffectList* pEffectList, const bool bVal)
+{
+	ASSERT(pEffectList);
+	const UINT currentTurn = this->pCurrentGame ? this->pCurrentGame->wTurnNo : 0;
+
+	list<CEffect*>& effects = pEffectList->Effects;
+	for (list<CEffect*>::iterator it = effects.begin(); it != effects.end(); ++it)
+	{
+		CEffect* pEffect = *it;
+		if (pEffect->GetEffectType() == EIMAGEOVERLAY) {
+			bool thisVal = bVal;
+			if (thisVal) {
+				CImageOverlayEffect* pImageEffect = DYN_CAST(CImageOverlayEffect*, CEffect*, pEffect);
+				UINT startTurn = pImageEffect->getStartTurn();
+				thisVal = startTurn <= currentTurn;
+			}
+			pEffect->RequestRetainOnClear(thisVal);
+		}
 	}
 }
 

--- a/drodrpg/DROD/RoomWidget.h
+++ b/drodrpg/DROD/RoomWidget.h
@@ -325,6 +325,8 @@ public:
 	void           RerenderRoom() {this->bRenderRoom = true; DirtyRoom(); }
 	void           RenderRoomLighting() {this->bRenderRoomLight = true;}
 	void           RerenderRoomCeilingLight(CCueEvents& CueEvents);
+	void           RetainImageOverlay(const bool bVal);
+	void           RetainImageOverlay(CRoomEffectList* pEffectList, const bool bVal);
 	void           DrawTLayerTile(const UINT wX, const UINT wY,
 			const int nX, const int nY, SDL_Surface *pDestSurface,
 			const UINT wOTileNo, const TileImages& ti, LIGHTTYPE *psL,

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4454,7 +4454,7 @@ int CCharacter::CountEntityType(
 			}
 
 			if (pMonster->wType == pflags) {
-				if (pMonster->IsPiece()) {
+				if (pMonster->IsPiece() || pMonster->IsLongMonster()) {
 					pMonster = pMonster->GetOwningMonsterConst();
 					if (seenHeads.count(pMonster)) {
 						continue;

--- a/drodrpg/DRODLib/DbSpeech.cpp
+++ b/drodrpg/DRODLib/DbSpeech.cpp
@@ -284,7 +284,6 @@ bool CDbSpeech::UpdateNew()
 	//Save new sound clip, if set.
 	if (this->pSound)
 	{
-		ASSERT(!this->dwDataID);   //no sound data should be associated with this speech object yet
 		ASSERT(this->bDirtySound); //dirty bit for sound should be set
 		if (this->pSound->Update())
 			this->dwDataID = this->pSound->dwDataID;


### PR DESCRIPTION
Moving a bunch of fixes that were made in TSS to their RPG equivalent code. Specifically:

#1119 - Fix infinite loop when clearing image overlay groups
#1120 - Fix double count of multi-tile monsters with `Count entity type`
#1081 - Fix an issue with image overlays during room transitions
#1068 - Make image overlays persist when leaving the returning to game
#1123 - Removing obselete asserts in speech sound management code