### PR TITLE
RPG: Fix command options still visible when filtered out all of them

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -2467,7 +2467,6 @@ void CCharacterDialogWidget::OnClick(
 			} else {
 				//Command addition was canceled.
 				//Clear any data generated for the command.
-				ASSERT(!this->pSound || !this->pSound->dwDataID);	//should be fresh (not added to DB yet)
 				delete this->pSound;
 				this->pSound = NULL;
 			}

--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -5164,6 +5164,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 
 	this->pActionListBox->SelectLine(0);
 	this->pActionListBox->SetAllowFiltering(true);
+	this->pActionListBox->SetFilterDispatchOnEmpty(true);
 }
 
 //*****************************************************************************

--- a/DROD/DemoScreen.cpp
+++ b/DROD/DemoScreen.cpp
@@ -227,13 +227,10 @@ void CDemoScreen::OnKeyDown(
 
 	int nCommand = GetCommandForInputKey(BuildInputKey(Key));
 
-	if (nCommand == CMD_ESCAPE) {
+	if (nCommand == CMD_ESCAPE || !this->bCanInteract) {
 		Deactivate();
 		return;
 	}
-
-	if (!this->bCanInteract)
-		return;
 
 	// The longer forward/backwards key is pressed the faster frames should pass
 	UINT wMovesToDo = static_cast<UINT>(max(
@@ -534,26 +531,32 @@ void CDemoScreen::AdvanceTurn()
 					(this->bCanInteract ? this->fMoveRateMultiplier : 1.0f)));
 
 	//If one room in a multi-room demo just ended, show room transition immediately.
-	if (this->currentCommandIter == CGameScreen::pCurrentGame->Commands.end() &&
-			this->pDemo->dwNextDemoID) //Multi-room demo.
+	if (this->currentCommandIter == CGameScreen::pCurrentGame->Commands.end()) //Multi-room demo.
 	{
-		//Show transition to new room once it is loaded.
-		UINT wExitOrientation = NO_ORIENTATION;
-		const CAttachableWrapper<UINT> *pExitOrientation =
-				DYN_CAST(const CAttachableWrapper<UINT>*, const CAttachableObject*,
-				CGameScreen::sCueEvents.GetFirstPrivateData(CID_ExitRoomPending));
-		if (pExitOrientation)
-			wExitOrientation = static_cast<UINT>(*pExitOrientation);
-
-		//Load next demo and get first command.
-		if (LoadDemoGame(this->pDemo->dwNextDemoID))
+		if (this->pDemo->dwNextDemoID) //Multi-room demo.
 		{
-			//Load succeeded -- start playing it next frame.
-			this->pRoomWidget->ShowRoomTransition(wExitOrientation, CGameScreen::sCueEvents);
-			this->pMapWidget->DrawMapSurfaceFromRoom(CGameScreen::pCurrentGame->pRoom);
-			this->pMapWidget->RequestPaint();
-			this->currentCommandIter = CGameScreen::pCurrentGame->Commands.GetFirst();
-			bClearFlashingMessages = false;
+			//Show transition to new room once it is loaded.
+			UINT wExitOrientation = NO_ORIENTATION;
+			const CAttachableWrapper<UINT>* pExitOrientation =
+				DYN_CAST(const CAttachableWrapper<UINT>*, const CAttachableObject*,
+					CGameScreen::sCueEvents.GetFirstPrivateData(CID_ExitRoomPending));
+			if (pExitOrientation)
+				wExitOrientation = static_cast<UINT>(*pExitOrientation);
+
+			//Load next demo and get first command.
+			if (LoadDemoGame(this->pDemo->dwNextDemoID))
+			{
+				//Load succeeded -- start playing it next frame.
+				this->pRoomWidget->ShowRoomTransition(wExitOrientation, CGameScreen::sCueEvents);
+				this->pMapWidget->DrawMapSurfaceFromRoom(CGameScreen::pCurrentGame->pRoom);
+				this->pMapWidget->RequestPaint();
+				this->currentCommandIter = CGameScreen::pCurrentGame->Commands.GetFirst();
+				bClearFlashingMessages = false;
+			}
+		} else if (!this->bCanInteract) {
+			//Automatically return to previous screen
+			Deactivate();
+			return;
 		}
 	}
 

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -3327,6 +3327,9 @@ SCREENTYPE CGameScreen::ProcessCommand(
 
 			bWasCutScene = this->pCurrentGame->dwCutScene != 0;
 			this->pCurrentGame->ProcessCommand(nCommand, this->sCueEvents);
+			// If player left the room then pRoomWidget will have a reference
+			// to a deleted room, sync them to fix it
+			this->pRoomWidget->SynchRoomToCurrentGame();
 
 			bLeftRoom = this->sCueEvents.HasAnyOccurred(IDCOUNT(CIDA_PlayerLeftRoom), CIDA_PlayerLeftRoom);
 			if (bLeftRoom)

--- a/DROD/Main.cpp
+++ b/DROD/Main.cpp
@@ -701,6 +701,10 @@ MESSAGE_ID Init(
 				CScreen::eFullScreenMode = SCREENLIB::FULLSCREENMODE(mode);
 			}
 		}
+
+		if (CFiles::GetGameProfileString(INISection::Customizing, INIKey::KeepSoundsFromDeletedSpeech, strIniValue) && atoi(strIniValue.c_str()) == 1) {
+			g_pTheDB->Speech.bKeepSoundsFromDeletedSpeech = true;
+		}
 	}
 
 	//Init the internet interface.
@@ -1924,6 +1928,7 @@ void RepairMissingINIKeys(const bool bFullVersion)
 	AddIfMissing(INISection::Customizing, INIKey::RoomTransitionSpeed, "500");
 	AddIfMissing(INISection::Customizing, INIKey::ValidateSavesOnImport, "1");
 	AddIfMissing(INISection::Customizing, INIKey::Windib, "1");
+	AddIfMissing(INISection::Customizing, INIKey::KeepSoundsFromDeletedSpeech, "0");
 
 	AddIfMissing(INISection::Graphics, "Clock", "Clock");
 	AddIfMissing(INISection::Graphics, "General", "GeneralTiles");

--- a/DROD/RoomEffectList.cpp
+++ b/DROD/RoomEffectList.cpp
@@ -174,14 +174,14 @@ void CRoomEffectList::RemoveOverlayEffectsInGroup(
 	list<CEffect*>::const_iterator iSeek = this->Effects.begin();
 	while (iSeek != this->Effects.end())
 	{
-		if ((*iSeek)->GetEffectType() == EIMAGEOVERLAY)
+		CEffect* pDelete = *iSeek;
+		++iSeek;
+		if (pDelete->GetEffectType() == EIMAGEOVERLAY)
 		{
 			//Remove from list.
-			CEffect* pDelete = *iSeek;
 			ASSERT(pDelete);
 			if (pDelete->RequestsRetainOnClear() && !bForceClearAll)
 			{
-				++iSeek;
 				continue;
 			}
 
@@ -189,12 +189,9 @@ void CRoomEffectList::RemoveOverlayEffectsInGroup(
 
 			if (pDeleteOverlay->getGroup() == clearGroup) {
 				DirtyTilesForRects(pDelete->dirtyRects);  //touch up area before deleting
-				++iSeek;
 				this->Effects.remove(pDelete);
 				delete pDelete;
 			}
 		}
-		else
-			++iSeek;
 	}
 }

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -805,6 +805,12 @@ CSubtitleEffect* CRoomWidget::AddSubtitle(
 		}
 	}
 
+	//Make sure the speaker is not deleted if it dies
+	CMonster* pMonster = dynamic_cast<CMonster*>(pCoord);
+	if (pMonster) {
+		pMonster->bSafeToDelete = false;
+	}
+
 	//Speaker text effect.
 	CSubtitleEffect *pSubtitle = new CSubtitleEffect(this, pCoord,
 			wStr.c_str(), Black, color, dwDuration);

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3752,7 +3752,13 @@ void CCharacter::Process(
 				} else {
 					CMonster* pMonster = pGame->pRoom->GetMonsterAtSquare(px, py);
 					if (pMonster != NULL){
-						wOrientation = pMonster->wO;
+						if (pMonster->IsPiece()) {
+							if (!bIsSerpentOrGentryii(pMonster->GetIdentity())) {
+								wOrientation = pMonster->GetOwningMonster()->wO;
+							}
+						} else {
+							wOrientation = pMonster->wO;
+						}
 					}
 				}
 

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -5859,12 +5859,7 @@ void CCharacter::SetArrayVariable(
 			default: break;
 		}
 
-		if (x == 0) {
-			//Save memory by clearing value
-			scriptArrays[varIndex].erase(arrayIndex);
-		} else {
-			scriptArrays[varIndex][arrayIndex] = x;
-		}
+		scriptArrays[varIndex][arrayIndex] = x;
 		++arrayIndex;
 	}
 }

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -8377,6 +8377,7 @@ void CCharacter::ReplaceWithDefault(
 
 	//New character neeeds to be flagged and given a new id
 	pNewCharacter->bIsFirstTurn = true;
+	pNewCharacter->bNoTurnZeroProcess = true; // Prevent from double processing on 0th turn
 	pNewCharacter->bNewEntity = true;
 	pNewCharacter->bIsDefaultScript = true;
 	pNewCharacter->dwScriptID = this->pCurrentGame->pHold->GetNewScriptID();

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4838,7 +4838,7 @@ int CCharacter::CountEntityType(
 			}
 
 			if (pMonster->wType == pflags) {
-				if (pMonster->IsPiece()) {
+				if (pMonster->IsPiece() || pMonster->IsLongMonster()) {
 					pMonster = pMonster->GetOwningMonsterConst();
 					if (seenHeads.count(pMonster)) {
 						continue;

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -3620,7 +3620,11 @@ void CCharacter::Process(
 			case CCharacterCommand::CC_WaitForOpenMove:
 				getCommandX(command, px);
 
-				if (!this->IsOpenMove(nGetOX(px), nGetOY(px)))
+				if (
+					px != NO_ORIENTATION
+					&& IsValidOrientation(px)
+					&& !this->IsOpenMove(nGetOX(px), nGetOY(px))
+				)
 					STOP_COMMAND;
 				bProcessNextCommand = true;
 			break;

--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -2187,7 +2187,6 @@ void CCurrentGame::DeserializeScriptArrays()
 		while (size) {
 			int key = (int)readBpUINT(buffer, index);
 			int value = (int)readBpUINT(buffer, index);
-			ASSERT(value != 0);
 			scriptArray[key] = value;
 			--size;
 		}

--- a/DRODLib/DbSavedGames.cpp
+++ b/DRODLib/DbSavedGames.cpp
@@ -1002,10 +1002,6 @@ void CDbSavedGame::SerializeScriptArrays()
 		UINT size = 0;
 		for (map<int, int>::const_iterator arrayIt = arrayMap.cbegin();
 			arrayIt != arrayMap.cend(); ++arrayIt) {
-			if (arrayIt->second == 0) {
-				continue; //save space by skipping zero-value entries
-			}
-
 			writeBpUINT(buffer, (UINT)arrayIt->first);
 			writeBpUINT(buffer, (UINT)arrayIt->second);
 			++size;

--- a/DRODLib/DbSpeech.cpp
+++ b/DRODLib/DbSpeech.cpp
@@ -53,9 +53,11 @@ void CDbSpeeches::Delete(
 	const UINT dwTextMID = (UINT) (p_MessageID(row));
 	if (dwTextMID)
 		DeleteMessage(static_cast<MESSAGE_ID>(dwTextMID));
-	const UINT dwDataID = (UINT) (p_DataID(row));
-	if (dwDataID)
-		g_pTheDB->Data.Delete(dwDataID);
+	if (!this->bKeepSoundsFromDeletedSpeech) {
+		const UINT dwDataID = (UINT) (p_DataID(row));
+		if (dwDataID)
+			g_pTheDB->Data.Delete(dwDataID);
+	}
 
 	SpeechView.RemoveAt(dwSpeechRowI);
 

--- a/DRODLib/DbSpeech.cpp
+++ b/DRODLib/DbSpeech.cpp
@@ -284,7 +284,6 @@ bool CDbSpeech::UpdateNew()
 	//Save new sound clip, if set.
 	if (this->pSound)
 	{
-		ASSERT(!this->dwDataID);   //no sound data should be associated with this speech object yet
 		ASSERT(this->bDirtySound); //dirty bit for sound should be set
 		if (this->pSound->Update())
 			this->dwDataID = this->pSound->dwDataID;
@@ -378,7 +377,7 @@ MESSAGE_ID CDbSpeech::SetProperty(
 
 //*****************************************************************************
 MESSAGE_ID CDbSpeech::SetProperty(
-//Used during XML data import.                      
+//Used during XML data import.
 //According to pType, convert string to proper datatype and member
 //
 //Returns: whether operation was successful

--- a/DRODLib/DbSpeech.h
+++ b/DRODLib/DbSpeech.h
@@ -45,13 +45,18 @@ protected:
 	friend class CDb;
 
 	CDbSpeeches()
-		: CDbVDInterface<CDbSpeech>(V_Speech, p_SpeechID)
+		: CDbVDInterface<CDbSpeech>(V_Speech, p_SpeechID),
+		bKeepSoundsFromDeletedSpeech(false)
 	{}
 
 public:
 	void              Delete(const UINT dwSpeechID);
 	virtual bool      ExportText(const UINT dwSpeechID, CDbRefs &dbRefs, CStretchyBuffer &str);
 	virtual void      ExportXML(const UINT dwSpeechID, CDbRefs &dbRefs, string &str, const bool bRef=false);
+
+	/// By default deleting speech deletes associated sound data. With this set
+	/// to true the data is kept and has to be managed manually.
+	bool              bKeepSoundsFromDeletedSpeech;
 };
 
 //*****************************************************************************

--- a/DRODLib/SettingsKeys.cpp
+++ b/DRODLib/SettingsKeys.cpp
@@ -37,6 +37,7 @@ namespace INIKey
 	DEF(Style);
 	DEF(ValidateSavesOnImport);
 	DEF(Windib);
+	DEF(KeepSoundsFromDeletedSpeech);
 }
 
 namespace Settings

--- a/DRODLib/SettingsKeys.h
+++ b/DRODLib/SettingsKeys.h
@@ -37,6 +37,9 @@ namespace INIKey
 	DEF(Style);
 	DEF(ValidateSavesOnImport);
 	DEF(Windib);
+	/// By default deleting Speech also deletes the sound data attached to it.
+	/// With this enabled the sound data will be kept and has to be deleted manually.
+	DEF(KeepSoundsFromDeletedSpeech);
 }
 
 namespace Settings

--- a/DRODLibTests/DRODLibTests.2019.vcxproj
+++ b/DRODLibTests/DRODLibTests.2019.vcxproj
@@ -409,6 +409,7 @@
     <ClCompile Include="src\tests\Scripting\Build\BuildingTarstuff.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\BuildSanityTest.cpp" />
     <ClCompile Include="src\tests\Scripting\Build\RemovingTransparentObjects.cpp" />
+    <ClCompile Include="src\tests\Scripting\CountEntityType.cpp" />
     <ClCompile Include="src\tests\Scripting\GoToLevelEntrance.cpp" />
     <ClCompile Include="src\tests\Scripting\ImperativeFriendly.cpp" />
     <ClCompile Include="src\tests\Scripting\ImperativePushable\PushableByBody.cpp" />

--- a/DRODLibTests/DRODLibTests.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTests.2019.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClCompile Include="src\tests\Scripting\GoToLevelEntrance.cpp">
       <Filter>Tests\Scripting</Filter>
     </ClCompile>
+    <ClCompile Include="src\tests\Scripting\CountEntityType.cpp">
+      <Filter>Tests\Scripting</Filter>
+    </ClCompile>
     <ClCompile Include="src\tests\Scripting\Imperative_BrainPathmapObstacle.cpp">
       <Filter>Tests\Scripting</Filter>
     </ClCompile>

--- a/DRODLibTests/src/tests/Scripting/CountEntityType.cpp
+++ b/DRODLibTests/src/tests/Scripting/CountEntityType.cpp
@@ -1,0 +1,57 @@
+#include "../../test-include.hpp"
+#include "../../CAssert.h"
+
+TEST_CASE("Scripting: CountEntityType", "[game][scripting][imperative]") {
+	RoomBuilder::ClearRoom();
+	RoomBuilder::PlotRect(T_WALL, 10, 10, 15, 12);
+	RoomBuilder::PlotRect(T_FLOOR, 11, 11, 14, 11);
+	RoomBuilder::Plot(T_FLOOR, 13, 12);
+	RoomBuilder::AddMonster(M_STALWART, 11, 11, E);
+	RoomBuilder::AddMonster(M_EYE, 14, 11, E);
+
+	CCharacter* pScript = RoomBuilder::AddCharacter(1,1);
+	RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_SetPlayerStealth, Stealth_On);
+
+	SECTION("Count roaches") {
+		RoomBuilder::AddMonster(M_ROACH, 15, 15, E);
+		RoomBuilder::AddMonster(M_EYE, 16, 15, E);
+		RoomBuilder::AddMonster(M_GOBLIN, 17, 15, E);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 0, 0, 37, 31, M_ROACH);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+
+	SECTION("Do not double count serpents if area both head and body") {
+		CSerpent* serpent = DYN_CAST(CSerpent*, CMonster*, RoomBuilder::AddMonster(M_SERPENT, 10, 10, E));
+		RoomBuilder::AddSerpentPiece(serpent, 9, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 8, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 7, 10);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 0, 0, 37, 31, M_SERPENT);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+
+	SECTION("Count serpent's head") {
+		CSerpent* serpent = DYN_CAST(CSerpent*, CMonster*, RoomBuilder::AddMonster(M_SERPENT, 10, 10, E));
+		RoomBuilder::AddSerpentPiece(serpent, 9, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 8, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 7, 10);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 10, 10, 0, 0, M_SERPENT);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+
+	SECTION("Count serpent's body") {
+		CSerpent* serpent = DYN_CAST(CSerpent*, CMonster*, RoomBuilder::AddMonster(M_SERPENT, 10, 10, E));
+		RoomBuilder::AddSerpentPiece(serpent, 9, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 8, 10);
+		RoomBuilder::AddSerpentPiece(serpent, 7, 10);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_CountEntityType, 7, 10, 0, 0, M_SERPENT);
+
+		CCurrentGame* pGame = Runner::StartGame(4, 4, E);
+		CHECK(pGame->getVar(ScriptVars::P_RETURN_X) == 1);
+	}
+}

--- a/Data/Help/1/customizing.html
+++ b/Data/Help/1/customizing.html
@@ -143,6 +143,13 @@ or add additional sound effects to a line (semicolon-separated).</p>
 		<a name="windib"><b>Windib</b></a>: By default, DROD uses Windib drivers under Windows.
 		Set this parameter to 0 to use DirectX drivers instead.
 	</li>
+	<li>
+		<a name="KeepSoundsFromDeletedSpeech"><b>KeepSoundsFromDeletedSpeech</b></a>:
+		By default when you delete a Speech command with attached sound the sound
+		data also gets deleted. Set this to 1 if you want the attached sound data
+		to be retained. This is helpful if you find yourself often copying commands
+		and accidentally losing data.
+	</li>
 </ul>
 
 <p>

--- a/Data/Help/1/scriptarray.html
+++ b/Data/Help/1/scriptarray.html
@@ -26,7 +26,7 @@
     If an index that has not been set is accessed, a default value of 0 is returned.</p>
 
     <p><u>Querying full arrays</u></p>
-    <p>Two commands operate over an entire array, to provide a concise way to determine its state:
+    <p>Two commands operate over an entire array, checking all set values to provide a concise way to determine its state:
     <ul>
         <li><a name="wait-for-entry"><b>Wait for array entry</b></a> - Waits until the given array contains a value that satisfies the given comparison to a given value.
         As with other variable commands, an expression can be used in place of a constant value.</li>

--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -79,6 +79,7 @@ CListBoxWidget::CListBoxWidget(
 	, wDraggingLineNo(UINT(-1))
 	, bRearranged(false)
 	, bAllowFiltering(false)
+	, bFilterDispatchOnEmpty(false)
 	, wstrActiveFilter(wszEmpty)
 {
 	if (CListBoxWidget::wstrFilterWord.size() == 0)

--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -1295,6 +1295,9 @@ void CListBoxWidget::UpdateFilter(WSTRING wstrFilter)
 			CEventHandlerWidget *pEventHandler = GetEventHandlerWidget();
 			if (pEventHandler) pEventHandler->OnSelectChange(GetTagNo());
 		}
+	} else if (this->bFilterDispatchOnEmpty) {
+		CEventHandlerWidget *pEventHandler = GetEventHandlerWidget();
+		if (pEventHandler) pEventHandler->OnSelectChange(GetTagNo());
 	}
 
 }

--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -1183,7 +1183,11 @@ void CListBoxWidget::HandleKeyDown(
 			break;
 
 		default:
-			if (this->bAllowFiltering && !(KeyboardEvent.keysym.mod & KMOD_SHIFT)) {
+			if (
+				this->bAllowFiltering
+				&& !(KeyboardEvent.keysym.mod & KMOD_SHIFT)
+				&& !(KeyboardEvent.keysym.mod & KMOD_CTRL)
+			) {
 				const WCHAR character = KeyboardEvent.keysym.sym == SDLK_SPACE ? We(' ') : TranslateUnicodeKeysym(KeyboardEvent.keysym);
 
 				if (IsValidFilterCharacter(character)) {
@@ -1199,7 +1203,7 @@ void CListBoxWidget::HandleKeyDown(
 				if (KeyboardEvent.keysym.mod & KMOD_CTRL)
 				{
 					const WCHAR wc = TranslateUnicodeKeysym(KeyboardEvent.keysym);
-					if (SelectLineStartingWith(wc))
+					if (wc != 0 && SelectLineStartingWith(wc))
 						wNewCursorLine = this->wCursorLine;
 				}
 			}

--- a/FrontEndLib/ListBoxWidget.cpp
+++ b/FrontEndLib/ListBoxWidget.cpp
@@ -659,6 +659,8 @@ bool CListBoxWidget::RemoveItem(const void* pKey)
 			//Update set of selected lines to their new list positions.
 			CIDSet remainingSelectedKeys = GetSelectedItems();
 			this->Items.erase(iSeek);
+			// Must rerun the filter before `SelectItems()` as it uses the filtered list
+			UpdateFilter(this->wstrActiveFilter);
 			SelectItems(remainingSelectedKeys);
 
 			if (!this->Items.empty())
@@ -675,8 +677,6 @@ bool CListBoxWidget::RemoveItem(const void* pKey)
 			break;
 		}
 	}
-
-	UpdateFilter(this->wstrActiveFilter);
 
 	//Recalc areas of widget since they may have changed.
 	CalcAreas();
@@ -818,10 +818,10 @@ bool CListBoxWidget::SelectLineStartingWith(const WCHAR wc)
 	UINT wLineNo;
 	for (wLineNo = 0; wLineNo < this->filteredItems.size(); ++wLineNo)
 	{
-		const WCHAR line_wc = this->bIgnoreLeadingArticlesInSort ? 
+		const WCHAR line_wc = this->bIgnoreLeadingArticlesInSort ?
 			towlower(StripLeadingArticle(this->filteredItems[wLineNo]->text)[0]) :
 			towlower(this->filteredItems[wLineNo]->text[0]);
-		
+
 		if (line_wc == wc)
 			break; //found one
 		if (this->bSortAlphabetically &&
@@ -939,7 +939,7 @@ void CListBoxWidget::Paint(
 		drawY = this->y + TEXT_DRAW_Y_OFFSET + this->h - CY_LBOX_ITEM - 1;
 
 		const SURFACECOLOR FilterSeparatorColor = GetSurfaceColor(GetDestSurface(), 102, 102, 102);
-		
+
 		WSTRING message = this->wstrFilterWord;
 		message += wszColon;
 		message += wszSpace;

--- a/FrontEndLib/ListBoxWidget.h
+++ b/FrontEndLib/ListBoxWidget.h
@@ -121,6 +121,7 @@ public:
 	bool           SelectLineWithText(const WCHAR* pText);
 	void           SelectMultipleItems(const bool bVal);
 	void           SetAllowFiltering(const bool bVal) { this->bAllowFiltering = bVal; }
+	void           SetFilterDispatchOnEmpty(const bool bVal) { this->bFilterDispatchOnEmpty = bVal; }
 	void           SetHotkeyItemSelection(const bool bVal=true) {this->bHotkeyItemSelection = bVal;}
 	void           SetItemColor(const UINT dwKey, const SDL_Color& color);
 	void           SetItemColorAtLine(const UINT index, const SDL_Color& color);
@@ -172,6 +173,8 @@ protected:
 	UINT           wDraggingLineNo;  //this line # is being moved in the list
 	bool           bRearranged;      //choices were rearranged on mouse drag
 	bool           bAllowFiltering;  //Allow filtering by typing text
+	/// Dispatch change event when filtering and the list becomes empty
+	bool           bFilterDispatchOnEmpty;
 	WSTRING        wstrActiveFilter;
 
 private:

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4742,6 +4742,7 @@ void CCharacterDialogWidget::PopulateCommandListBox()
 
 	this->pActionListBox->SelectLine(0);
 	this->pActionListBox->SetAllowFiltering(true);
+	this->pActionListBox->SetFilterDispatchOnEmpty(true);
 }
 
 //*****************************************************************************


### PR DESCRIPTION
#1122 for RPG. This requires a master merge to get the `FrontEndLib` changes in, so it also fixes #1121 