### PR TITLE
Add way to quietly run Build command.

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -195,6 +195,9 @@ const UINT TAG_ENTITY_LISTBOX = 863;
 const UINT TAG_PLAYER_STATE_LISTBOX = 862;
 const UINT TAG_PLAYER_STATE_LISTBOX2 = 861;
 const UINT TAG_RESTRICTED_LABEL = 860;
+/// Playing sound effect for Build command
+const UINT TAG_BUILD_SOUNDLABEL = 859;
+const UINT TAG_BUILD_SOUNDLISTBOX = 858;
 
 const UINT MAX_TEXT_LABEL_SIZE = 100;
 
@@ -467,6 +470,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	, pColorListBox(NULL)
 	, pOrbAgentListBox(NULL)
 	, pPlayerBehaviorListBox(NULL), pPlayerBehaviorStateListBox(NULL)
+	, pBuildSoundOnOffListBox(NULL)
 	, pCharacter(NULL)
 	, pCommand(NULL)
 	, pSound(NULL)
@@ -1263,6 +1267,17 @@ void CCharacterDialogWidget::AddCommandDialog()
 	static const int Y_ITEMLISTBOX = Y_GRAPHICLISTBOX2;
 	static const UINT CX_ITEMLISTBOX = 420;
 	static const UINT CY_ITEMLISTBOX = CY_GRAPHICLISTBOX2;
+	static const UINT CY_BUILDITEMLISTBOX = 18*LIST_LINE_HEIGHT+4;
+
+	static const int X_BUILD_SOUNDLABEL = X_ITEMLISTBOX;
+	static const int Y_BUILD_SOUNDLABEL = Y_ITEMLISTBOX + CY_BUILDITEMLISTBOX + CY_SPACE/2;
+	static const UINT CX_BUILD_SOUNDLABEL = CX_DIRECTIONLISTBOX3;
+	static const UINT CY_BUILD_SOUNDLABEL = CY_WAITLABEL;
+
+	static const int X_BUILD_SOUNDLISTBOX = X_ITEMLISTBOX;
+	static const int Y_BUILD_SOUNDLISTBOX = Y_BUILD_SOUNDLABEL + CY_BUILD_SOUNDLABEL;
+	static const UINT CX_BUILD_SOUNDLISTBOX = 100;
+	static const UINT CY_BUILD_SOUNDLISTBOX = 53;
 
 	static const int X_CUTSCENELABEL = X_WAITLABEL;
 	static const int Y_CUTSCENELABEL = Y_WAITLABEL;
@@ -1711,7 +1726,7 @@ void CCharacterDialogWidget::AddCommandDialog()
 		CX_WAITLABEL, CY_WAITLABEL, F_Small, g_pTheDB->GetMessageText(MID_IgnoreWeapons)));
 
 	this->pBuildItemsListBox = new CListBoxWidget(TAG_BUILDITEMLISTBOX,
-		X_ITEMLISTBOX, Y_ITEMLISTBOX, CX_ITEMLISTBOX, CY_ITEMLISTBOX);
+		X_ITEMLISTBOX, Y_ITEMLISTBOX, CX_ITEMLISTBOX, CY_BUILDITEMLISTBOX);
 	this->pAddCommandDialog->AddWidget(this->pBuildItemsListBox);
 	this->pBuildItemsListBox->SortAlphabetically(true);
 	this->pBuildItemsListBox->SetHotkeyItemSelection(true);
@@ -1779,6 +1794,13 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pOnOffListBox2->AddItem(0, g_pTheDB->GetMessageText(MID_Off));
 	this->pOnOffListBox2->AddItem(1, g_pTheDB->GetMessageText(MID_On));
 	this->pOnOffListBox2->SelectLine(0);
