### PR TITLE
RPG: Improvements to building and waiting for items

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -5123,6 +5123,7 @@ void CCharacterDialogWidget::PopulateItemGroupListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(ScriptFlag::IG_AnyArrow, g_pTheDB->GetMessageText(MID_AnyArrow));
 	pListBox->AddItem(ScriptFlag::IG_Tarstuff, g_pTheDB->GetMessageText(MID_TarstuffGroup));
 	pListBox->AddItem(ScriptFlag::IG_Briar, g_pTheDB->GetMessageText(MID_Briars));
+	pListBox->AddItem(ScriptFlag::IG_AnyToken, g_pTheDB->GetMessageText(MID_AnyToken));
 	pListBox->AddItem(ScriptFlag::IG_Health, g_pTheDB->GetMessageText(MID_HealthGroup));
 	pListBox->AddItem(ScriptFlag::IG_AttackUp, g_pTheDB->GetMessageText(MID_AttackUpGroup));
 	pListBox->AddItem(ScriptFlag::IG_DefenseUp, g_pTheDB->GetMessageText(MID_DefenseUpGroup));
@@ -5132,6 +5133,7 @@ void CCharacterDialogWidget::PopulateItemGroupListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(ScriptFlag::IG_Map, g_pTheDB->GetMessageText(MID_LevelMap));
 	pListBox->AddItem(ScriptFlag::IG_Collectable, g_pTheDB->GetMessageText(MID_CollectableGroup));
 	pListBox->AddItem(ScriptFlag::IG_Equipment, g_pTheDB->GetMessageText(MID_EquipmentGroup));
