### PR TITLE
Fix issues with text selection and scrolling.

### DIFF
--- a/FrontEndLib/BitmapManager.cpp
+++ b/FrontEndLib/BitmapManager.cpp
@@ -385,11 +385,11 @@ void CBitmapManager::SetSurfaceAlpha(
 			}
 
 			pPixel += dwRowOffset;
-		}   
+		}
 
 		if (SDL_MUSTLOCK(pSurface))
 			SDL_UnlockSurface(pSurface);
-	}       
+	}
 }
 
 //**********************************************************************************
@@ -1688,6 +1688,23 @@ void CBitmapManager::NegativeRect(
 }
 
 //**********************************************************************************
+void CBitmapManager::CropRect(
+// Crop `rect` to the dimensions of `bounds`, modifying it in place.
+	SDL_Rect& rect,
+	const SDL_Rect& bounds
+) {
+    const int x1 = std::max(rect.x, bounds.x);
+    const int y1 = std::max(rect.y, bounds.y);
+    const int x2 = std::min(rect.x + rect.w, bounds.x + bounds.w);
+    const int y2 = std::min(rect.y + rect.h, bounds.y + bounds.h);
+
+    rect.x = x1;
+    rect.y = y1;
+    rect.w = std::max(x2 - x1, 0);
+    rect.h = std::max(y2 - y1, 0);
+}
+
+//**********************************************************************************
 void CBitmapManager::ClipSrcAndDestToRect(
 //Updates the dest rectangle to fit properly within the positive view area.
 //Translates src to match.
@@ -2677,7 +2694,7 @@ void CBitmapManager::HsvToRectWithTileMask(SDL_Surface* pDestSurface,
 				if (b < minc) {
 					minc = b;
 				}
-				
+
 				maxc /= 255.0f; //0..255 -> 0..1
 				minc /= 255.0f;
 				const float range = float(maxc - minc);
@@ -2710,7 +2727,7 @@ void CBitmapManager::HsvToRectWithTileMask(SDL_Surface* pDestSurface,
 				if (bSetV) {
 					v = v1;
 				}
-				
+
 				//hsv -> rgb
 				if (s == 0.0f) {
 					r = g = b = int(v * 255.0f);

--- a/FrontEndLib/BitmapManager.h
+++ b/FrontEndLib/BitmapManager.h
@@ -110,7 +110,7 @@ public:
 		{BAndWRect(x,y,CX_TILE,CY_TILE,pDestSurface);}
 	void        BlitAlphaSurfaceWithTransparency(SDL_Rect src, SDL_Surface *pSrcSurface,
 			SDL_Rect dest, SDL_Surface *pDestSurface, const Uint8 opacity);
-	void        BlitRGBAtoRGBA(SDL_Surface *pSrcSurface, SDL_Rect *src, 
+	void        BlitRGBAtoRGBA(SDL_Surface *pSrcSurface, SDL_Rect *src,
 			SDL_Surface *pDestSurface, SDL_Rect *dest);
 	void        BlitSurface(SDL_Surface *pSrcSurface, SDL_Rect* src,
 			SDL_Surface *pDestSurface, SDL_Rect* dest,	const Uint8 nOpacity=255);
@@ -140,6 +140,7 @@ public:
 	void        BlitWrappingSurface(SDL_Surface *pSrcSurface, SDL_Rect src,
 			SDL_Surface *pDestSurface, SDL_Rect dest, const Uint8 nOpacity=255);
 
+	static void CropRect(SDL_Rect& cropped, const SDL_Rect& bounds);
 	static void ClipSrcAndDestToRect(SDL_Rect& src, SDL_Rect& dest,
 			const UINT W, const UINT H);
 	static SDL_Surface* ConvertSurface(SDL_Surface *pSurface);

--- a/FrontEndLib/BitmapManager.h
+++ b/FrontEndLib/BitmapManager.h
@@ -140,7 +140,7 @@ public:
 	void        BlitWrappingSurface(SDL_Surface *pSrcSurface, SDL_Rect src,
 			SDL_Surface *pDestSurface, SDL_Rect dest, const Uint8 nOpacity=255);
 
-	static void CropRect(SDL_Rect& cropped, const SDL_Rect& bounds);
+	static void CropRect(SDL_Rect& rect, const SDL_Rect& bounds);
 	static void ClipSrcAndDestToRect(SDL_Rect& src, SDL_Rect& dest,
 			const UINT W, const UINT H);
 	static SDL_Surface* ConvertSurface(SDL_Surface *pSurface);

--- a/FrontEndLib/TextBox2DWidget.cpp
+++ b/FrontEndLib/TextBox2DWidget.cpp
@@ -110,13 +110,15 @@ void CTextBox2DWidget::HandleKeyDown(
 			break;
 		case SDLK_HOME:
 		case SDLK_KP_7:
-			MoveCursorToLineStart();
+			if (bCtrl) MoveCursorToTextStart();
+			else MoveCursorToLineStart();
 			if (bShift) SetSelection(wOldCursorPos, wOldCursorX, wOldCursorY);
 			else ClearSelection();
 			break;
 		case SDLK_END:
 		case SDLK_KP_1:
-			MoveCursorToLineEnd();
+			if (bCtrl) MoveCursorToTextEnd();
+			else MoveCursorToLineEnd();
 			if (bShift) SetSelection(wOldCursorPos, wOldCursorX, wOldCursorY);
 			else ClearSelection();
 			break;
@@ -312,6 +314,30 @@ bool CTextBox2DWidget::MoveCursorToLineEnd()
 }
 
 //******************************************************************************
+bool CTextBox2DWidget::MoveCursorToTextStart()
+//Moves cursor to start of all text.
+//Returns: true
+{
+	// +1 is technically unnecessary but is kept
+	// for consistency with MoveCursorToTextEnd
+	MoveCursorUp(this->lineIndices.size() + 1);
+
+	return true;
+}
+
+//******************************************************************************
+bool CTextBox2DWidget::MoveCursorToTextEnd()
+//Moves cursor to end of all text.
+//Returns: true
+{
+	// +1 is required to put it at the end of the last line if
+	// started on the first
+	MoveCursorDown(this->lineIndices.size() + 1);
+
+	return true;
+}
+
+//******************************************************************************
 bool CTextBox2DWidget::MoveCursorUpPage()
 //Moves cursor down one page (widget height) and moves view with it.
 //Returns: Whether or not the operation was successful (possible)
@@ -332,7 +358,7 @@ bool CTextBox2DWidget::MoveCursorUpPage()
 
 //******************************************************************************
 bool CTextBox2DWidget::MoveCursorDownPage()
-//Moves cursor up one page (widget height) and moves view with it.
+//Moves cursor down one page (widget height) and moves view with it.
 //Returns: Whether or not the operation was successful (possible)
 {
 	ASSERT(this->wCursorIndex <= this->text.size());
@@ -354,27 +380,8 @@ void CTextBox2DWidget::SelectAllText()
 {
 	CTextBoxWidget::SelectAllText();
 
-	// Calculating the selection area on the screen is a bit complicated because
-	// vertical scroll values are baked-into the selection's Y coordinates
-
-	const UINT wLineHeight = g_pTheFM->GetFontLineHeight(this->fontType);
-
-	// Calculate selection start Y - can be negative
-	const int wCurrentLineIndex = getLineContainingIndex(this->wTextDisplayIndex);
-
-	// Calculate selection end X - for good visuals must be the width of the
-	// last line of text
-	const UINT wLastCharacter = this->text.length();
-	const UINT wLastLineStartIndex = getIndexAtStartOfLine(this->lineIndices.size());
-
-	UINT wLastLineWidth, wHIgnored;
-	const WSTRING wStr = this->text.substr(wLastLineStartIndex, wLastCharacter - wLastLineStartIndex);
-	g_pTheFM->GetTextWidthHeight(this->fontType, wStr.c_str(), wLastLineWidth, wHIgnored);
-
-	this->nSelectStartX = 0;
-	this->nSelectStartY = -wCurrentLineIndex * wLineHeight;
-	this->nSelectEndX = wLastLineWidth;
-	this->nSelectEndY = g_pTheFM->GetFontLineHeight(this->fontType) * this->lineIndices.size() + this->nSelectStartY;
+	this->getPositionAtIndex(0, this->nSelectStartX, this->nSelectStartY);
+	this->getPositionAtIndex(this->text.size(), this->nSelectEndX, this->nSelectEndY);
 }
 
 //******************************************************************************
@@ -531,6 +538,20 @@ UINT CTextBox2DWidget::GetViewableTextLinesInWidget() const
 }
 
 //******************************************************************************
+UINT CTextBox2DWidget::GetMaxScrollInLines() const
+// Return the maximum number of lines the widget can be scrolled down
+{
+	const UINT wViewableLines = GetViewableTextLinesInWidget();
+	const UINT wTotalLines = this->lineIndices.size();
+
+	if (wTotalLines < wViewableLines) {
+		return 0;
+	} else {
+		return wTotalLines - wViewableLines + 1;
+	}
+}
+
+//******************************************************************************
 void CTextBox2DWidget::ScrollDownOnePage()
 //Scroll view down one page of text, if possible.
 {
@@ -665,10 +686,8 @@ void CTextBox2DWidget::SetSelection(const UINT wStart,
 	const UINT wCursorStartX, const UINT wCursorStartY)
 {
 	CTextBoxWidget::SetSelection(wStart);
-	if (this->nSelectStartX == -1)
-	{
-		this->nSelectStartX = wCursorStartX;
-		this->nSelectStartY = wCursorStartY;
+	if (this->nSelectStartX == -1) {
+		this->getPositionAtIndex(wStart, this->nSelectStartX, this->nSelectStartY);
 	}
 	this->nSelectEndX = this->wCursorX;
 	this->nSelectEndY = this->wCursorY;
@@ -1080,15 +1099,48 @@ const
 }
 
 //******************************************************************************
+void CTextBox2DWidget::getPositionAtIndex(
+//Given an index returns the relative position of the character's top-left corner
+//to the current view. This takes into account scrolls and can produce negative
+//Y positions. Most useful to fill nSelect variables
+	const UINT index, // IN: Index of the character
+	int &wX, int &wY) // OUT: Calculated position
+const {
+	if (index > this->text.size()) {
+		wX = 0;
+		wY = 0;
+		return;
+	}
+
+	const UINT wLineHeight = g_pTheFM->GetFontLineHeight(this->fontType);
+	const int wCurrentLineIndex = getLineContainingIndex(this->wTextDisplayIndex);
+	const int wLine = getLineContainingIndex(index);
+	const int wLineFirstCharacterIndex = getIndexAtStartOfLine(wLine);
+
+	UINT wLineWidthTillCharacter, wHIgnored;
+	const WSTRING wStr = this->text.substr(
+		wLineFirstCharacterIndex,
+		index - wLineFirstCharacterIndex
+	);
+	g_pTheFM->GetTextWidthHeight(this->fontType, wStr.c_str(), wLineWidthTillCharacter, wHIgnored);
+
+	wX = wLineWidthTillCharacter;
+	wY = (wLine - wCurrentLineIndex) * wLineHeight;
+}
+
+//******************************************************************************
 UINT CTextBox2DWidget::MoveViewDown(const UINT wNumLines)   //[default=1]
 //Move viewing area down a line.
 //Returns: Number of lines actually moved down
 {
 	UINT numMoved = 0;
 	UINT wIndex = this->wTextDisplayIndex;
+	UINT wStartingLine = getLineContainingIndex(wIndex);
 	const UINT wLength = this->text.size();
+	const UINT wMaxLines = GetMaxScrollInLines();
 	for (UINT line = 0; line < wNumLines; ++line)
 	{
+		if (wStartingLine + line >= wMaxLines) break;
 		if (wIndex >= wLength) break;
 		if (!getLineStartIndexFollowingIndex(wIndex))
 			break; //already at bottom line

--- a/FrontEndLib/TextBox2DWidget.cpp
+++ b/FrontEndLib/TextBox2DWidget.cpp
@@ -353,50 +353,28 @@ bool CTextBox2DWidget::MoveCursorDownPage()
 void CTextBox2DWidget::SelectAllText()
 {
 	CTextBoxWidget::SelectAllText();
-	CalculateHighlightedRegion();
-}
 
-void CTextBox2DWidget::CalculateHighlightedRegion()
-{
-	if (!HasSelection())
-		return;
+	// Calculating the selection area on the screen is a bit complicated because
+	// vertical scroll values are baked-into the selection's Y coordinates
 
-	const int nLineHeightPixels = g_pTheFM->GetFontLineHeight(this->fontType);
+	const UINT wLineHeight = g_pTheFM->GetFontLineHeight(this->fontType);
 
-	//Calculate where to start highlighting.
-	const UINT wTopViewLine = getLineContainingIndex(this->wTextDisplayIndex);
-	if (this->wMarkStart <= this->wTextDisplayIndex) {
-		this->nSelectStartX = this->nSelectStartY = 0;
-	} else {
-		const UINT wStartLineIndex = getLineContainingIndex(this->wMarkStart);
-		ASSERT(wStartLineIndex >= wTopViewLine);
-		this->nSelectStartY = (wStartLineIndex - wTopViewLine) * nLineHeightPixels;
+	// Calculate selection start Y - can be negative
+	const int wCurrentLineIndex = getLineContainingIndex(this->wTextDisplayIndex);
 
-		const UINT wIndexAtStartOfHighlightStartLine = getIndexAtStartOfLine(wStartLineIndex);
-		UINT wW, wHIgnored;
-		const WSTRING wStr = this->text.substr(wIndexAtStartOfHighlightStartLine, this->wMarkStart);
-		g_pTheFM->GetTextWidthHeight(this->fontType, wStr.c_str(), wW, wHIgnored);
-		this->nSelectStartX = int(wW);
-	}
+	// Calculate selection end X - for good visuals must be the width of the
+	// last line of text
+	const UINT wLastCharacter = this->text.length();
+	const UINT wLastLineStartIndex = getIndexAtStartOfLine(this->lineIndices.size());
 
-	//Calculate where to end highlighting.
-	const UINT wEndLineIndex = getLineContainingIndex(this->wMarkEnd);
-	const UINT wViewableTextLinesInWidget = GetViewableTextLinesInWidget();
-	const UINT wHighlightedLines = wEndLineIndex - wTopViewLine;
+	UINT wLastLineWidth, wHIgnored;
+	const WSTRING wStr = this->text.substr(wLastLineStartIndex, wLastCharacter - wLastLineStartIndex);
+	g_pTheFM->GetTextWidthHeight(this->fontType, wStr.c_str(), wLastLineWidth, wHIgnored);
 
-	if (wHighlightedLines > wViewableTextLinesInWidget) {
-		const int nOffsetX = 0; //!!TODO needed?
-		this->nSelectEndX = GetTextLineDisplayWidth(nOffsetX);
-		this->nSelectEndY = wViewableTextLinesInWidget * nLineHeightPixels - EDGE_OFFSET;
-	} else {
-		const UINT wIndexAtStartOfHighlightEndLine = getIndexAtStartOfLine(wEndLineIndex);
-		UINT wW, wHIgnored;
-		const WSTRING wStr = this->text.substr(wIndexAtStartOfHighlightEndLine, this->wMarkEnd);
-		g_pTheFM->GetTextWidthHeight(this->fontType, wStr.c_str(), wW, wHIgnored);
-		this->nSelectEndX = int(wW);
-
-		this->nSelectEndY = wHighlightedLines * nLineHeightPixels;
-	}
+	this->nSelectStartX = 0;
+	this->nSelectStartY = -wCurrentLineIndex * wLineHeight;
+	this->nSelectEndX = wLastLineWidth;
+	this->nSelectEndY = g_pTheFM->GetFontLineHeight(this->fontType) * this->lineIndices.size() + this->nSelectStartY;
 }
 
 //******************************************************************************
@@ -541,7 +519,6 @@ void CTextBox2DWidget::ScrollDownOneLine(const UINT wLines)   //[default=1]
 		MoveViewDown(lineDelta);
 		CalcAreas();
 		GetPixelLocationAt(this->wTextDisplayIndex, this->wCursorIndex, this->wCursorX, this->wCursorY);
-		CalculateHighlightedRegion();
 	}
 }
 
@@ -571,7 +548,6 @@ void CTextBox2DWidget::ScrollUpOneLine(const UINT wLines)   //[default=1]
 		MoveViewUp(wLines);
 		CalcAreas();
 		GetPixelLocationAt(this->wTextDisplayIndex, this->wCursorIndex, this->wCursorX, this->wCursorY);
-		CalculateHighlightedRegion();
 	}
 }
 
@@ -807,51 +783,103 @@ void CTextBox2DWidget::DrawText(
 		index = nextIndex;
 	}
 
-	if (!HasSelection() || !IsSelected()) //don't show selection when widget doesn't have focus
+	// Don't show selection when widget doesn't have focus or selection is
+	// not calculated/visible
+	if (
+		!HasSelection() || !IsSelected()
+		|| this->nSelectStartX == -1 || this->nSelectStartY == -1
+		|| this->nSelectEndX == -1 || this->nSelectEndY == -1
+	) {
 		return;
+	}
 
 	//Highlight selected text.
 	const UINT wW = GetTextLineDisplayWidth(nOffsetX);
+	const UINT wViewableTextLinesInWidget = GetViewableTextLinesInWidget();
+	const int dItemsListH = this->ItemsRect.h - Y_KLUDGE * 2;
 
 	//Determine where to start and end highlighting.
 	int nStartX, nStartY, nEndX, nEndY;
-	if (this->nSelectStartY <= this->nSelectEndY)
-	{
-		nStartX = this->nSelectStartX;  nStartY = this->nSelectStartY;
-		nEndX = this->nSelectEndX;  nEndY = this->nSelectEndY;
+	if (this->nSelectStartY <= this->nSelectEndY) {
+		nStartX = this->nSelectStartX;
+		nStartY = this->nSelectStartY;
+		nEndX = this->nSelectEndX;
+		nEndY = this->nSelectEndY;
+
+		// For single line selections make sure start is smaller than end
+		// to simplify later calculations
+		if (this->nSelectStartY == this->nSelectEndY && nStartX > nEndX) {
+			std::swap(nStartX, nEndX);
+		}
+
 	} else {
-		nStartX = this->nSelectEndX;  nStartY = this->nSelectEndY;
-		nEndX = this->nSelectStartX;  nEndY = this->nSelectStartY;
+		nStartX = this->nSelectEndX;
+		nStartY = this->nSelectEndY;
+		nEndX = this->nSelectStartX;
+		nEndY = this->nSelectStartY;
 	}
-	nEndY += Y_KLUDGE + EDGE_OFFSET;
-	if (nEndY < 0) return;  //selected area out of view
-	if (nStartY < 0)
-	{	//Highlight begins above viewed area.  Start highlighting from beginning.
-		nStartX = nStartY = 0;
+	// Selection completely outside display, ignore
+	if (nEndY < 0 || nStartY > dItemsListH) {
+		return;
 	}
-	nStartY += Y_KLUDGE + EDGE_OFFSET;
 
 	//Highlight.
 	const int nLineHeight = g_pTheFM->GetFontLineHeight(this->fontType);
-	if (nStartY == nEndY)
-	{
-		if (nStartX == nEndX) return;
-		if (nStartX > nEndX) std::swap(nStartX, nEndX);
-		g_pTheBM->Invert(GetDestSurface(), wX + nStartX, wY + nStartY,
-				nEndX - nStartX, nLineHeight-1);
-	} else {
-		//Highlight multi-line region in three strips.
-		const int nMidRegionY = nEndY - (nStartY + nLineHeight);
-		g_pTheBM->Invert(GetDestSurface(), wX + nStartX, wY + nStartY,
-				wW - nStartX, nLineHeight);
-		if (nMidRegionY >= nLineHeight) {
-			g_pTheBM->Invert(GetDestSurface(), wX, wY + nStartY + nLineHeight,
-					wW, nMidRegionY);
-		} else if (nEndX>nStartX && nMidRegionY > 0) {
-			g_pTheBM->Invert(GetDestSurface(), wX+nStartX, wY + nStartY + nLineHeight,
-					nEndX-nStartX, nMidRegionY);
-		}
-		g_pTheBM->Invert(GetDestSurface(), wX, wY + nEndY, nEndX, nLineHeight-1);
+
+	nStartY += Y_KLUDGE + EDGE_OFFSET;
+	nEndY += Y_KLUDGE + EDGE_OFFSET + nLineHeight;
+
+	/*
+	 Highlight is constructed in three strips:
+	  - One for the top line of the selection which can have an indent
+	  - One for the bottom line of the selection which may take only some of the line
+	  - One for the middle section which takes full width of the line and
+	    fills the space between the two
+	 */
+
+	// STEP 1: Calculate strips' rects in relation to the widget without limitations
+	SDL_Rect StripTop    = MAKE_SDL_RECT(wX + nStartX, wY + nStartY, wW - nStartX, nLineHeight);
+	SDL_Rect StripMiddle = MAKE_SDL_RECT(wX, wY + nStartY + nLineHeight, wW, nEndY - nStartY - nLineHeight * 2);
+	SDL_Rect StripBottom = MAKE_SDL_RECT(wX, wY + nEndY - nLineHeight, nEndX, nLineHeight);
+
+	// STEP 2: Special case, if it's only a single-line selection adjust top strip width
+	if (nStartY + nLineHeight >= nEndY) {
+		StripTop.w = nEndX - nStartX;
+		StripMiddle.h = 0;
+		StripBottom.h = 0;
+	}
+
+	// STEP 3: Crop the strips against the visible space
+	SDL_Rect CropArea = this->ItemsRect;
+	CropArea.h -= EDGE_OFFSET; // to avoid drawing outside text box
+
+	CBitmapManager::CropRect(StripTop, CropArea);
+	CBitmapManager::CropRect(StripMiddle, CropArea);
+	CBitmapManager::CropRect(StripBottom, CropArea);
+
+	// STEP 4: Render each strip if possible
+	if (StripTop.w > 0 && StripTop.h > 0) {
+		g_pTheBM->Invert(
+			GetDestSurface(),
+			StripTop.x, StripTop.y,
+			StripTop.w, StripTop.h
+		);
+	}
+
+	if (StripMiddle.w > 0 && StripMiddle.h > 0) {
+		g_pTheBM->Invert(
+			GetDestSurface(),
+			StripMiddle.x, StripMiddle.y,
+			StripMiddle.w, StripMiddle.h
+		);
+	}
+
+	if (StripBottom.w > 0 && StripBottom.h > 0) {
+		g_pTheBM->Invert(
+			GetDestSurface(),
+			StripBottom.x, StripBottom.y,
+			StripBottom.w, StripBottom.h
+		);
 	}
 }
 

--- a/FrontEndLib/TextBox2DWidget.h
+++ b/FrontEndLib/TextBox2DWidget.h
@@ -69,6 +69,8 @@ protected:
 	bool           MoveCursorDown(UINT wNumLines = 1);
 	bool           MoveCursorToLineStart();
 	bool           MoveCursorToLineEnd();
+	bool           MoveCursorToTextStart();
+	bool           MoveCursorToTextEnd();
 	bool           MoveCursorUpPage();
 	bool           MoveCursorDownPage();
 
@@ -86,10 +88,12 @@ private:
 
 	UINT           GetTextLineDisplayWidth(const int nOffsetX) const;
 	UINT           GetViewableTextLinesInWidget() const;
+	UINT           GetMaxScrollInLines() const;
 
 	UINT           getIndexAtStartOfLine(const UINT lineNo) const;
 	UINT           getLineContainingIndex(const UINT index) const;
 	bool           getLineStartIndexFollowingIndex(UINT& index) const;
+	void           getPositionAtIndex(const UINT index, int &wX, int &wY) const;
 
 	UINT           MoveViewDown(const UINT wNumLines = 1);
 	UINT           MoveViewUp(const UINT wNumLines = 1);

--- a/FrontEndLib/TextBox2DWidget.h
+++ b/FrontEndLib/TextBox2DWidget.h
@@ -81,7 +81,6 @@ protected:
 private:
 	void           CalcCursorPosition(const UINT viewIndex, const UINT wCursorIndex,
 			UINT &wCursorX, UINT &wCursorY) const;
-	void           CalculateHighlightedRegion();
 	void           GetPixelLocationAt(const UINT viewIndex, const UINT wIndex,
 			UINT &wPixelX, UINT &wPixelY) const;
 
@@ -99,6 +98,11 @@ private:
 	int            nSelectStartX, nSelectStartY; //highlighted region marker
 	int            nSelectEndX, nSelectEndY;
 
+	/**
+	 * Vector containing the index+1 of the last character displayed on that line.
+	 * Eg text "Hello\rOrb" will have values [6, 9] because "Hello\r" is 5
+	 * characters (so 5+1 = 6) and "Orb" is 3 characters (so 5 + 3 + 1).
+	 */
 	vector<UINT>   lineIndices; //text index located at the start of each text display line (after the first)
 	WSTRING        prevText;    //text used last time widget stats were calculated
 	UINT           wPosClickTopLine; //retain original location when dragging vert scroll bar

--- a/FrontEndLib/TextBoxWidget.cpp
+++ b/FrontEndLib/TextBoxWidget.cpp
@@ -133,14 +133,21 @@ void CTextBoxWidget::HandleKeyDown(
 	case SDLK_BACKSPACE:
 		if (HasSelection())
 			DeleteSelected();
-		else if (MoveCursorLeft())
+		else if (MoveCursorLeft()) {
+			this->undoList.push_back(TextUndoInfo(this->GetText(), this->wCursorIndex + 1));
 			DeleteAtCursor();
+		}
 		break;
 	case SDLK_DELETE:
 	case SDLK_KP_PERIOD:
-		if (!HasSelection())
+		if (!HasSelection()) {
+			// Only store undo if there is anything to delete
+			if (this->wCursorIndex < this->text.size()) {
+				this->undoList.push_back(TextUndoInfo(this->GetText(), this->wCursorIndex));
+			}
+
 			DeleteAtCursor();
-		else
+		} else
 			DeleteSelected();
 		break;
 	case SDLK_LEFT:
@@ -588,7 +595,9 @@ void CTextBoxWidget::SetText(const WCHAR* newText, const bool bClearUndos)
 	//Selection is no longer valid.
 	ClearSelection();
 
-	this->wTextDisplayIndex = 0;
+	if (bClearUndos) {
+		this->wTextDisplayIndex = 0;
+	}
 	CalcAreas();
 
 	//Undo/redo lists are invalidated.  Cursor is placed at end of text.
@@ -693,6 +702,8 @@ bool CTextBoxWidget::DeleteSelected()
 {
 	if (!HasSelection())
 		return false;
+
+	this->undoList.push_back(TextUndoInfo(this->GetText(), this->wCursorIndex));
 
 	UINT wStart, wEnd;
 	GetSelection(wStart, wEnd);

--- a/Master/Linux/ninjamaker
+++ b/Master/Linux/ninjamaker
@@ -44,7 +44,7 @@ distlinkflags_post=(
 
 declare -A buildflags
 buildflags=(
-	[debug]="-Og -D_DEBUG -DENABLE_BREAKPOINTS"
+	[debug]="-O0 -D_DEBUG -DENABLE_BREAKPOINTS"
 	[debugsan]="-Og -D_DEBUG -DENABLE_BREAKPOINTS -fsanitize=address -fsanitize=undefined"
 	[dev]="-Og -D_DEBUG -DENABLE_BREAKPOINTS -DDEV_BUILD"
 	[release]="-O2 -DNDEBUG -flto"


### PR DESCRIPTION
(In this commit message when I mention "selection pixels" I am referring to the four `nSelect...` properties in `TextBox2DWidget` which are responsible for determining the pixel positions of the first and last selection character that are then used to draw the selection area)

ISSUE: A bunch of issues with text selection and scrolling:
 - When selection contains an empty line, scrolling with mouse wheel or scroll bar buttons causes assertion beep
 - Generally scrolling with mouse wheel breaks selection
 - Scrolling with scroll bar causes issues with selection drawing outside the widget if the selection is "below" the widget

DIAGNOSIS: Basically there were two mechanism for calculating the selection area on the screen:
1. First a selection can be made by arrows/mouse by dragging. This stores the selection pixels in the four `nSelect...` variables.
2. Then if you use the scrollbar it just moves the selection Y by pixels up and down.
3. But if then used mouse wheel or the buttons this caused a call to `CalculateHighlightedRegion()` which regenerated the selection pixels and was broken. It also tried to crop the selected area to the visible area on the screen which meant that if this cropped the selection area and you switched to using the scrollbar the selection would be wrong. It would be wrong if it worked at all.

Then there was only partial cropping during the render phase which had a few issues of its own.

SOLUTION: A big rewrite of major parts on how the selection pixels are calculated. The gist is that we now keep the selection intact as calculated during selecting and then crop it to the visible area during render.

It was the broken selection-pixel-regeneration method. It was called in a few places:
 - `ScrollDownOneLine` and `ScrollUpOneLine` - in both cases it was completely unnecessary because they both call `MoveView...` functions which already move the selection. Removing it fixed the beep and all issues with scrolling with mouse wheel. It still caused a bunch of other issues when selection was fully or partially outside the drawing area.
 - `SelectAllText` - it didn't work correctly and was replaced with a mechanism to calculate the position of the first and last character in the text box.

I tried to salvage the existing highlight drawing code but beyond the general idea it was rewritten from scratch as nothing worked quite well. It now calculates the area of each strip in relation to current view and then crops it to the visible area. This way we don't need special hacks for various scenarios (is the first strip still visible? last strip? what if they are only visible partially?) and if a strip is partially visible we render it partially.

Also disabled optimizations for linux debug builds because that caused too much inlining which made me waste an hour or two chasing the bug in an incorrect place.

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47367&page=0