### PR TITLE
Fix DisplayRectModify in Image Overlay.

### DIFF
--- a/DRODLib/CharacterCommand.cpp
+++ b/DRODLib/CharacterCommand.cpp
@@ -298,7 +298,7 @@ ImageOverlayCommand::IOC matchCommand(const char* pText, UINT& index)
 		commandMap[string("center")] = ImageOverlayCommand::Center;
 		commandMap[string("display ")] = ImageOverlayCommand::DisplayDuration;
 		commandMap[string("displayms")] = ImageOverlayCommand::DisplayDuration; //deprecated
-		commandMap[string("displayrect")] = ImageOverlayCommand::DisplayRect;
+		commandMap[string("displayrect ")] = ImageOverlayCommand::DisplayRect;
 		commandMap[string("displayrectmodify")] = ImageOverlayCommand::DisplayRectModify;
 		commandMap[string("displaysize")] = ImageOverlayCommand::DisplaySize;
 		commandMap[string("displayturns")] = ImageOverlayCommand::TurnDuration;


### PR DESCRIPTION
Using DisplayRectModify always resulted in the Image Overlay parse failing. This was because the parser matched "DisplayRect" instead and was trying to parse "Modify" as the first numeric argument.

Added a space after "DisplayRect" to match the convention of other commands

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47370&page=0#457837