### PR TITLE
RPG: Fully support multiple scorepoints in single turn

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -4758,14 +4758,12 @@ void CGameScreen::FadeRoom(const bool bFadeIn, const Uint32 dwDuration, CCueEven
 }
 
 //*****************************************************************************
-void CGameScreen::ScoreCheckpoint(const WCHAR* pScoreIDText)
+void CGameScreen::ScoreCheckpoint(const ScoreCheckpointData& scoreData)
 //Displays score checkpoint stats and uploads the score.
 {
 	//Stats involved in score tallying.
 	ASSERT(this->pCurrentGame);
-	ASSERT(this->pCurrentGame->pPlayer);
-	const PlayerStats& st = this->pCurrentGame->pPlayer->st;
-	UINT dwTotalScore = this->pCurrentGame->GetScore();
+	UINT dwTotalScore = this->pCurrentGame->GetScore(scoreData.stats);
 
 /*
 	wstrLevelStats += wszCRLF;
@@ -4774,10 +4772,10 @@ void CGameScreen::ScoreCheckpoint(const WCHAR* pScoreIDText)
 		this->pRoomWidget, wstrLevelStats.c_str(), F_Stats, 5000, 8000, true));
 */
 
-	SendAchievement(UnicodeToUTF8(pScoreIDText).c_str(), dwTotalScore);
+	SendAchievement(UnicodeToUTF8(scoreData.scorepointName).c_str(), dwTotalScore);
 
 	//Display.
-	ShowScoreDialog(pScoreIDText, st);
+	ShowScoreDialog(scoreData.scorepointName, scoreData.stats);
 }
 
 void CGameScreen::ShowScoreDialog(const WSTRING pTitle, const PlayerStats& st)