+
+	this->pBuildSoundOnOffListBox = new CListBoxWidget(TAG_BUILD_SOUNDLISTBOX,
+			X_BUILD_SOUNDLISTBOX, Y_BUILD_SOUNDLISTBOX, CX_BUILD_SOUNDLISTBOX, CY_BUILD_SOUNDLISTBOX);
+	this->pAddCommandDialog->AddWidget(this->pBuildSoundOnOffListBox);
+	this->pBuildSoundOnOffListBox->AddItem(0, g_pTheDB->GetMessageText(MID_Off));
+	this->pBuildSoundOnOffListBox->AddItem(1, g_pTheDB->GetMessageText(MID_On));
+	this->pBuildSoundOnOffListBox->SelectLine(1);
 
 	this->pImperativeListBox = new CListBoxWidget(TAG_IMPERATIVELISTBOX,
 			X_IMPERATIVELISTBOX, Y_IMPERATIVELISTBOX, CX_IMPERATIVELISTBOX, CY_IMPERATIVELISTBOX);
@@ -2052,6 +2074,10 @@ void CCharacterDialogWidget::AddCommandDialog()
 
 	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_SOUNDEFFECTLABEL,
 			X_SOUNDEFFECTLABEL, Y_SOUNDEFFECTLABEL, CX_SOUNDEFFECTLABEL, CY_SOUNDEFFECTLABEL,
+			F_Small, g_pTheDB->GetMessageText(MID_SoundEffect)));
+
+	this->pAddCommandDialog->AddWidget(new CLabelWidget(TAG_BUILD_SOUNDLABEL,
+			X_BUILD_SOUNDLABEL, Y_BUILD_SOUNDLABEL, CX_BUILD_SOUNDLABEL, CY_BUILD_SOUNDLABEL,
 			F_Small, g_pTheDB->GetMessageText(MID_SoundEffect)));
 
 	//Display filter list box.
@@ -3886,6 +3912,12 @@ const
 			wstr += wszComma;
 			wstr += _itoW(command.y + command.h, temp, 10);
 			wstr += wszRightParen;
+			if (command.label.compare(wszBuildCommandModifierQuiet) == 0) {
+				wstr += wszSpace;
+				wstr += wszLeftParen;
+				wstr += g_pTheDB->GetMessageText(MID_BuildModifierQuiet);
+				wstr += wszRightParen;
+			}
 		break;
 
 		case CCharacterCommand::CC_LinkOrb:
@@ -6002,7 +6034,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 {
 	//Code is structured in this way to facilitate quick addition of
 	//additional action parameters.
-	static const UINT NUM_WIDGETS = 67;
+	static const UINT NUM_WIDGETS = 68;
 	static const UINT widgetTag[NUM_WIDGETS] = {
 		TAG_WAIT, TAG_EVENTLISTBOX, TAG_DELAY, TAG_SPEECHTEXT,
 		TAG_SPEAKERLISTBOX, TAG_MOODLISTBOX, TAG_ADDSOUND, TAG_TESTSOUND, TAG_DIRECTIONLISTBOX,
@@ -6023,7 +6055,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_MOVETYPELISTBOX, TAG_IGNOREFLAGSLISTBOX, TAG_COLOR_LISTBOX, TAG_WEAPON_LISTBOX2,
 		TAG_VARCOMPLIST2, TAG_ORBAGENTLIST, TAG_PLAYERBEHAVE_LIST, TAG_PLAYERBEHAVESTATE_LIST,
 		TAG_ARRAYVARLIST, TAG_ARRAYVAROPLIST, TAG_ARRAYVAR_REMOVE, TAG_ITEM_GROUP_LISTBOX,
-		TAG_ENTITY_LISTBOX, TAG_PLAYER_STATE_LISTBOX, TAG_PLAYER_STATE_LISTBOX2
+		TAG_ENTITY_LISTBOX, TAG_PLAYER_STATE_LISTBOX, TAG_PLAYER_STATE_LISTBOX2,
+		TAG_BUILD_SOUNDLISTBOX
 	};
 
 	static const UINT NO_WIDGETS[] =    {0};
@@ -6048,7 +6081,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT IMPERATIVE[] =    {TAG_IMPERATIVELISTBOX, 0};
 	static const UINT BEHAVIOR[] =      {TAG_ONOFFLISTBOX3, TAG_BEHAVIOR_LISTBOX, 0};
 	static const UINT ANSWER[] =        {TAG_GOTOLABELTEXT, TAG_GOTOLABELLISTBOX, 0};
-	static const UINT BUILD_ITEMS[] =   { TAG_BUILDITEMLISTBOX, 0 };
+	static const UINT BUILD_ITEMS[] =   { TAG_BUILDITEMLISTBOX, TAG_BUILD_SOUNDLISTBOX, 0 };
 	static const UINT BUILD_MARKER_ITEMS[] = { TAG_BUILDMARKERITEMLISTBOX, 0 };
 	static const UINT WAIT_FOR_ITEMS[] = {TAG_WAITFORITEMLISTBOX, 0};
 	static const UINT XY[] =            {TAG_X_COORD, TAG_Y_COORD, 0};
@@ -6210,7 +6243,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		NO_WIDGETS,         //CC_IfElseIfNot
 	};
 