+	pListBox->AddItem(ScriptFlag::IG_AnyTTile, g_pTheDB->GetMessageText(MID_AnyTLayer));
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -4984,7 +4984,11 @@ void CCharacterDialogWidget::PopulateItemListBox(
 	pListBox->AddItem(T_WATER, g_pTheDB->GetMessageText(MID_Water));
 	pListBox->AddItem(T_BRIDGE, g_pTheDB->GetMessageText(MID_Bridge));
 	pListBox->AddItem(T_BRIDGE_H, g_pTheDB->GetMessageText(MID_Bridge_H));
-	pListBox->AddItem(T_BRIDGE_V, g_pTheDB->GetMessageText(MID_Bridge_V));
+	pListBox->AddItem(T_BRIDGE_H, g_pTheDB->GetMessageText(MID_Bridge_H));
+	if (!bBuildItems) {
+		pListBox->AddItem(T_PLATFORM_P, g_pTheDB->GetMessageText(MID_PlatformPit));
+		pListBox->AddItem(T_PLATFORM_W, g_pTheDB->GetMessageText(MID_PlatformWater));
+	}
 	pListBox->AddItem(T_TUNNEL_N, g_pTheDB->GetMessageText(MID_Tunnel_N));
 	pListBox->AddItem(T_TUNNEL_E, g_pTheDB->GetMessageText(MID_Tunnel_E));
 	pListBox->AddItem(T_TUNNEL_S, g_pTheDB->GetMessageText(MID_Tunnel_S));

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -122,7 +122,7 @@ const UINT TAG_TEXT2 = 931;
 const UINT TAG_COLOR_LABEL = 930;
 
 const UINT TAG_GRAPHICLISTBOX2 = 929;
-const UINT TAG_ITEMLISTBOX = 928;
+const UINT TAG_BUILDITEM_LISTBOX = 928;
 const UINT TAG_VISUALEFFECTS_LISTBOX = 927;
 const UINT TAG_DIRECTIONLISTBOX3 = 926;
 const UINT TAG_SOUNDEFFECTLABEL = 925;
@@ -174,6 +174,7 @@ const UINT TAG_Y_COORD = 876;
 const UINT TAG_X_COORD_LABEL = 875;
 const UINT TAG_Y_COORD_LABEL = 874;
 const UINT TAG_ENTITY_LISTBOX = 873;
+const UINT TAG_WAITFORITEMS_LISTBOX = 872;
 
 const UINT MAX_TEXT_LABEL_SIZE = 100;
 
@@ -425,6 +426,7 @@ CCharacterDialogWidget::CCharacterDialogWidget(
 	, pVarListBox(NULL), pVarOpListBox(NULL), pVarCompListBox(NULL), pVarCompListBox2(NULL)
 	, pArrayVarListBox(NULL), pArrayVarOpListBox(NULL), pItemGroupListBox(NULL)
 	, pWaitFlagsListBox(NULL), pImperativeListBox(NULL), pBuildItemsListBox(NULL)
+	, pWaitForItemsListBox(NULL)
 	, pEquipmentTypesListBox(NULL), pCustomNPCListBox(NULL), pEquipTransListBox(NULL)
 	, pCharNameText(NULL), pCharListBox(NULL), pEntityListBox(NULL)
 	, pSpeechText(NULL)
@@ -1543,11 +1545,18 @@ void CCharacterDialogWidget::AddCommandDialog()
 	this->pVisualEffectsListBox->SetAllowFiltering(true);
 
 	//Build items.
-	this->pBuildItemsListBox = new CListBoxWidget(TAG_ITEMLISTBOX,
+	this->pBuildItemsListBox = new CListBoxWidget(TAG_BUILDITEM_LISTBOX,
 			X_ITEMLISTBOX, Y_ITEMLISTBOX, CX_ITEMLISTBOX, CY_ITEMLISTBOX);
 	this->pAddCommandDialog->AddWidget(this->pBuildItemsListBox);
-	this->PopulateItemListBox(this->pBuildItemsListBox);
+	this->PopulateItemListBox(this->pBuildItemsListBox, true);
 	this->pBuildItemsListBox->SelectLine(0);
+
+	//Wait for items
+	this->pWaitForItemsListBox = new CListBoxWidget(TAG_WAITFORITEMS_LISTBOX,
+		X_ITEMLISTBOX, Y_ITEMLISTBOX, CX_ITEMLISTBOX, CY_ITEMLISTBOX);
+	this->pAddCommandDialog->AddWidget(this->pWaitForItemsListBox);
+	this->PopulateItemListBox(this->pWaitForItemsListBox, false);
+	this->pWaitForItemsListBox->SelectLine(0);
 
 	this->pItemGroupListBox = new CListBoxWidget(TAG_ITEM_GROUP_LISTBOX,
 		X_ITEMLISTBOX, Y_ITEMLISTBOX, CX_ITEMLISTBOX, CY_ITEMLISTBOX);
@@ -3567,7 +3576,10 @@ const
 		case CCharacterCommand::CC_BuildTile:
 		case CCharacterCommand::CC_WaitForItem:
 		case CCharacterCommand::CC_CountItem:
-			wstr += this->pBuildItemsListBox->GetTextForKey(command.flags);
+		{
+			CListBoxWidget* pListBox = command.command == CCharacterCommand::CC_BuildTile ?
+				this->pBuildItemsListBox : this->pWaitForItemsListBox;
+			wstr += pListBox->GetTextForKey(command.flags);
 			wstr += wszSpace;
 			wstr += g_pTheDB->GetMessageText(MID_At);
 			wstr += wszSpace;
@@ -3582,6 +3594,7 @@ const
 			wstr += wszComma;
 			wstr += _itoW(command.y + command.h, temp, 10);
 			wstr += wszRightParen;
+		}
 		break;
 
 		case CCharacterCommand::CC_WaitForItemGroup:
@@ -4926,7 +4939,8 @@ void CCharacterDialogWidget::PopulateImperativeListBox(const bool bDefaultScript
 }
 
 //*****************************************************************************
-void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget* pListBox)
+void CCharacterDialogWidget::PopulateItemListBox(
+	CListBoxWidget* pListBox, bool bBuildItems)
 {
 	pListBox->Clear();
 
@@ -4992,7 +5006,10 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(T_ARROW_OFF_SW, g_pTheDB->GetMessageText(MID_ForceArrowDisabledSW));
 	pListBox->AddItem(T_ARROW_OFF_W, g_pTheDB->GetMessageText(MID_ForceArrowDisabledW));
 	pListBox->AddItem(T_NODIAGONAL, g_pTheDB->GetMessageText(MID_Ortho));
-	pListBox->AddItem(T_OBSTACLE, g_pTheDB->GetMessageText(MID_Obstacle));
+	if (!bBuildItems) {
+		pListBox->AddItem(T_SCROLL, g_pTheDB->GetMessageText(MID_Scroll));
+		pListBox->AddItem(T_OBSTACLE, g_pTheDB->GetMessageText(MID_Obstacle));
+	}
 	pListBox->AddItem(T_BOMB, g_pTheDB->GetMessageText(MID_Bomb));
 	pListBox->AddItem(T_FUSE, g_pTheDB->GetMessageText(MID_Fuse));
 	pListBox->AddItem(T_BRIAR_SOURCE, g_pTheDB->GetMessageText(MID_FlowSource));
@@ -5060,10 +5077,12 @@ void CCharacterDialogWidget::PopulateItemListBox(CListBoxWidget* pListBox)
 	pListBox->AddItem(TV_ACCESSORY11, g_pTheDB->GetMessageText(MID_Accessory11));
 	pListBox->AddItem(TV_ACCESSORY12, g_pTheDB->GetMessageText(MID_Accessory12));
 	pListBox->AddItem(TV_EXPLOSION, g_pTheDB->GetMessageText(MID_Explosion));
-	pListBox->AddItem(T_EMPTY_F, g_pTheDB->GetMessageText(MID_RemoveFLayerItem));
-	pListBox->AddItem(T_EMPTY, g_pTheDB->GetMessageText(MID_RemoveItem));
-	pListBox->AddItem(TV_REMOVE_TRANSPARENT, g_pTheDB->GetMessageText(MID_RemoveTransparentLayer));
-	pListBox->AddItem(TV_REMOVE_OVERHEAD_IMAGE, g_pTheDB->GetMessageText(MID_RemoveOverheadImage));
+	if (bBuildItems) {
+		pListBox->AddItem(T_EMPTY_F, g_pTheDB->GetMessageText(MID_RemoveFLayerItem));
+		pListBox->AddItem(T_EMPTY, g_pTheDB->GetMessageText(MID_RemoveItem));
+		pListBox->AddItem(TV_REMOVE_TRANSPARENT, g_pTheDB->GetMessageText(MID_RemoveTransparentLayer));
+		pListBox->AddItem(TV_REMOVE_OVERHEAD_IMAGE, g_pTheDB->GetMessageText(MID_RemoveOverheadImage));
+	}
 
 	pListBox->SetAllowFiltering(true);
 }
@@ -5604,7 +5623,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 {
 	//Code is structured in this way to facilitate quick addition of
 	//additional action parameters.
-	static const UINT NUM_WIDGETS = 52;
+	static const UINT NUM_WIDGETS = 53;
 	static const UINT widgetTag[NUM_WIDGETS] = {
 		TAG_WAIT, TAG_EVENTLISTBOX, TAG_DELAY, TAG_SPEECHTEXT,
 		TAG_SPEAKERLISTBOX, TAG_MOODLISTBOX, TAG_ADDSOUND, TAG_TESTSOUND, TAG_DIRECTIONLISTBOX,
@@ -5613,14 +5632,15 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		TAG_WAITFLAGSLISTBOX, TAG_VARADD, TAG_VARREMOVE,
 		TAG_VARLIST, TAG_VAROPLIST, TAG_VARCOMPLIST, TAG_VARVALUE,
 		TAG_GRAPHICLISTBOX2, TAG_MOVERELX, TAG_MOVERELY, TAG_IMPERATIVELISTBOX,
-		TAG_ITEMLISTBOX, TAG_BEHAVIORLISTBOX,
+		TAG_BUILDITEM_LISTBOX, TAG_BEHAVIORLISTBOX,
 		TAG_EQUIPMENTTYPE_LISTBOX, TAG_CUSTOMNPC_LISTBOX, TAG_EQUIPTRANS_LISTBOX,
 		TAG_DIRECTIONLISTBOX2,
 		TAG_VISUALEFFECTS_LISTBOX, TAG_DIRECTIONLISTBOX3, TAG_ONOFFLISTBOX3,
 		TAG_TEXT2, TAG_STATLISTBOX, TAG_MOVETYPELISTBOX, TAG_VARCOMPLIST2, TAG_IMAGEOVERLAYTEXT,
 		TAG_ARRAYVARLIST, TAG_ARRAYVAROPLIST, TAG_ARRAYVAR_REMOVE, TAG_ITEM_GROUP_LISTBOX,
 		TAG_MAP_ICON_STATE_LISTBOX, TAG_MAP_ICON_LISTBOX, TAG_COLOR_LISTBOX,
-		TAG_ICONDISPLAY, TAG_IMAGEDISPLAY, TAG_X_COORD, TAG_Y_COORD, TAG_ENTITY_LISTBOX
+		TAG_ICONDISPLAY, TAG_IMAGEDISPLAY, TAG_X_COORD, TAG_Y_COORD, TAG_ENTITY_LISTBOX,
+		TAG_WAITFORITEMS_LISTBOX
 	};
 
 	static const UINT NO_WIDGETS[] =  {0};
@@ -5643,7 +5663,8 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 	static const UINT MOVEREL[] =     { TAG_ONOFFLISTBOX, TAG_ONOFFLISTBOX2, TAG_MOVERELX, TAG_MOVERELY, 0 };
 	static const UINT IMPERATIVE[] =  { TAG_IMPERATIVELISTBOX, 0 };
 	static const UINT ANSWER[] =      { TAG_GOTOLABELTEXT, TAG_GOTOLABELLISTBOX, 0 };
-	static const UINT ITEMS[] =       { TAG_ITEMLISTBOX, 0 };
+	static const UINT BUILD_ITEMS[] = { TAG_BUILDITEM_LISTBOX, 0 };
+	static const UINT WAITFORITEMS[] ={ TAG_WAITFORITEMS_LISTBOX, 0 };
 	static const UINT XY[] =          { TAG_X_COORD, TAG_Y_COORD, 0};
 	static const UINT BEHAVIOR[] =    { TAG_BEHAVIORLISTBOX, 0 };
 	static const UINT EQUIPMENT[] =   { TAG_EQUIPMENTTYPE_LISTBOX, TAG_CUSTOMNPC_LISTBOX, TAG_EQUIPTRANS_LISTBOX, 0};
@@ -5710,7 +5731,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		MOVEREL,
 		ONOFF,
 		ANSWER,
-		ITEMS,
+		BUILD_ITEMS,
 		ONOFF,
 		ONOFF,
 		NO_WIDGETS,
@@ -5728,7 +5749,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		GOTOLIST,
 		GOTOLIST,
 		EQUIPMENT,
-		ITEMS,
+		WAITFORITEMS,
 		NEWENTITY,
 		EFFECT,
 		NO_WIDGETS,         //CC_IfElseIf
@@ -5770,7 +5791,7 @@ void CCharacterDialogWidget::SetActionWidgetStates()
 		ENTITY_LIST,        //CC_WaitForEntityType
 		ENTITY_LIST,        //CC_WaitForNotEntityType
 		ENTITY_LIST,        //CC_CountEntityType
-		ITEMS,              //CC_CountItem
+		WAITFORITEMS,       //CC_CountItem
 		WAITFORITEMGROUP,   //CC_CountItemGroup
 		ARRAYVARPUSH,       //CC_PushToArrayVar
 		CLEARARRAYVAR,      //CC_PopFromArrayVar
@@ -6403,9 +6424,12 @@ void CCharacterDialogWidget::SetCommandParametersFromWidgets(
 		break;
 
 		case CCharacterCommand::CC_BuildTile:
+			this->pCommand->flags = this->pBuildItemsListBox->GetSelectedItem();
+			QueryRect();
+		break;
 		case CCharacterCommand::CC_WaitForItem:
 		case CCharacterCommand::CC_CountItem:
-			this->pCommand->flags = this->pBuildItemsListBox->GetSelectedItem();
+			this->pCommand->flags = this->pWaitForItemsListBox->GetSelectedItem();
 			QueryRect();
 		break;
 
@@ -7266,9 +7290,11 @@ void CCharacterDialogWidget::SetWidgetsFromCommandParameters()
 		break;
 
 		case CCharacterCommand::CC_BuildTile:
+			this->pBuildItemsListBox->SelectItem(this->pCommand->flags);
+		break;
 		case CCharacterCommand::CC_WaitForItem:
 		case CCharacterCommand::CC_CountItem:
-			this->pBuildItemsListBox->SelectItem(this->pCommand->flags);
+			this->pWaitForItemsListBox->SelectItem(this->pCommand->flags);
 		break;
 
 		case CCharacterCommand::CC_WaitForItemGroup:
@@ -8138,7 +8164,10 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 	case CCharacterCommand::CC_BuildTile:
 	case CCharacterCommand::CC_WaitForItem:
 	case CCharacterCommand::CC_CountItem:
-		parseMandatoryOption(pCommand->flags,this->pBuildItemsListBox,bFound);
+	{
+		CListBoxWidget* pListBox = eCommand == CCharacterCommand::CC_BuildTile ?
+			this->pBuildItemsListBox : this->pWaitForItemsListBox;
+		parseMandatoryOption(pCommand->flags, pListBox, bFound);
 		skipComma;
 		skipLeftParen;
 		parseNumber(pCommand->x); skipComma;
@@ -8147,6 +8176,7 @@ CCharacterCommand* CCharacterDialogWidget::fromText(
 		skipLeftParen;
 		parseNumber(pCommand->w); pCommand->w -= pCommand->x; skipComma;
 		parseNumber(pCommand->h); pCommand->h -= pCommand->y;
+	}
 	break;
 
 	case CCharacterCommand::CC_WaitForItemGroup:
@@ -9028,12 +9058,16 @@ WSTRING CCharacterDialogWidget::toText(
 	case CCharacterCommand::CC_BuildTile:
 	case CCharacterCommand::CC_WaitForItem:
 	case CCharacterCommand::CC_CountItem:
-		wstr += this->pBuildItemsListBox->GetTextForKey(c.flags);
+	{
+		CListBoxWidget* pListBox = c.command == CCharacterCommand::CC_BuildTile ?
+			this->pBuildItemsListBox : this->pWaitForItemsListBox;
+		wstr += pListBox->GetTextForKey(c.flags);
 		wstr += wszComma;
 		concatNumWithComma(c.x);
 		concatNumWithComma(c.y);
 		concatNumWithComma(c.x + c.w);
 		concatNum(c.y + c.h);
+	}
 	break;
 
 	case CCharacterCommand::CC_WaitForItemGroup:

--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -5023,6 +5023,13 @@ void CCharacterDialogWidget::PopulateItemListBox(
 	pListBox->AddItem(T_POWDER_KEG, g_pTheDB->GetMessageText(MID_PowderKeg));
 	pListBox->AddItem(T_MIST, g_pTheDB->GetMessageText(MID_Mist));
 	pListBox->AddItem(T_MISTVENT, g_pTheDB->GetMessageText(MID_MistVent));
+	pListBox->AddItem(TV_TOKEN_ROTATE_ARROWS_CW, g_pTheDB->GetMessageText(MID_Token));
+	pListBox->AddItem(TV_TOKEN_ROTATE_ARROWS_CCW, g_pTheDB->GetMessageText(MID_TokenRotateCCW));
+	pListBox->AddItem(TV_TOKEN_SWITCH_TAR_MUD, g_pTheDB->GetMessageText(MID_TokenTarMud));
+	pListBox->AddItem(TV_TOKEN_SWITCH_TAR_GEL, g_pTheDB->GetMessageText(MID_TokenTarGel));
+	pListBox->AddItem(TV_TOKEN_SWITCH_GEL_MUD, g_pTheDB->GetMessageText(MID_TokenGelMud));
+	pListBox->AddItem(TV_TOKEN_VISION, g_pTheDB->GetMessageText(MID_TokenTranslucentTar));
+	pListBox->AddItem(TV_TOKEN_DISARM, g_pTheDB->GetMessageText(MID_TokenSwordDisarm));
 	pListBox->AddItem(T_HEALTH_HUGE, g_pTheDB->GetMessageText(MID_HugeHealth));
 	pListBox->AddItem(T_HEALTH_BIG, g_pTheDB->GetMessageText(MID_LargeHealth));
 	pListBox->AddItem(T_HEALTH_MED, g_pTheDB->GetMessageText(MID_MediumHealth));

--- a/drodrpg/DROD/CharacterDialogWidget.h
+++ b/drodrpg/DROD/CharacterDialogWidget.h
@@ -138,7 +138,7 @@ private:
 	void  PopulateGotoLabelList(const COMMANDPTR_VECTOR& commands);
 	void  PopulateGraphicListBox(CListBoxWidget *pListBox);
 	void  PopulateImperativeListBox(const bool bDefaultScript=false);
-	void  PopulateItemListBox(CListBoxWidget* pListBox);
+	void  PopulateItemListBox(CListBoxWidget* pListBox, bool bBuildItems);
 	void  PopulateItemGroupListBox(CListBoxWidget* pListBox);
 	void  PopulateMainGraphicList();
 	void  PopulateSpeakerList(CListBoxWidget *pListBox);
@@ -194,7 +194,7 @@ private:
 	CListBoxWidget *pGotoLabelListBox;
 	CListBoxWidget *pMusicListBox;
 	CListBoxWidget *pVarListBox, *pVarOpListBox, *pVarCompListBox, *pWaitFlagsListBox,
-			*pImperativeListBox, *pBuildItemsListBox, *pBehaviorListBox, *pVarCompListBox2,
+			*pImperativeListBox, *pBuildItemsListBox, *pWaitForItemsListBox, *pBehaviorListBox, *pVarCompListBox2,
 			*pArrayVarListBox, *pArrayVarOpListBox, *pItemGroupListBox;
 	CListBoxWidget *pEquipmentTypesListBox, *pCustomNPCListBox, *pEquipTransListBox;
 	CTextBoxWidget *pCharNameText;

--- a/drodrpg/DRODLib/BuildUtil.cpp
+++ b/drodrpg/DRODLib/BuildUtil.cpp
@@ -255,6 +255,11 @@ bool BuildUtil::BuildVirtualTile(CDbRoom& room, const UINT tile, const UINT x, c
 		case TV_ACCESSORY9: case TV_ACCESSORY10: case TV_ACCESSORY11: case TV_ACCESSORY12:
 			newTile = T_ACCESSORY;
 			break;
+		case TV_TOKEN_ROTATE_ARROWS_CW: case TV_TOKEN_ROTATE_ARROWS_CCW:
+		case TV_TOKEN_SWITCH_TAR_MUD: case TV_TOKEN_SWITCH_TAR_GEL: case TV_TOKEN_SWITCH_GEL_MUD:
+		case TV_TOKEN_VISION: case TV_TOKEN_DISARM:
+			newTile = T_TOKEN;
+			break;
 
 		case TV_EXPLOSION:
 		{
@@ -349,6 +354,13 @@ bool BuildUtil::BuildVirtualTile(CDbRoom& room, const UINT tile, const UINT x, c
 		case TV_ACCESSORY10: room.SetTParam(x, y, WallWalking); break;
 		case TV_ACCESSORY11: room.SetTParam(x, y, XPDoubler); break;
 		case TV_ACCESSORY12: room.SetTParam(x, y, AccessorySlot); break;
+		case TV_TOKEN_ROTATE_ARROWS_CW: room.SetTParam(x, y, RotateArrowsCW); break;
+		case TV_TOKEN_ROTATE_ARROWS_CCW: room.SetTParam(x, y, RotateArrowsCCW); break;
+		case TV_TOKEN_SWITCH_TAR_MUD: room.SetTParam(x, y, SwitchTarMud); break;
+		case TV_TOKEN_SWITCH_TAR_GEL: room.SetTParam(x, y, SwitchTarGel); break;
+		case TV_TOKEN_SWITCH_GEL_MUD: room.SetTParam(x, y, SwitchGelMud); break;
+		case TV_TOKEN_VISION: room.SetTParam(x, y, TarTranslucent); break;
+		case TV_TOKEN_DISARM: room.SetTParam(x, y, SwordDisarm); break;
 		default: break; //nothing else to do here
 	}
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -4694,6 +4694,8 @@ TileCheckFunc getItemGroupFunction(ScriptFlag::ItemGroup group)
 	case ScriptFlag::IG_Equipment: return bIsEquipment;
 	case ScriptFlag::IG_Keys: return bIsKey;
 	case ScriptFlag::IG_Collectable: return bIsCollectable;
+	case ScriptFlag::IG_AnyToken: return [](UINT t) { return t == T_TOKEN; };
+	case ScriptFlag::IG_AnyTTile: return [](UINT t) { return t != 0; };
 	default: return bIsPlainFloor;
 	}
 }
@@ -4742,6 +4744,8 @@ UINT getItemGroupLayer(ScriptFlag::ItemGroup group)
 	case ScriptFlag::IG_Equipment: return LAYER_TRANSPARENT;
 	case ScriptFlag::IG_Keys: return LAYER_TRANSPARENT;
 	case ScriptFlag::IG_Collectable: return LAYER_TRANSPARENT;
+	case ScriptFlag::IG_AnyToken: return LAYER_TRANSPARENT;
+	case ScriptFlag::IG_AnyTTile: return LAYER_TRANSPARENT;
 	default: return LAYER_OPAQUE;
 	}
 }

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -235,6 +235,8 @@ namespace ScriptFlag
 		IG_Equipment = 35, //Any equipment slot
 		IG_Keys = 36, //Any key
 		IG_Collectable = 37, //Any item the player can pick up
+		IG_AnyToken = 38, //Any token
+		IG_AnyTTile, //Any T-layer object
 		ItemGroupCount //Total number of defined groups
 	};
 

--- a/drodrpg/DRODLib/CharacterCommand.h
+++ b/drodrpg/DRODLib/CharacterCommand.h
@@ -236,7 +236,7 @@ namespace ScriptFlag
 		IG_Keys = 36, //Any key
 		IG_Collectable = 37, //Any item the player can pick up
 		IG_AnyToken = 38, //Any token
-		IG_AnyTTile, //Any T-layer object
+		IG_AnyTTile = 39, //Any T-layer object
 		ItemGroupCount //Total number of defined groups
 	};
 

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -855,6 +855,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_PushToArrayVar: strText = "Push to array var"; break;
 		case MID_PopFromArrayVar: strText = "Pop from array var"; break;
 		case MID_ArrayVarRange: strText = "Get array var range"; break;
+		case MID_AnyToken: strText = "Any token"; break;
+		case MID_AnyTLayer: strText = "Any T-layer object"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbRooms.cpp
+++ b/drodrpg/DRODLib/DbRooms.cpp
@@ -2753,6 +2753,11 @@ bool CDbRoom::DoesSquareContainTile(
 			case TV_ACCESSORY9: case TV_ACCESSORY10: case TV_ACCESSORY11: case TV_ACCESSORY12:
 				realTile = T_ACCESSORY;
 				break;
+			case TV_TOKEN_ROTATE_ARROWS_CW: case TV_TOKEN_ROTATE_ARROWS_CCW:
+			case TV_TOKEN_SWITCH_TAR_MUD: case TV_TOKEN_SWITCH_TAR_GEL: case TV_TOKEN_SWITCH_GEL_MUD:
+			case TV_TOKEN_VISION: case TV_TOKEN_DISARM:
+				realTile = T_TOKEN;
+				break;
 			default: break;
 		}
 		if (realTile != GetTSquare(wX, wY))
@@ -2799,6 +2804,13 @@ bool CDbRoom::DoesSquareContainTile(
 			case TV_ACCESSORY10: param = WallWalking; break;
 			case TV_ACCESSORY11: param = XPDoubler; break;
 			case TV_ACCESSORY12: param = AccessorySlot; break;
+			case TV_TOKEN_ROTATE_ARROWS_CW: param = RotateArrowsCW; break;
+			case TV_TOKEN_ROTATE_ARROWS_CCW: param = RotateArrowsCCW; break;
+			case TV_TOKEN_SWITCH_TAR_MUD: param = SwitchTarMud; break;
+			case TV_TOKEN_SWITCH_TAR_GEL: param = SwitchTarGel; break;
+			case TV_TOKEN_SWITCH_GEL_MUD: param = SwitchGelMud; break;
+			case TV_TOKEN_VISION: param = TarTranslucent; break;
+			case TV_TOKEN_DISARM: param = SwordDisarm; break;
 			default: break; //nothing else to do here
 		}
 		if (param == GetTParam(wX, wY))

--- a/drodrpg/DRODLib/TileConstants.h
+++ b/drodrpg/DRODLib/TileConstants.h
@@ -424,7 +424,14 @@ static inline bool IsMonsterTileNo(const UINT t) {return t>=TILE_COUNT && t<TOTA
 #define TV_SHIELD9     ((UINT)-39)
 #define TV_REMOVE_OVERHEAD_IMAGE (UINT(-40))
 #define TV_REMOVE_TRANSPARENT (UINT(-41))
-static inline bool IsVirtualTile(const UINT t) {return t>=(UINT)TV_REMOVE_TRANSPARENT;}
+#define TV_TOKEN_ROTATE_ARROWS_CW (UINT(-42))
+#define TV_TOKEN_ROTATE_ARROWS_CCW (UINT(-43))
+#define TV_TOKEN_SWITCH_TAR_MUD (UINT(-44))
+#define TV_TOKEN_SWITCH_TAR_GEL (UINT(-45))
+#define TV_TOKEN_SWITCH_GEL_MUD (UINT(-46))
+#define TV_TOKEN_VISION (UINT(-47))
+#define TV_TOKEN_DISARM (UINT(-48))
+static inline bool IsVirtualTile(const UINT t) {return t>=(UINT)TV_TOKEN_DISARM;}
 
 //Virtual tiles: enumerate after TOTAL_TILE_COUNT
 #define T_SWORDSMAN           (TOTAL_TILE_COUNT + 0)  //for placing the level entrance

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1819,6 +1819,8 @@ enum MID_CONSTANT {
   MID_PushToArrayVar = 2174,
   MID_PopFromArrayVar = 2175,
   MID_ArrayVarRange = 2176,
+  MID_AnyToken = 2177,
+  MID_AnyTLayer = 2178,
 
   //Messages from Stats.uni:
   MID_VarHP = 1536,

--- a/drodrpg/Texts/Speech.uni
+++ b/drodrpg/Texts/Speech.uni
@@ -1863,3 +1863,11 @@ Pop from array var
 [MID_ArrayVarRange]
 [eng]
 Get array var range
+
+[MID_AnyToken]
+[eng]
+Any token
+
+[MID_AnyTLayer]
+[eng]
+Any T-layer object


### PR DESCRIPTION
A few changes to make building items and querying them a little better:

1. The `Build` command and the `Wait for item` command were using the same input widgets, meaning they had to share options. I've split this into two, one for building and one for waiting.
2. Scrolls and platforms are now options available for `Wait for item`. Obstacles have been removed from `Build` because they can't be built. All the special removal virtual tiles have been removed from `Wait for item` because it doesn't make sense to wait for them.
3. Virtual tiles have been added for each token, and they've all been added to both lists.
4. Two new groups have been added to `Wait for item group` - `Any token` and `Any T_layer object`.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47221