### PR TITLE
Fix clones pressing plates when role change from flying to flying.

### DIFF
--- a/DRODLib/CurrentGame.cpp
+++ b/DRODLib/CurrentGame.cpp
@@ -4800,6 +4800,24 @@ void CCurrentGame::SynchClonesWithPlayer(CCueEvents& CueEvents)
 
 	SetCloneWeaponsSheathed();
 
+	/*
+	MAURYCY (SKELL):
+	Intentionally left here as a future reference for 5.3 release if/when we
+	decide to tackle the issue that player changing role from flying to non-flying
+	does not cause pressure plate pressing. Nor any other action or interaction.
+	This extends to an issue with clones. Prior to TSS 5.0.2 clones would press plates
+	if player role changed from flying to non-flying but as part of fixes to a seep
+	bug I accidentally broke it so that they only press the plate if they cannot
+	press it.
+
+	So when we fix this we may want to reuse this code because
+	it's good code for the most part.
+
+	Reference threads:
+	 - Seep bug: https://forum.caravelgames.com/viewtopic.php?TopicID=39739
+	 - Player role issue: https://forum.caravelgames.com/viewtopic.php?TopicID=47375
+	 - Clone issue: https://forum.caravelgames.com/viewtopic.php?TopicID=47180
+
 	//Check for clones depressing pressure plates according to player role.
 	if (this->wTurnNo > 0) //...except on room entrance
 	{
@@ -4818,6 +4836,7 @@ void CCurrentGame::SynchClonesWithPlayer(CCueEvents& CueEvents)
 			}
 		}
 	}
+	*/
 }
 
 //*****************************************************************************

--- a/DRODLibTests/DRODLibTests.2019.vcxproj
+++ b/DRODLibTests/DRODLibTests.2019.vcxproj
@@ -418,6 +418,7 @@
     <ClCompile Include="src\tests\Scripting\Imperative_Vulnerable_Invulnerable.cpp" />
     <ClCompile Include="src\tests\Scripting\PrimitiveFunctions.cpp" />
     <ClCompile Include="src\tests\Scripting\PushTile.cpp" />
+    <ClCompile Include="src\tests\Scripting\SetPlayerAppearance.cpp" />
     <ClCompile Include="src\tests\Scripting\SetPlayerWeapon.cpp" />
     <ClCompile Include="src\tests\Scripting\SmartGotoLabels.cpp" />
     <ClCompile Include="src\tests\Scripting\TeleportPlayer\TeleportPlayer.cpp" />

--- a/DRODLibTests/DRODLibTests.2019.vcxproj.filters
+++ b/DRODLibTests/DRODLibTests.2019.vcxproj.filters
@@ -192,7 +192,7 @@
     <ClCompile Include="src\tests\Player\Bugs\PushPlayerAgainstCaber.cpp">
       <Filter>Tests\Player\Bugs</Filter>
     </ClCompile>
-    <ClCompile Include="src\tests\Scripting\SetPlayerWeapon.cpp">
+    <ClCompile Include="src\tests\Scripting\SetPlayerAppearance.cpp">
       <Filter>Tests\Scripting</Filter>
     </ClCompile>
     <ClCompile Include="src\tests\Scripting\Build\BuildingRelayStations.cpp">

--- a/DRODLibTests/src/tests/Scripting/SetPlayerAppearance.cpp
+++ b/DRODLibTests/src/tests/Scripting/SetPlayerAppearance.cpp
@@ -1,0 +1,29 @@
+#include "../../test-include.hpp"
+#include "../../CAssert.h"
+
+TEST_CASE("Scripting: Set player appearance", "[game]") {
+	RoomBuilder::ClearRoom();
+
+	SECTION("Clones don't press plates when role changes between two flying ones") {
+		// SETUP: Room with plate and door, clone on multi-use plate;
+		// script changes player role to flying then another flying
+		RoomBuilder::AddMonster(M_CLONE, 10, 10);
+		RoomBuilder::Plot(T_PRESSPLATE, 10, 10);
+		RoomBuilder::Plot(T_DOOR_Y, 11, 11);
+		RoomBuilder::AddOrbDataToTile(10, 10, OrbType::OT_NORMAL);
+		RoomBuilder::LinkOrb(10, 10, 11, 11, OrbAgentType::OA_TOGGLE);
+
+		CCharacter* pScript = RoomBuilder::AddCharacter(1, 1);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_Wait, 1);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_SetPlayerAppearance, M_WWING);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_Wait, 1);
+		RoomBuilder::AddCommand(pScript, CCharacterCommand::CC_SetPlayerAppearance, M_FEGUNDO);
+
+		CCurrentGame* pGame = Runner::StartGame(20, 20, N);
+		// Sanity check, door should start closed
+		REQUIRE(pGame->pRoom->GetOSquare(11, 11) == T_DOOR_Y);
+		Runner::ExecuteCommand(CMD_WAIT, 3);
+		// THEN: Door should remain closed
+		REQUIRE(pGame->pRoom->GetOSquare(11, 11) == T_DOOR_Y);
+	}
+}


### PR DESCRIPTION
Quick story:
 - TCB added clones & player roles.
 - WHen player role changed from flying to non-flying then clones would press plates.
 - For 5.0.2 I [Maurycy] was fixing a bug with seep and plates and broke that behavior - from that point role change from flying to non-flying clones don't press plates; instead they incorrectly press when changing from flying to flying
- This fixes this behavior but does not restore the pre-5.0.2 clone pressing plates for three reasons: A) This makes it consistent with player behavior
B) It worked like that for more time than the old behavior which makes it more canonical C) There is a bug request about changing the behavior for player role which, if implemented, will need to be made as an expansion to Set Player Appearance command and then we could make them work the same.

COPIED OVER IMPORTANT COMMENT FROM CODE IN THIS COMMIT: Intentionally left [some code] as a future reference for 5.3 release if/when we
	decide to tackle the issue that player changing role from flying to non-flying
	does not cause pressure plate pressing. Nor any other action or interaction.
	This extends to an issue with clones. Prior to TSS 5.0.2 clones would press plates
	if player role changed from flying to non-flying but as part of fixes to a seep
	bug I accidentally broke it so that they only press the plate if they cannot
	press it.

Reference threads:
 - Seep bug: https://forum.caravelgames.com/viewtopic.php?TopicID=39739
 - Player role issue: https://forum.caravelgames.com/viewtopic.php?TopicID=47375
 - Clone issue: https://forum.caravelgames.com/viewtopic.php?TopicID=47180