-	static const UINT NUM_LABELS = 35;
+	static const UINT NUM_LABELS = 36;
 	static const UINT labelTag[NUM_LABELS] = {
 		TAG_EVENTLABEL, TAG_WAITLABEL, TAG_DELAYLABEL, TAG_SPEAKERLABEL,
 		TAG_MOODLABEL, TAG_TEXTLABEL, TAG_DIRECTIONLABEL, TAG_SOUNDNAME_LABEL,
@@ -6221,7 +6254,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_X_COORD_LABEL, TAG_Y_COORD_LABEL, TAG_COLOR_LABEL, TAG_INPUTLABEL,
 		TAG_IMAGEOVERLAY_LABEL, TAG_SINGLESTEP2, TAG_KEEPBEHAVIOR_LABEL,
 		TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, TAG_ARRAYINDEX_LABEL,
-		TAG_ARRAYVAR_TEXTLABEL, TAG_RESTRICTED_LABEL
+		TAG_ARRAYVAR_TEXTLABEL, TAG_RESTRICTED_LABEL, TAG_BUILD_SOUNDLABEL
 	};
 
 	static const UINT NO_LABELS[] =      {0};
@@ -6246,14 +6279,15 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT NEWENTITY_L[] =    {TAG_DIRECTIONLABEL2, 0};
 	static const UINT EFFECT_L[] =       {TAG_DIRECTIONLABEL, TAG_SOUNDEFFECTLABEL, 0};
 	static const UINT INPUT_L[] =        {TAG_INPUTLABEL, 0};
-	static const UINT IMAGE_OVERLAY_L[] = { TAG_IMAGEOVERLAY_LABEL, 0 };
+	static const UINT IMAGE_OVERLAY_L[] ={ TAG_IMAGEOVERLAY_LABEL, 0 };
 	static const UINT FACE_TOWARDS_L[] = { TAG_SINGLESTEP2, 0 };
 	static const UINT PUSH_TILE_L[] =    { TAG_DIRECTIONLABEL2, 0 };
 	static const UINT NPC_GRAPHIC_L[] =  { TAG_KEEPBEHAVIOR_LABEL, 0 };
 	static const UINT OPEN_TILE_L[] =    { TAG_IGNOREFLAGS_LABEL, TAG_IGNOREWEAPONS_LABEL, 0 };
-	static const UINT EXPRESSION_L[] =     { TAG_VARVALUELABEL, 0 };
+	static const UINT EXPRESSION_L[] =   { TAG_VARVALUELABEL, 0 };
 	static const UINT ARRAYSET_L[] =     { TAG_ARRAYINDEX_LABEL, TAG_ARRAYVAR_TEXTLABEL, 0 };
