### PR TITLE
Allow using labels as comments.

### DIFF
--- a/DROD/CharacterDialogWidget.cpp
+++ b/DROD/CharacterDialogWidget.cpp
@@ -2598,7 +2598,7 @@ void CCharacterDialogWidget::OnKeyDown(
 				command != this->commandBuffer.end(); ++command)
 			{
 				CCharacterCommand *pCommand = *command;
-				if (pCommand->command == CCharacterCommand::CC_Label)
+				if (pCommand->IsActiveLabel())
 					this->pGotoLabelListBox->RemoveItem(pCommand->x);
 			}
 
@@ -2934,7 +2934,7 @@ void CCharacterDialogWidget::AddCommand()
 		nSelectedLine = pActiveCommandListBox->AddItemPointer(pCommand,
 				wszEmpty,	//real text added below
 				false, nSelectedLine+1);
-		SetCommandColor(pActiveCommandListBox, nSelectedLine, pCommand->command);
+		SetCommandColor(pActiveCommandListBox, nSelectedLine, *pCommand);
 	}
 
 	AddLabel(pCommand);
@@ -2951,7 +2951,7 @@ void CCharacterDialogWidget::AddLabel(CCharacterCommand* pCommand)
 //If command is a label, then adds the label ID+text to the label list.
 {
 	ASSERT(pCommand);
-	if (pCommand->command == CCharacterCommand::CC_Label)
+	if (pCommand->IsActiveLabel())
 	{
 		this->pGotoLabelListBox->AddItem(pCommand->x, pCommand->label.c_str());
 		if (!this->pGotoLabelListBox->ItemIsSelected())
@@ -3115,7 +3115,7 @@ void CCharacterDialogWidget::DeleteCommands(
 		COMMANDPTR_VECTOR::iterator iter = commands.begin() + wLine;
 		ASSERT(iter != commands.end());
 		commands.erase(iter);
-		if (pCommand->command == CCharacterCommand::CC_Label)
+		if (pCommand->IsActiveLabel())
 			this->pGotoLabelListBox->RemoveItem(pCommand->x);
 		if (pCommand->pSpeech)
 		{
@@ -4156,7 +4156,8 @@ const
 
 		case CCharacterCommand::CC_Label:
 			wstr += command.label;
-			wstr += wszColon;
+			if (command.IsActiveLabel())
+				wstr += wszColon;
 		break;
 		case CCharacterCommand::CC_ChallengeCompleted:
 			wstr += wszQuote;
@@ -4743,7 +4744,8 @@ void CCharacterDialogWidget::PrettyPrintCommands(CListBoxWidget* pCommandList, c
 					wstr += wszQuestionMark;	//questionable If condition
 				break;
 			case CCharacterCommand::CC_Label:
-				bIsLabel = true;
+				if (pCommand->IsActiveLabel())
+					bIsLabel = true;
 				if (bLastWasIfCondition || wLogicNestDepth)
 					wstr += wszQuestionMark;	//questionable If condition
 				break;
@@ -5533,7 +5535,7 @@ void CCharacterDialogWidget::PopulateCommandDescriptions(
 		CCharacterCommand *pCommand = commands[wIndex];
 		const UINT insertedIndex = pCommandList->AddItemPointer(pCommand,
 				GetCommandDesc(commands, pCommand).c_str());
-		SetCommandColor(pCommandList, insertedIndex, pCommand->command);
+		SetCommandColor(pCommandList, insertedIndex, *pCommand);
 	}
 
 	PrettyPrintCommands(pCommandList, commands);
@@ -5578,9 +5580,13 @@ void CCharacterDialogWidget::PopulateGotoLabelList(const COMMANDPTR_VECTOR& comm
 		CCharacterCommand *pCommand = commands[wIndex];
 		if (pCommand->command == CCharacterCommand::CC_Label)
 		{
-			this->pGotoLabelListBox->AddItem(pCommand->x, pCommand->label.c_str());
-			if (!this->pGotoLabelListBox->ItemIsSelected())
-				this->pGotoLabelListBox->SelectLine(0);
+			if (pCommand->IsActiveLabel()) {
+				this->pGotoLabelListBox->AddItem(pCommand->x, pCommand->label.c_str());
+				if (!this->pGotoLabelListBox->ItemIsSelected())
+					this->pGotoLabelListBox->SelectLine(0);
+			}
+			// Comment-labels still store an ID because they can easily be
+			// renamed to an active label and that must keep working.
 			if (pCommand->x > this->wIncrementedLabel)
 				this->wIncrementedLabel = pCommand->x;
 		}
@@ -5925,11 +5931,14 @@ void CCharacterDialogWidget::QueryXYWH()
 
 //*****************************************************************************
 void CCharacterDialogWidget::SetCommandColor(
-	CListBoxWidget* pListBox, int line, CCharacterCommand::CharCommand command)
+	CListBoxWidget* pListBox, int line, const CCharacterCommand& command)
 {
-	switch (command) {
+	switch (command.command) {
 		case CCharacterCommand::CC_Label:
-			pListBox->SetItemColorAtLine(line, DarkGreen);
+			if (command.IsCommentLabel())
+				pListBox->SetItemColorAtLine(line, MidDarkGray);
+			else
+				pListBox->SetItemColorAtLine(line, DarkGreen);
 		break;
 		case CCharacterCommand::CC_GoTo:
 		case CCharacterCommand::CC_GoSub:
@@ -6675,7 +6684,7 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 	if (this->bEditingCommand)
 	{
 		oldCommandType = this->pCommand->command;
-		if (oldCommandType == CCharacterCommand::CC_Label)
+		if (this->pCommand->IsActiveLabel())
 		{
 			this->pGotoLabelListBox->RemoveItem(this->pCommand->x);
 			bRemovedLabel = true;

--- a/DROD/CharacterDialogWidget.h
+++ b/DROD/CharacterDialogWidget.h
@@ -166,7 +166,7 @@ private:
 	void  SetActionWidgetStates();
 	void  SetAnimationSpeed();
 	void  SetCharacterWidgetStates();
-	void  SetCommandColor(CListBoxWidget* pListBox, int line, CCharacterCommand::CharCommand command);
+	void  SetCommandColor(CListBoxWidget* pListBox, int line, const CCharacterCommand& command);
 	void  SetCommandParametersFromWidgets(CListBoxWidget *pActiveCommandList, COMMANDPTR_VECTOR& commands);
 	void  SetCustomImage();
 	void  SetCustomGraphic();

--- a/DRODLib/CharacterCommand.h
+++ b/DRODLib/CharacterCommand.h
@@ -11,6 +11,10 @@
 #include <vector>
 #include <cstring> // memcpy
 
+/// Prefix for labels indicating that they should display differently and not show up
+/// in Go To and GoSub commands. Basically a label that functions like a comment
+const WCHAR wszCommentPrefix[] = { We('/'),We('/'),We(0) };
+
 //Speakers for whom some faces are implemented.
 enum SPEAKER
 {
@@ -468,6 +472,25 @@ public:
 			default:
 				return false;
 		}
+	}
+
+	/// Labels prefixed with "//" function as comments: they display differently
+	/// in the command list and cannot be selected in the UI in Go To and GoSub
+	/// and other Label-selecting commands.
+	/// This helper can be used to quickly check if the label has full functionality
+	/// or not.
+	/// This should only matter on the UI level - if a hold already contains such
+	/// labels with other commands linking to them those must stay and work
+	/// as before.
+	bool IsActiveLabel() const {
+		return command == CC_Label
+			&& label.compare(0, 2, wszCommentPrefix) != 0;
+	}
+
+	/// @see IsActiveLabel
+	bool IsCommentLabel() const {
+		return command == CC_Label
+			&& label.compare(0, 2, wszCommentPrefix) == 0;
 	}
 
 	bool isIfNotCommand() const {

--- a/Data/Help/1/script.html
+++ b/Data/Help/1/script.html
@@ -332,7 +332,7 @@ the state of the room and wait indefinitely until certain events occur.</p>
       <b>Question</b> is executed as the condition for an <a href="#if">
       <b>If ...</b></a> command, the corresponding script block will execute if
       the user answers "Yes".</li>
-  <li><a name="select-square"></a><b>Select square</b> - Causes the next game move to become a position input, as if the player had stepped on a potion. The selected position is placed into the <b>_ReturnX</b> and <b>_ReturnY</b> variables. 
+  <li><a name="select-square"></a><b>Select square</b> - Causes the next game move to become a position input, as if the player had stepped on a potion. The selected position is placed into the <b>_ReturnX</b> and <b>_ReturnY</b> variables.
     The selection can be configured to allow any room tile to be chosen, or to use the same restriction as double potions. If the player has consumed a potion, this command will be delayed until the next full turn has processed.</li>
   <li><a name="wait"><b>Wait</b></a> - This tells the NPC to do nothing until
       the number of game turns you specify has passed.  <b>Wait 0</b> will stop
@@ -474,7 +474,11 @@ continue executing script commands from a different location in the script.</p>
       continue executing commands from (used in conjunction with
       <a href="#goto"><b>Go to</b></a> and <a href="#answer"><b>Answer option</b></a>
       commands).  Also, labels may be used to simply comment in normal language
-      on what the following script commands do.</li>
+      on what the following script commands do.<br />
+      Labels can also be used as comments if you prefix them with a double
+      slash. Eg: "// This is a comment" will display differently in the command
+      list and will not appear in any command that allows jumping to a label.
+    </li>
   <li><a name="goto"><b>Go to</b></a> - Select a label to continue executing
       commands from.  Hint: Use "Go to" to make a loop in the script that repeats a
       sequence of commands over and over. Use a <a href="#wait"><b>Wait 0</b></a>
@@ -545,9 +549,9 @@ continue executing script commands from a different location in the script.</p>
       this NPC won't harm the player.</li>
     <li><a name="impdeadly"><b>Deadly</b></a>: Allows the NPC to step on the
       player and kill him.  Also makes sword hits deadly to the player (default).</li>
-    <li><a name="imp-friendly"><b>Friendly</b></a>: Marks the NPC as "friendly". Killing it will not break stealth, and Stalwarts and Soldiers will avoid stabbing the NPC. 
+    <li><a name="imp-friendly"><b>Friendly</b></a>: Marks the NPC as "friendly". Killing it will not break stealth, and Stalwarts and Soldiers will avoid stabbing the NPC.
 	An NPC that is set as <a href="impsafe">Safe</a> is automatically set to be friendly.</li>
-    <li><a name="imp-unfriendly"><b>Unfriendly</b></a>:  Marks the NPC as "unfriendly". Killing it will break stealth, and Stalwarts and Soldiers may stab the NPC. 
+    <li><a name="imp-unfriendly"><b>Unfriendly</b></a>:  Marks the NPC as "unfriendly". Killing it will break stealth, and Stalwarts and Soldiers may stab the NPC.
 	An NPC that is set as <a href="impdeadly">Deadly</a> is automatically set to be unfriendly.</li>
     <li><a name="impdie"><b>Die</b></a>: Makes the NPC die with a blood splatter.</li>
     <li><a name="impdiespecial"><b>Die special</b></a>: Makes the NPC perform a

--- a/FrontEndLib/FontManager.cpp
+++ b/FrontEndLib/FontManager.cpp
@@ -44,6 +44,7 @@ static const UINT MAXLEN_WORD = 1024;
 //pre-defined colors
 const SDL_Color Black = {0, 0, 0, 0};
 const SDL_Color DarkGray = {64, 64, 64, 0};
+const SDL_Color MidDarkGray = {96, 96, 96, 0};
 const SDL_Color DarkBrown = {138, 126, 103, 0};
 const SDL_Color MediumBrown = {190, 181, 165, 0};
 const SDL_Color LightGray = {180, 180, 180, 0};

--- a/FrontEndLib/FontManager.h
+++ b/FrontEndLib/FontManager.h
@@ -69,7 +69,7 @@ struct FontCacheMember
 };
 
 //pre-defined colors
-extern const SDL_Color Black, DarkGray, DarkBrown, MediumBrown, LightGray,
+extern const SDL_Color Black, MidDarkGray, DarkGray, DarkBrown, MediumBrown, LightGray,
 		Gray, LightBrown, BlueishWhite, PinkishWhite, DarkYellow, MidYellow,
 		Yellow, LightYellow, White, Maroon, Gold, Blue, DarkBlue, LightBlue,
 		LightCyan,


### PR DESCRIPTION
Complex scripts can benefit greatly from having comments. It's possible to use labels for this but it has a few issues:
1. Lack of indent makes following the flow of the script harder
2. It's more difficult, at a glance, to differentiate usable labels from comments
3. They pollute the Goto lists when using GoTo/Sub/Answer options

This change makes it so that if a label begins with "//" it is treated like a comment:
- Indents the same way as the rest of the code
- Has gray color
- Does not appear in the goto lists

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=47371