@@ -7094,11 +7092,11 @@ SCREENTYPE CGameScreen::ProcessCueEventsAfterRoomDraw(
 		for (pObj = CueEvents.GetFirstPrivateData(CID_ScoreCheckpoint);
 				pObj != NULL; pObj = CueEvents.GetNextPrivateData())
 		{
-			const CDbMessageText *pScoreIDText = DYN_CAST(const CDbMessageText*, const CAttachableObject*, pObj);
-			ASSERT((const WCHAR*)(*pScoreIDText));
+			const ScoreCheckpointData* pScoreData = DYN_CAST(const ScoreCheckpointData*, const CAttachableObject*, pObj);
+			ASSERT(pScoreData);
 			if (!g_pTheSound->IsSoundEffectPlaying(SEID_LEVELCOMPLETE))
 				g_pTheSound->PlaySoundEffect(SEID_LEVELCOMPLETE); //SEID_AREACLEAR is jarring over other music
-			ScoreCheckpoint((const WCHAR*)(*pScoreIDText));
+			ScoreCheckpoint(*pScoreData);
 		}
 	}
 

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -2688,9 +2688,14 @@ void CGameScreen::OnKeyDown(
 		break;
 
 		case CMD_SCORE_KEY:
+		{
 			ASSERT(this->pCurrentGame);
 			ASSERT(this->pCurrentGame->pPlayer);
-			ShowScoreDialog(g_pTheDB->GetMessageText(MID_Score), this->pCurrentGame->pPlayer->st);
+			PlayerStats st = this->pCurrentGame->pPlayer->st; //temp copy for display
+			st.ATK = this->pCurrentGame->getPlayerATK();
+			st.DEF = this->pCurrentGame->getPlayerDEF();
+			ShowScoreDialog(g_pTheDB->GetMessageText(MID_Score), st);
+		}
 		break;
 
 		case CMD_EXTRA_SAVE_GAME:
@@ -4789,8 +4794,8 @@ void CGameScreen::ShowScoreDialog(const WSTRING pTitle, const PlayerStats& st)
 	//Stats involved in score tallying.
 	ASSERT(this->pCurrentGame);
 	dwHP = st.HP;
-	dwATK = this->pCurrentGame->getPlayerATK();
-	dwDEF = this->pCurrentGame->getPlayerDEF();
+	dwATK = st.ATK;
+	dwDEF = st.DEF;
 	dwYKeys = st.yellowKeys;
 	dwGKeys = st.greenKeys;
 	dwBKeys = st.blueKeys;
@@ -4809,7 +4814,7 @@ void CGameScreen::ShowScoreDialog(const WSTRING pTitle, const PlayerStats& st)
 	dwBKeysScore = CCurrentGame::CalculateStatScore(dwBKeys, st.scoreBlueKeys);
 	dwSKeysScore = CCurrentGame::CalculateStatScore(dwSKeys, st.scoreSkeletonKeys);
 	dwShovelsScore = CCurrentGame::CalculateStatScore(dwShovels, st.scoreShovels);
-	dwTotalScore = this->pCurrentGame->GetScore();
+	dwTotalScore = this->pCurrentGame->GetScore(st);
 
 	CTilesWidget* pTilesWidget = DYN_CAST(CTilesWidget*, CWidget*, this->pScoreDialog->GetWidget(TAG_SCORETILES));
 	pTilesWidget->ClearTiles();

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -183,7 +183,7 @@ private:
 	bool           ProcessSpeechSpeaker(CFiredCharacterCommand *pCommand);
 	void           ReattachRetainedSubtitles();
 	void           RestartRoom(int nCommand, CCueEvents& CueEvents);
-	void           ScoreCheckpoint(const WCHAR* pScoreIDText);
+	void           ScoreCheckpoint(const ScoreCheckpointData& scoreData);
 	WSTRING        GetScoreCheckpointLine(const MID_CONSTANT statName, const UINT statAMount, const int scoreMultiplier, const UINT statScore);
 	void           SendAchievement(const char* achievement, const UINT dwScore=0);
 	void           ShowBigMap();

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -3341,13 +3341,15 @@ void CCharacter::Process(
 					if (bNotFrozen ||  //when playing back commands, don't do this stuff
 						this->pCurrentGame->IsValidatingPlayback()) //unless we're validating
 					{
-						CDbMessageText* pScoreIDText = new CDbMessageText();
-						*pScoreIDText = command.label.c_str();
-						CueEvents.Add(CID_ScoreCheckpoint, pScoreIDText, true);
+						PlayerStats stats = player.st;
+						stats.ATK = pGame->getPlayerATK();
+						stats.DEF = pGame->getPlayerDEF();
+						ScoreCheckpointData* pScoreData = new ScoreCheckpointData(stats, command.label);
+						CueEvents.Add(CID_ScoreCheckpoint, pScoreData, true);
 						//Score save and local highscore data will be created at end of turn process
-						//Creating a score during turn processing can cause problems with validation, as it
-						//will only check the end state of a turn. We also don't know if this turn will finish
-						//yet - it might have to be rewound due to blocked or stalled combat.
+						//Creating a score during turn processing can cause problems with validation, as
+						//we don't know if this turn will finish yet - it might have to be rewound due to
+						//blocked or stalled combat. (or the player might die)
 					}
 				}
 				bProcessNextCommand = true;

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -198,7 +198,7 @@ enum CUEEVENT_ID
 
 	//A score checkpoint is triggered.
 	//
-	//Private data: CDbMessageText *pScoreIDText (one)
+	//Private data: ScoreCheckpointData *pScoreData (one)
 	CID_ScoreCheckpoint,
 
 	//If any calls to CDbRoom::Plot() were made in the current room, this event will

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3326,11 +3326,10 @@ void CCurrentGame::ProcessCommand(
 		for (const CAttachableObject* pObj = CueEvents.GetFirstPrivateData(CID_ScoreCheckpoint);
 			pObj != NULL; pObj = CueEvents.GetNextPrivateData())
 		{
-			const CDbMessageText* pScoreIDText = DYN_CAST(const CDbMessageText*, const CAttachableObject*, pObj);
-			ASSERT((const WCHAR*)(*pScoreIDText));
-			const WSTRING wstrScoreIDText((WSTRING)(*pScoreIDText));
-			this->WriteScoreCheckpointSave(wstrScoreIDText);
-			this->WriteLocalHighScore(wstrScoreIDText);
+			const ScoreCheckpointData* pScoreData = DYN_CAST(const ScoreCheckpointData*, const CAttachableObject*, pObj);
+			ASSERT(pScoreData);
+			this->WriteScoreCheckpointSave(*pScoreData);
+			this->WriteLocalHighScore(*pScoreData);
 		}
 	}
 }
@@ -8513,7 +8512,7 @@ UINT CCurrentGame::WriteCurrentRoomConquerDemo()
 */
 
 //***************************************************************************************
-UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
+UINT CCurrentGame::WriteLocalHighScore(const ScoreCheckpointData& scoreData)
 //Creates or updates a high score record for the given scorepoint.
 //
 //Returns:
@@ -8521,10 +8520,6 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 {
 	if (this->bNoSaves)
 		return 0; //playing a dummy game session -- don't save scores
-
-	PlayerStats st = this->pPlayer->st; //temp copy
-	st.ATK = getPlayerATK();
-	st.DEF = getPlayerDEF();
 
 	CDbPlayer* pPlayer = g_pTheDB->GetCurrentPlayer();
 	ASSERT(pPlayer);
@@ -8536,19 +8531,19 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 	}
 
 	CDbLocalHighScore* pHighScore = NULL;
-	int score = GetScore(st);
+	int score = GetScore(scoreData.stats);
 	CDb db;
 	UINT holdID = this->pHold->dwHoldID;
 	UINT playerID = pPlayer->dwPlayerID;
 	CDbPackedVars stats;
-	st.Pack(stats);
+	scoreData.stats.Pack(stats);
 
 	db.HighScores.FilterByHold(holdID);
 	db.HighScores.FilterByPlayer(playerID);
 
-	if (db.HighScores.HasScorepoint(name)) {
+	if (db.HighScores.HasScorepoint(scoreData.scorepointName)) {
 		//Update existing score if a new best has been achieved
-		UINT id = db.HighScores.GetIDForScorepoint(name);
+		UINT id = db.HighScores.GetIDForScorepoint(scoreData.scorepointName);
 		ASSERT(id);
 		pHighScore = db.HighScores.GetByID(id);
 		ASSERT(pHighScore);
@@ -8574,7 +8569,7 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 		pHighScore->dwHoldID = holdID;
 		pHighScore->dwPlayerID = playerID;
 		pHighScore->score = score;
-		pHighScore->scorepointName = name;
+		pHighScore->scorepointName = scoreData.scorepointName;
 		pHighScore->stats = stats;
 		pHighScore->Update();
 
@@ -8589,7 +8584,7 @@ UINT CCurrentGame::WriteLocalHighScore(const WSTRING& name)
 }
 
 //***************************************************************************************
-UINT CCurrentGame::WriteScoreCheckpointSave(const WSTRING& name)
+UINT CCurrentGame::WriteScoreCheckpointSave(const ScoreCheckpointData& scoreData)
 //Writes a saved game record containing the saved game's stats info for upload.
 //
 //Returns:
@@ -8603,12 +8598,11 @@ UINT CCurrentGame::WriteScoreCheckpointSave(const WSTRING& name)
 
 	//Insert the current ATK/DEF levels for the record made for score upload.
 	PlayerStats st = this->pPlayer->st; //temp copy
-	this->pPlayer->st.ATK = getPlayerATK();
-	this->pPlayer->st.DEF = getPlayerDEF();
+	this->pPlayer->st = scoreData.stats;
 
 	PackData(this->stats); //data must be packed at current stat values in order to upload
 			//score values correctly, since room move sequence will not be replayed on the server
-	SaveGame(ST_ScoreCheckpoint, name);
+	SaveGame(ST_ScoreCheckpoint, scoreData.scorepointName);
 	this->pPlayer->st = st; //revert
 	this->stats = tempStats;
 
@@ -8632,7 +8626,7 @@ UINT CCurrentGame::WriteScoreCheckpointSave(const WSTRING& name)
 			{
 				//Uploads are to be handled by front end to avoid delay here.
 				CCurrentGame::scoresForUpload.push(new SCORE_UPLOAD(text, GetScore(),
-						name, this->dwSavedGameID));
+					scoreData.scorepointName, this->dwSavedGameID));
 			}
 		}
 	} else {

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -192,7 +192,7 @@ struct TarstuffStab {
 //*******************************************************************************
 class ScoreCheckpointData : public CAttachableObject {
 public:
-	ScoreCheckpointData(PlayerStats ps, WSTRING name)
+	ScoreCheckpointData(const PlayerStats& ps, const WSTRING& name)
 		: stats(ps), scorepointName(name) {}
 	~ScoreCheckpointData() {}
 	PlayerStats stats;

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -189,6 +189,16 @@ struct TarstuffStab {
 	CMonster* pTarstuffMonster;
 };
 
+//*******************************************************************************
+class ScoreCheckpointData : public CAttachableObject {
+public:
+	ScoreCheckpointData(PlayerStats ps, WSTRING name)
+		: stats(ps), scorepointName(name) {}
+	~ScoreCheckpointData() {}
+	PlayerStats stats;
+	WSTRING scorepointName;
+};
+
 typedef pair<ScriptVars::MapIcon, ScriptVars::MapIconState> MapIconPair;
 
 //*******************************************************************************
@@ -384,8 +394,8 @@ public:
 	bool     UseAccessory(CCueEvents &CueEvents);
 	bool     WalkDownStairs();
 //	UINT     WriteCurrentRoomDieDemo();
-	UINT     WriteLocalHighScore(const WSTRING& name);
-	UINT     WriteScoreCheckpointSave(const WSTRING& name);
+	UINT     WriteLocalHighScore(const ScoreCheckpointData& scoreData);
+	UINT     WriteScoreCheckpointSave(const ScoreCheckpointData& scoreData);
 
 	bool     PrepTempGameForRoomDisplay(const UINT roomID);
 

--- a/drodrpg/DRODLib/Db.cpp
+++ b/drodrpg/DRODLib/Db.cpp
@@ -265,8 +265,7 @@ bool CDb::ValidateSavedGame(
 //
 //Params:
 	const UINT savedGameID,
-	WSTRING& scoreCheckpointName, //(out) name of last score checkpoint encountered
-	PlayerStats& ps) //(out) player stats when last checkpoint is encountered
+	std::vector<ScoreCheckpointData>& scoresData) //(out) scorepoints when last checkpoint is encountered
 {
 	CDbSavedGame *pSavedGame = this->SavedGames.GetByID(savedGameID);
 	if (!pSavedGame)
@@ -291,7 +290,7 @@ bool CDb::ValidateSavedGame(
 	const CStretchyBuffer& moveSequence = pSavedGameMoves->getMoves();
 
 	const UINT holdID = this->SavedGames.GetHoldIDofSavedGame(savedGameID);
-	const bool bGood = ValidateMoveSequence(holdID, moveSequence, scoreCheckpointName, ps);
+	const bool bGood = ValidateMoveSequence(holdID, moveSequence, scoresData);
 
 	delete pSavedGameMoves;
 	delete pSavedGame;
@@ -308,8 +307,7 @@ bool CDb::ValidateMoveSequence(
 //Params:
 	const UINT holdID,
 	const CStretchyBuffer& moves, //full move sequence
-	WSTRING& scoreCheckpointName, //(out) name of last score checkpoint encountered
-	PlayerStats& ps) //(out) player stats when last checkpoint is encountered
+	std::vector<ScoreCheckpointData>& scoresData) //(out) scorepoints when last checkpoint is encountered
 {
 	const UINT bufSize = moves.Size();
 
@@ -338,7 +336,7 @@ bool CDb::ValidateMoveSequence(
 			break;
 		}
 
-		if (!ValidateMoveSequenceCheckCueEvents(CueEvents, pGame, command, bGood, scoreCheckpointName, ps))
+		if (!ValidateMoveSequenceCheckCueEvents(CueEvents, pGame, command, bGood, scoresData))
 			break;
 
 		if (CueEvents.HasAnyOccurred(IDCOUNT(CIDA_PlayerLeftRoom), CIDA_PlayerLeftRoom))
@@ -430,7 +428,7 @@ bool CDb::ValidateMoveSequence(
 	{
 		CueEvents.Clear();
 		pGame->ProcessCommand(CMD_ADVANCE_COMBAT, CueEvents);
-		if (!ValidateMoveSequenceCheckCueEvents(CueEvents, pGame, CMD_ADVANCE_COMBAT, bGood, scoreCheckpointName, ps))
+		if (!ValidateMoveSequenceCheckCueEvents(CueEvents, pGame, CMD_ADVANCE_COMBAT, bGood, scoresData))
 			break;
 	}
 
@@ -442,7 +440,7 @@ bool CDb::ValidateMoveSequence(
 //Returns: true if play continues, false if ended
 bool CDb::ValidateMoveSequenceCheckCueEvents(
 	CCueEvents& CueEvents, CCurrentGame* pGame, const UINT command,
-	bool& bGood, WSTRING& scoreCheckpointName, PlayerStats& ps) //(out)
+	bool& bGood, std::vector<ScoreCheckpointData>& scoresData) //(out)
 const
 {
 	const bool bPlayerDied = CueEvents.HasAnyOccurred(IDCOUNT(CIDA_PlayerDied), CIDA_PlayerDied);
@@ -455,16 +453,16 @@ const
 	//Check for a score checkpoint.
 	if (CueEvents.HasOccurred(CID_ScoreCheckpoint))
 	{
-		//Output name of score checkpoint and player stats at that checkpoint.
-		const CDbMessageText *pScoreIDText = DYN_CAST(const CDbMessageText*, const CAttachableObject*,
-			CueEvents.GetFirstPrivateData(CID_ScoreCheckpoint));
-		ASSERT((const WCHAR*)(*pScoreIDText));
-		scoreCheckpointName = (const WCHAR*)(*pScoreIDText);
-		ps = pGame->pPlayer->st;
-
-		//Alter stats to match how they are scored.
-		ps.ATK = pGame->getPlayerATK();
-		ps.DEF = pGame->getPlayerDEF();
+		//Clear any data from previous turns
+		scoresData.clear();
+		for (const CAttachableObject* pObj = CueEvents.GetFirstPrivateData(CID_ScoreCheckpoint);
+			pObj != NULL; pObj = CueEvents.GetNextPrivateData()) {
+			//Output name of score checkpoint and player stats at that checkpoint.
+			const ScoreCheckpointData *pScoreData = DYN_CAST(const ScoreCheckpointData*, const CAttachableObject*,
+				pObj);
+			ASSERT(pScoreData);
+			scoresData.push_back(*pScoreData);
+		}
 	}
 
 	//Was room exited?

--- a/drodrpg/DRODLib/Db.h
+++ b/drodrpg/DRODLib/Db.h
@@ -86,13 +86,12 @@ public:
 	static bool    FreezingTimeStamps() {return bFreezeTimeStamps;}
 	static void    FreezeTimeStamps(const bool bFlag) {bFreezeTimeStamps = bFlag;}
 
-	bool        ValidateSavedGame(const UINT savedGameID, WSTRING& scoreCheckpointName,
-			PlayerStats& ps);
+	bool        ValidateSavedGame(const UINT savedGameID, std::vector<ScoreCheckpointData>& scoresData);
 	bool        ValidateMoveSequence(const UINT holdID, const CStretchyBuffer& moves,
-			WSTRING& scoreCheckpointName, PlayerStats& ps);
+			 std::vector<ScoreCheckpointData>& scoresData);
 	bool        ValidateMoveSequenceCheckCueEvents(
 			CCueEvents& CueEvents, CCurrentGame* pGame, const UINT command,
-			bool& bGood, WSTRING& scoreCheckpointName, PlayerStats& ps) const;
+			bool& bGood, std::vector<ScoreCheckpointData>& scoresData) const;
 
 	//Use these members to access data directly.  Requires more knowledge of
 	//the database.

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -687,7 +687,7 @@ bool PlayerStats::IsGlobalStatIndex(UINT i)
 }
 
 //***************************************************************************************
-void PlayerStats::Pack(CDbPackedVars& stats)
+void PlayerStats::Pack(CDbPackedVars& stats) const
 //Writes player (and global) RPG stats to the stats buffer.
 {
 	for (UINT i=PredefinedVarCount; i--; )

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -288,7 +288,7 @@ public:
 	void setVar(const ScriptVars::Predefined var, const UINT val);
 
 	static bool IsGlobalStatIndex(UINT i);
-	void Pack(CDbPackedVars& stats);
+	void Pack(CDbPackedVars& stats) const;
 	void Unpack(CDbPackedVars& stats);
 
 //protected:


### PR DESCRIPTION
DROD RPG technically supports having multiple scorepoints trigger on a single turn, in the sense that each one will pop up a score dialog and register a local highscore. However, there are two problems:

- All scores are currently calculated at the end of a turn, so all scorepoints from the same turn will report the same score.
- Score verification can only handle one scorepoint at a time. This means a CNet-published hold that triggers multiple scorepoints on a single turn will have scorepoints that can't be verified.

To fix this, I've made some changes to the scorepoint event:

1. I've created a new utility class, `ScoreCheckpointData`, which allows a scorepoint name and a set of player stats to be attached to a `CID_ScoreCheckpoint` event. This replaces the previous situation where only the name was attached.
2. When a `CC_ScoreCheckpoint` command is processed, it can now attach the "in the moment" player stats to a scorepoint.
3. Every place that proccesses a `CID_ScoreCheckpoint` event now uses the attached player stats where stats are required.
4. `CDb::ValidateSavedGame` can now output multiple scorepoint data objects, allowing all scorepoints from a turn to be verified.

This should probably be looked over by @schikore since he'll have to implement server-side changes to consume the updated validation output.