-	static const UINT RESTRICTED_L[] =     { TAG_RESTRICTED_LABEL, 0 };
+	static const UINT RESTRICTED_L[] =   { TAG_RESTRICTED_LABEL, 0 };
+	static const UINT BUILD_L[] =        { TAG_BUILD_SOUNDLABEL, 0 };
 
 	static const UINT* activeLabels[CCharacterCommand::CC_Count] = {
 		NO_LABELS,          //CC_Appear
@@ -6314,7 +6348,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TEXT_L,             //CC_RoomLocationText
 		TEXT_AND_COLOR_L,   //CC_FlashingText
 		NO_LABELS,          //CC_DisplayFilter
-		NO_LABELS,          //CC_Build
+		BUILD_L,            //CC_Build
 		MUSIC_L,            //CC_WorldMapMusic
 		XY_L,               //CC_WorldMapIcon
 		NO_LABELS,          //CC_WorldMapSelect
@@ -6850,6 +6884,11 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 
 		case CCharacterCommand::CC_Build:
 			this->pCommand->flags = this->pBuildItemsListBox->GetSelectedItem();
+			if (this->pBuildSoundOnOffListBox->GetSelectedItem() == 0) {
+				this->pCommand->label = wszBuildCommandModifierQuiet;
+			} else {
+				this->pCommand->label = wszEmpty;
+			}
 			QueryRect();
 		break;
 
@@ -7684,6 +7723,11 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 
 		case CCharacterCommand::CC_Build:
 			this->pBuildItemsListBox->SelectItem(this->pCommand->flags);
+			if (this->pCommand->label.compare(wszBuildCommandModifierQuiet) == 0) {
+				this->pBuildSoundOnOffListBox->SelectItem(0);
+			} else {
+				this->pBuildSoundOnOffListBox->SelectItem(1);
+			}
 			break;
 
 		case CCharacterCommand::CC_LinkOrb:
@@ -8701,6 +8745,7 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 		break;
 
 	case CCharacterCommand::CC_Build:
+	{
 		parseMandatoryOption(pCommand->flags, this->pBuildItemsListBox, bFound);
 		skipComma;
 		skipLeftParen;
@@ -8711,7 +8756,13 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 		skipLeftParen;
 		parseNumber(pCommand->w); pCommand->w -= pCommand->x; skipComma;
 		parseNumber(pCommand->h); pCommand->h -= pCommand->y;
+		skipComma;
+		if (WCSncmp(pText+pos, wszBuildCommandModifierQuiet, WCSlen(wszBuildCommandModifierQuiet)) == 0) {
+			pCommand->label = wszBuildCommandModifierQuiet;
+			pos += WCSlen(wszBuildCommandModifierQuiet);
+		}
 		break;
+	}
 
 	case CCharacterCommand::CC_LinkOrb:
 		parseMandatoryOption(pCommand->flags, this->pOrbAgentListBox, bFound);
@@ -9647,6 +9698,10 @@ WSTRING CCharacterDialogWidget::toText(
 		concatNumWithComma(c.y);
 		concatNumWithComma(c.x + c.w);
 		concatNum(c.y + c.h);
+		if (c.label.size() > 0) {
+			wstr += wszComma;
+			wstr += c.label;
+		}
 		break;
 
 	case CCharacterCommand::CC_LinkOrb:

--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -219,9 +219,12 @@ private:
 	CListBoxWidget *pAttackTileListBox;
 	CListBoxWidget *pMovementTypeListBox;
 	CListBoxWidget *pIgnoreFlagsListBox;
-	CListBoxWidget* pColorListBox;
-	CListBoxWidget* pOrbAgentListBox;
-	CListBoxWidget* pPlayerBehaviorListBox, * pPlayerBehaviorStateListBox;
+	CListBoxWidget *pColorListBox;
+	CListBoxWidget *pOrbAgentListBox;
+	CListBoxWidget *pPlayerBehaviorListBox, * pPlayerBehaviorStateListBox;
+
+	/// List box for playing build sound
+	CListBoxWidget *pBuildSoundOnOffListBox;
 
 	map<UINT, pair<UINT, UINT>> onOffListBox3Positions;
 

--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -4094,9 +4094,23 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 
 	if (CueEvents.HasOccurred(CID_ObjectBuilt))
 	{
-		this->fPos[0] = static_cast<float>(player.wX);
-		this->fPos[1] = static_cast<float>(player.wY);
-		PlaySoundEffect(SEID_TRAPDOOR, this->fPos);
+		// If we find any non-T_SILENT_BUILD private data then play the sound
+		for (pObj = CueEvents.GetFirstPrivateData(CID_ObjectBuilt);
+			pObj != NULL; pObj = CueEvents.GetNextPrivateData())
+		{
+			const CAttachableWrapper<UINT> *pBuiltTileID = DYN_CAST(
+				const CAttachableWrapper<UINT>*,
+				const CAttachableObject*,
+				pObj
+			);
+
+			if (pBuiltTileID->data != T_SILENT_BUILD) {
+				this->fPos[0] = static_cast<float>(player.wX);
+				this->fPos[1] = static_cast<float>(player.wY);
+				PlaySoundEffect(SEID_TRAPDOOR, this->fPos);
+				break;
+			}
+		}
 	}
 	if (CueEvents.HasOccurred(CID_ObjectFell))
 	{

--- a/DRODLib/BuildUtil.cpp
+++ b/DRODLib/BuildUtil.cpp
@@ -29,6 +29,8 @@
 #include "PlayerDouble.h"
 #include "OrbUtil.h"
 
+bool BuildUtil::bQuietObjectBuildEvents = false;
+
 //*****************************************************************************
 bool BuildUtil::bIsValidBuildTile(const UINT wTileNo)
 {
@@ -524,7 +526,11 @@ bool BuildUtil::BuildNormalTile(CDbRoom& room, const UINT baseTile, const UINT t
 		room.ActivateOrb(x, y, CueEvents, OAT_PressurePlate);
 	}
 
-	CueEvents.Add(CID_ObjectBuilt, new CAttachableWrapper<UINT>(baseTile), true);
+	if (BuildUtil::bQuietObjectBuildEvents) {
+		CueEvents.Add(CID_ObjectBuilt, new CAttachableWrapper<UINT>(T_SILENT_BUILD), true);
+	} else {
+		CueEvents.Add(CID_ObjectBuilt, new CAttachableWrapper<UINT>(baseTile), true);
+	}
 
 	if (wLayer == LAYER_OPAQUE) {
 		// Building/removing tiles that (can) affect weapon sheathing should refresh it immediately

--- a/DRODLib/BuildUtil.h
+++ b/DRODLib/BuildUtil.h
@@ -42,6 +42,9 @@ public:
 	static bool BuildTileAt(CDbRoom& room, const UINT tile, const UINT x, const UINT y, const bool bAllowSame, CCueEvents& CueEvents);
 	static bool CanBuildAt(CDbRoom& room, const UINT tile, const UINT x, const UINT y, const bool bAllowSame);
 
+	/// If true then CID_ObjectBuilt CueEvents will be modified to signal they are quiet
+	static bool bQuietObjectBuildEvents;
+
 private:
 	static bool BuildAnyTile(CDbRoom& room, const UINT baseTile, const UINT tile, const UINT x, const UINT y, const bool bAllowSame, CCueEvents& CueEvents);
 	static bool BuildNormalTile(CDbRoom& room, const UINT baseTile, const UINT tile, const UINT x, const UINT y, const bool bAllowSame, CCueEvents& CueEvents);

--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -4245,8 +4245,13 @@ void CCharacter::BuildTiles(const CCharacterCommand& command, CCueEvents& CueEve
 	UINT px, py, pw, ph, pflags;  //command parameters
 	getCommandParams(command, px, py, pw, ph, pflags);
 
+	const bool bQuietObjectBuildEventsOld = BuildUtil::bQuietObjectBuildEvents;
+	bool bIsQuiet = command.label.compare(wszBuildCommandModifierQuiet) == 0;
+
 	CDbRoom& room = *(this->pCurrentGame->pRoom);
+	BuildUtil::bQuietObjectBuildEvents = bIsQuiet;
 	BuildUtil::BuildTilesAt(room, pflags, px, py, pw, ph, false, CueEvents);
+	BuildUtil::bQuietObjectBuildEvents = bQuietObjectBuildEventsOld;
 }
 
 //*****************************************************************************

--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -14,6 +14,8 @@ const int ImageOverlayCommand::NO_LAYERS = -3;
 const int ImageOverlayCommand::DEFAULT_GROUP = 0;
 const int ImageOverlayCommand::NO_GROUP = -1;
 
+const WCHAR wszBuildCommandModifierQuiet[] = { We('q'),We('u'), We('i'), We('e'), We('t'), We(0) };
+
 //*****************************************************************************
 CColorText::~CColorText() { delete pText; }
 

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -616,5 +616,6 @@ typedef std::vector<CCharacterCommand*> COMMANDPTR_VECTOR;
 
 extern SPEAKER getSpeakerType(const MONSTERTYPE eType);
 extern UINT getSpeakerNameText(const UINT wSpeaker, std::string& color);
+extern const WCHAR wszBuildCommandModifierQuiet[];
 
 #endif

--- a/DRODLib/DbBase.cpp
+++ b/DRODLib/DbBase.cpp
@@ -757,6 +757,7 @@ const WCHAR* CDbBase::GetMessageText(
 //		case MID_No: strText = "&No"; break;
 		case MID_Explosives: strText = "Explosives"; break;
 		case MID_PushableObjects: strText = "Pushable Objects"; break;
+		case MID_BuildModifierQuiet: strText = "Quietly"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/DRODLib/TileConstants.h
+++ b/DRODLib/TileConstants.h
@@ -200,6 +200,8 @@ static inline bool IsValidTileNo(const UINT t) {return t < TILE_COUNT;}
 #define T_REMOVE_FLOOR_ITEM (UINT(-56))
 #define T_ORB_NORMAL (UINT(-57))
 #define T_REMOVE_TRANSPARENT (UINT(-58))
+/// Used by CID_ObjectBuilt to trigger event but signify no sound effect to be played
+#define T_SILENT_BUILD (UINT(-59))
 #define LAST_FAKE_TILE_INDEX (UINT(-58))
 
 static inline bool bIsFakeTokenType(const UINT t) { return t >= T_TOKEN_RESERVED_SPACE && t <= T_ACTIVETOKEN; }
@@ -867,7 +869,7 @@ static const UINT TILE_MID[TOTAL_EDIT_TILE_COUNT] =
 	MID_Gentryii,     //M_GENTRYII      +41
 	MID_TemporalClone, //M_TEMPORALCLONE +42
 	MID_FluffBaby,    //M_FLUFFBABY     +43
-	
+
 	MID_Swordsman,    //T_SWORDSMAN     TOTAL+0
 	0,                //T_NOMONSTER     TOTAL+1
 	0                 //T_EMPTY_F       TOTAL+2

--- a/Texts/MIDs.h
+++ b/Texts/MIDs.h
@@ -1940,6 +1940,7 @@ enum MID_CONSTANT {
   MID_IfElseIfNot = 2171,
   MID_Explosives = 2172,
   MID_PushableObjects = 2173,
+  MID_BuildModifierQuiet = 2174,
 
   //Messages from Stats.uni:
   MID_VarMonsterColor = 1963,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -293,7 +293,7 @@ Enemy sneak attack
 [MID_HitObstacle]
 [eng]
 Player bumps obstacle
-	
+
 [MID_ItemUsed]
 [eng]
 Item used
@@ -1831,3 +1831,7 @@ Count array entries
 [MID_RemoveTransparentLayer]
 [eng]
 Remove transparent layer object
+
+[MID_BuildModifierQuiet]
+[eng]
+Build modifier Quiet

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1834,4 +1834,4 @@ Remove transparent layer object
 
 [MID_BuildModifierQuiet]
 [eng]
-Build modifier Quiet
+Quietly


### PR DESCRIPTION
This is achieved in a backwards-compatible manner to 5.2 by using the unused `label` property of the Build command. It is done in a generic way which stores a string modifier `quiet` in the field. If we ever want/need to expand it to support more things this can be easily achieved by using a delimiter for multiple options.

When Build commands executes with this label set, `BuildUtil` has a static field set to perform quiet building. I decided to do it like this primarily to avoid polluting the already large list of arguments that get passed down. One could argue this allows for a bit more versatility in different places should this ever be required.

When building with quiet build then the event `CID_ObjectBuilt` gets attached `T_SILENT_BUILD` instead of the `baseTile`. The attached value is not used anywhere so it's a safe change. In the future if we ever need those values we'll need to add a new struct/class to attach, possibly with the built position as well.

On the frontend side handling `CID_ObjectBuilt` was slightly changed to check if there is any non-T_SILENT_BUILD private data attached. If yes - play the sound and bail out of the loop. For old scripts this means there will be minimal slowness because the first attached data will always trigger playing the sound.

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47369&page=0#457834