### PR TITLE
Fix image overlay stopping on 0-duration commands.

### DIFF
--- a/DROD/ImageOverlayEffect.cpp
+++ b/DROD/ImageOverlayEffect.cpp
@@ -400,18 +400,19 @@ bool CImageOverlayEffect::CanLoop() const
 	return this->maxLoops == ImageOverlayCommand::NO_LOOP_MAX || this->loopIteration < this->maxLoops;
 }
 
-bool CImageOverlayEffect::CanContinuePlayingEffect(const Uint32 dwRemainingTIme) const
+bool CImageOverlayEffect::CanContinuePlayingEffect(const Uint32 dwRemainingTime) const
 {
 	// There are no more effects to play, so AdvanceState() has to handle looping nopw
 	if (IsCommandQueueFinished())
 		return false;
 
 	// If there is any remaining time then continue playing commands
-	if (dwRemainingTIme > 0)
+	if (dwRemainingTime > 0)
 		return true;
 
-	// If it's a time based command we need to stop
-	return !IsTimeBasedCommand(this->commands[this->index].type);
+	// Cannot continue if it's a time-based command with time larger than 0
+	return !IsTimeBasedCommand(this->commands[this->index].type)
+		|| this->executionState.remainingTime == 0;
 }
 
 bool CImageOverlayEffect::IsCommandQueueFinished() const

--- a/drodrpg/DROD/ImageOverlayEffect.cpp
+++ b/drodrpg/DROD/ImageOverlayEffect.cpp
@@ -384,18 +384,19 @@ bool CImageOverlayEffect::CanLoop() const
 	return this->maxLoops == ImageOverlayCommand::NO_LOOP_MAX || this->loopIteration < this->maxLoops;
 }
 
-bool CImageOverlayEffect::CanContinuePlayingEffect(const Uint32 dwRemainingTIme) const
+bool CImageOverlayEffect::CanContinuePlayingEffect(const Uint32 dwRemainingTime) const
 {
 	// There are no more effects to play, so AdvanceState() has to handle looping nopw
 	if (IsCommandQueueFinished())
 		return false;
 
 	// If there is any remaining time then continue playing commands
-	if (dwRemainingTIme > 0)
+	if (dwRemainingTime > 0)
 		return true;
 
-	// If it's a time based command we need to stop
-	return !IsTimeBasedCommand(this->commands[this->index].type);
+	// Cannot continue if it's a time-based command with time larger than 0
+	return !IsTimeBasedCommand(this->commands[this->index].type)
+		|| this->executionState.remainingTime == 0;
 }
 
 bool CImageOverlayEffect::IsCommandQueueFinished() const


### PR DESCRIPTION
**ISSUE:** When Image Overlay is first drawn it will stop execution on time based commands that have duration set to 0, eg. `Move 22 22 0`

**DIAGNOSIS:** The check that stops execution does not care about the command's duration, it just checks its type

**SOLUTION:** Fixed it to happily execute 0-time commands even if remaining time is also 0. Also fixed for RPG (did not test)

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47368&page=0