### PR TITLE
Replace unchecked access to TILE_LAYER with a dedicated function.

### DIFF
--- a/DROD/EditRoomScreen.cpp
+++ b/DROD/EditRoomScreen.cpp
@@ -5690,7 +5690,7 @@ void CEditRoomScreen::PlotObjects()
 			//Refresh room stats and/or covered tiles when needed.
 			if (bIsBriar(wPlottedObject) || wPlottedObject == T_TOKEN) //briar and conquer token require recalcs
 				this->pRoom->InitRoomStats();
-			else if (TILE_LAYER[wPlottedObject] == 0)
+			else if (getTileLayer(wPlottedObject) == 0)
 			{
 				//Redefine current connected components, like platforms,
 				//and synch coveredOTiles.
@@ -6050,7 +6050,7 @@ void CEditRoomScreen::EraseObjects()
 
 	Changing();
 
-	const UINT wLayer = TILE_LAYER[this->wSelectedObject];
+	const UINT wLayer = getTileLayer(this->wSelectedObject);
 	bool bSomethingPlotted = false, bSomethingDeleted = false;
 	if ((SDL_GetModState() & KMOD_SHIFT) == 0) {
 		EraseObjects(wLayer, bSomethingPlotted, bSomethingDeleted);
@@ -6338,7 +6338,7 @@ CObjectMenuWidget* CEditRoomScreen::ObjectMenuForTile(const UINT wTile)
 {
 	ASSERT(wTile < TOTAL_EDIT_TILE_COUNT);
 	UINT dwMenu = 0;
-	switch (TILE_LAYER[wTile])
+	switch (getTileLayer(wTile))
 	{
 		case 0: dwMenu = TAG_OMENU; break;
 		case 1: dwMenu = TAG_TMENU; break;
@@ -6689,7 +6689,7 @@ bool CEditRoomScreen::RemoveObjectAt(
 	const UINT wOTileNo = room.GetOSquare(wX,wY),
 			fTile = room.GetFSquare(wX,wY),
 			wTTileNo = room.GetTSquare(wX,wY),
-			wLayer = TILE_LAYER[wPlottedObject];
+			wLayer = getTileLayer(wPlottedObject);
 	CMonster *pMonster;
 
 	bool bSuccess = true;

--- a/DROD/EditRoomWidget.cpp
+++ b/DROD/EditRoomWidget.cpp
@@ -731,7 +731,7 @@ const
 
 	//Get what's on the other layers to see if they're compatible.
 	UINT wTileNo[4];
-	const UINT wTileLayer = TILE_LAYER[wSelectedObject];
+	const UINT wTileLayer = getTileLayer(wSelectedObject);
 	const UINT wSquareIndex = this->pRoom->ARRAYINDEX(wX,wY);
 	wTileNo[0] = this->pRoom->pszOSquares[wSquareIndex];
 	wTileNo[1] = this->pRoom->GetTSquare(wSquareIndex);

--- a/DRODLib/Briar.cpp
+++ b/DRODLib/Briar.cpp
@@ -610,7 +610,7 @@ void CBriars::plotted(const UINT wX, const UINT wY, const UINT wTileNo)
 
 	//If a door closes here or the t-layer is modified (i.e. briar is overwritten),
 	//synch data structures for any briar that used to be here.
-	if (!bIsDoor(wTileNo) && TILE_LAYER[wTileNo] != 1) //t-layer plots affect briars
+	if (!bIsDoor(wTileNo) && getTileLayer(wTileNo) != 1) //t-layer plots affect briars
 		return;
 
 	vector<CCoordSet>::iterator tiles;

--- a/DRODLib/BuildUtil.cpp
+++ b/DRODLib/BuildUtil.cpp
@@ -100,7 +100,7 @@ UINT BuildUtil::BuildTilesAt(
 	if (baseTile >= TOTAL_EDIT_TILE_COUNT)
 		return builtTiles;
 
-	if (TILE_LAYER[baseTile] == LAYER_OPAQUE) {
+	if (getTileLayer(baseTile) == LAYER_OPAQUE) {
 		for (UINT y = py; y <= endY; ++y)
 			for (UINT x = px; x <= endX; ++x) {
 				//When o-layer changes, refresh bridge supports.
@@ -137,7 +137,7 @@ bool BuildUtil::CanBuildAt(CDbRoom& room, const UINT tile, const UINT x, const U
 	const UINT baseTile = bConvertFakeElement(tile);
 	if (IsValidTileNo(baseTile))
 	{
-		switch (TILE_LAYER[baseTile])
+		switch (getTileLayer(baseTile))
 		{
 			case LAYER_OPAQUE:
 				//Don't build if this element is already there.
@@ -328,7 +328,7 @@ bool BuildUtil::BuildNormalTile(CDbRoom& room, const UINT baseTile, const UINT t
 	if (baseTile == wOldOTile && !bAllowSame)
 		return false;
 
-	const UINT wLayer = TILE_LAYER[baseTile];
+	const UINT wLayer = getTileLayer(baseTile);
 	if (wLayer == LAYER_OPAQUE)
 	{
 		//Update room's trapdoor stats when a trapdoor is removed this special way.

--- a/DRODLib/DbRooms.cpp
+++ b/DRODLib/DbRooms.cpp
@@ -699,7 +699,7 @@ void CDbRooms::FilterBy(
 void CDbRooms::LogRoomsWithItem(const UINT wTile, const UINT wParam)
 //Output a log of all rooms that contain the mentioned item.
 {
-	const UINT wLayer = TILE_LAYER[wTile];
+	const UINT wLayer = getTileLayer(wTile);
 
 	ASSERT(IsOpen());
 	CDb db;
@@ -2936,7 +2936,7 @@ bool CDbRoom::DoesSquareContainTile(
 		return false;
 	}
 
-	switch (TILE_LAYER[tile])
+	switch (getTileLayer(tile))
 	{
 		case 0:  //o-layer
 			if (bFakeElement) {
@@ -4282,7 +4282,7 @@ const
 
 	//Check each square for this tile.
 	char *pszSquare, *pszSquares;
-	switch (TILE_LAYER[wType])
+	switch (getTileLayer(wType))
 	{
 		case 0: pszSquares = pszOSquares; break;
 		case 1:
@@ -10678,7 +10678,7 @@ void CDbRoom::FloodPlot(
 	ASSERT(IsValidTileNo(wTileNo));
 
 	//Flood squares of tile type at (wX,wY).
-	const UINT wLayer = TILE_LAYER[wTileNo];
+	const UINT wLayer = getTileLayer(wTileNo);
 	CTileMask mask(wLayer == 0 ? GetOSquare(wX, wY) : GetTSquare(wX,wY));
 
 	//Gather list of squares to flood fill.
@@ -10911,7 +10911,7 @@ bool CDbRoom::RemoveTiles(const UINT wOldTile)
 //Returns:
 //True if any tiles were found
 {
-	ASSERT(TILE_LAYER[wOldTile] == 0);  //o-layer only implemented currently
+	ASSERT(getTileLayer(wOldTile) == 0);  //o-layer only implemented currently
 	bool bChangedTiles=false;
 	for (UINT wY=wRoomRows; wY--; )
 		for (UINT wX=wRoomCols; wX--; )
@@ -10944,8 +10944,8 @@ bool CDbRoom::ToggleTiles(const UINT wOldTile, const UINT wNewTile, CCueEvents& 
 //Returns:
 //True if any tiles were found
 {
-	ASSERT(TILE_LAYER[wOldTile] == 0);  //o-layer only implemented currently
-	ASSERT(TILE_LAYER[wNewTile] == 0);
+	ASSERT(getTileLayer(wOldTile) == 0);  //o-layer only implemented currently
+	ASSERT(getTileLayer(wNewTile) == 0);
 
 	bool bChangedTiles=false, bThisTileChanged=false;
 	const bool bSolidOldTile = bIsSolidOTile(wOldTile) || wOldTile == T_HOT;
@@ -11019,7 +11019,7 @@ void CDbRoom::Plot(
 	ASSERT(IsValidColRow(wX, wY));
 
 	const UINT wSquareIndex = ARRAYINDEX(wX,wY);
-	switch (TILE_LAYER[wTileNo])
+	switch (getTileLayer(wTileNo))
 	{
 		case 0: //Opaque layer.
 			this->pszOSquares[wSquareIndex] = static_cast<unsigned char>(wTileNo);

--- a/DRODLib/Monster.cpp
+++ b/DRODLib/Monster.cpp
@@ -1923,7 +1923,7 @@ const
 	CDbRoom *pRoom = this->pCurrentGame->pRoom;
 	ASSERT(pRoom);
 
-	const UINT wLayer = TILE_LAYER[wObject];
+	const UINT wLayer = getTileLayer(wObject);
 	ASSERT(wLayer <= 2);
 
 	int i,j;

--- a/DRODLib/TileConstants.h
+++ b/DRODLib/TileConstants.h
@@ -202,7 +202,7 @@ static inline bool IsValidTileNo(const UINT t) {return t < TILE_COUNT;}
 #define T_REMOVE_TRANSPARENT (UINT(-58))
 /// Used by CID_ObjectBuilt to trigger event but signify no sound effect to be played
 #define T_SILENT_BUILD (UINT(-59))
-#define LAST_FAKE_TILE_INDEX (UINT(-58))
+#define LAST_FAKE_TILE_INDEX (UINT(-59))
 
 static inline bool bIsFakeTokenType(const UINT t) { return t >= T_TOKEN_RESERVED_SPACE && t <= T_ACTIVETOKEN; }
 static inline bool bIsFakeOrbType(const UINT t) { return t == T_ORB_CRACKED || t == T_ORB_BROKEN || t == T_ORB_NORMAL; }
@@ -439,43 +439,6 @@ static inline BYTE calcLightRadius(const UINT val) {return (val & ((MAX_LIGHT_DI
 static inline BYTE calcLightType(const UINT val) {return val & (NUM_LIGHT_TYPES-1);}
 
 
-static inline UINT getBaseTile(const UINT wVirtualTile)
-{
-	switch (wVirtualTile)
-	{
-	case T_ACTIVETOKEN:
-	case T_TOKEN_ROTATECW:
-	case T_TOKEN_ROTATECCW:
-	case T_TOKEN_SWITCH_TARMUD:
-	case T_TOKEN_SWITCH_TARGEL:
-	case T_TOKEN_SWITCH_GELMUD:
-	case T_TOKEN_VISION:
-	case T_TOKEN_POWER:
-	case T_TOKEN_DISARM:
-	case T_TOKEN_PERSISTENTMOVE:
-	case T_TOKEN_CONQUER:
-	case T_TOKEN_WPSWORD:
-	case T_TOKEN_WPPICKAXE:
-	case T_TOKEN_WPSPEAR:
-	case T_TOKEN_WPSTAFF:
-	case T_TOKEN_WPDAGGER:
-	case T_TOKEN_WPCABER:
-	case T_TOKEN_TSPLIT:
-	case T_TOKEN_TSPLIT_USED:
-	case T_TOKEN_RESERVED_SPACE:
-		return T_TOKEN;
-	case T_ORB_CRACKED:
-	case T_ORB_BROKEN:
-		return T_ORB;
-	case T_PLATE_ONEUSE:
-	case T_PLATE_MULTI:
-	case T_PLATE_ON_OFF:
-		return T_PRESSPLATE;
-	default:
-		return wVirtualTile;
-	}
-}
-
 //Add to monster values so they don't overlap o- and t-layer values on a tile.
 //NOTE: Make sure list matches that in MonsterFactory.h.
 static const UINT M_OFFSET = TILE_COUNT;
@@ -544,8 +507,11 @@ enum TILELAYERS {
 	LAYER_FLOOR = 3
 };
 
-//Layer associated with each tile--0 is opaque layer, 1 is transparent layer,
-//    2 is monster layer, and 3 is the floor layer.
+/**
+ * Layer associated with each tile.
+ * Do not access directly, use `getTileLayer()` instead to ensure virtual
+ * or fake values don't cause invalid memory access.
+ */
 static const UINT TILE_LAYER[TOTAL_EDIT_TILE_COUNT] =
 {
 	LAYER_TRANSPARENT, //T_EMPTY         0
@@ -875,6 +841,11 @@ static const UINT TILE_MID[TOTAL_EDIT_TILE_COUNT] =
 	0                 //T_EMPTY_F       TOTAL+2
 };
 
+/// Returns true if the given tile has a layer assigned to it
+static inline bool bIsTileWithLayer(const UINT wTile) {
+	return wTile < TOTAL_EDIT_TILE_COUNT;
+}
+
 static inline UINT getBuildMarkerTileMID(const UINT wTile){
 	switch(wTile){
 		case T_ORB_NORMAL: return MID_OrbWaitNormal;
@@ -932,12 +903,30 @@ static inline UINT bConvertFakeElement(const UINT t) {
 	if (bIsFakePressurePlateType(t)){
 		return T_PRESSPLATE;
 	}
-	if (t == T_REMOVE_FLOOR_ITEM){
-		return T_EMPTY_F;
+	switch (t) {
+		case T_REMOVE_FLOOR_ITEM: return T_EMPTY_F;
+		case T_REMOVE_TRANSPARENT: return T_EMPTY_TRANSPARENT;
+		case T_REMOVE_OVERHEAD_IMAGE: return T_OVERHEAD_IMAGE;
+		default: return t;
 	}
-	if (t == T_REMOVE_TRANSPARENT) {
-		return T_EMPTY_TRANSPARENT;
+}
+
+/**
+ * Return the layer used by a tile:
+ *  - Fake tiles are converted to their base tile and its layer is returned
+ *  - Invalid values or fake tiles without base tile return Opaque Layer (0)
+ */
+static inline UINT getTileLayer(const UINT wTile) {
+	if (bIsTileWithLayer(wTile)) {
+		return TILE_LAYER[wTile];
 	}
-	return t;
+
+	const UINT wBaseTile = bConvertFakeElement(wTile);
+
+	if (bIsTileWithLayer(wBaseTile)) {
+		return TILE_LAYER[wBaseTile];
+	}
+
+	return LAYER_OPAQUE;
 }
 #endif //...#ifndef TILECONSTANTS_H

--- a/DRODLibTests/src/CAssert.cpp
+++ b/DRODLibTests/src/CAssert.cpp
@@ -122,7 +122,7 @@ bool Assert::HasTile(const UINT wExpectedX, const UINT wExpectedY, const UINT wE
 	const UINT baseTile = bConvertFakeElement(wExpectedType);
 	REQUIRE(IsValidTileNo(baseTile));
 
-	switch (TILE_LAYER[baseTile])
+	switch (getTileLayer(baseTile))
 	{
 	case LAYER_OPAQUE:
 		switch (baseTile) {

--- a/DRODLibTests/src/CTestDb.cpp
+++ b/DRODLibTests/src/CTestDb.cpp
@@ -37,7 +37,6 @@ bool Setting_SaveTestLevels = false;
 
 void CTestDb::Init(int argc, char* const argv[])
 {
-
 	CTestDb::InitializeCFiles(argv);
 	CTestDb::InitializeDb();
 	CTestDb::InitializePlayer();

--- a/DRODLibTests/src/tests/Scripting/Build/BuildSanityTest.cpp
+++ b/DRODLibTests/src/tests/Scripting/Build/BuildSanityTest.cpp
@@ -15,7 +15,9 @@ static void CanBuildOnPlayer(const UINT tileToBuild, const bool canBuild){
 	CCurrentGame* game = Runner::StartGame(10, 10, N);
 	Runner::ExecuteCommand(CMD_WAIT, 1);
 
-	const UINT wBaseTile = getBaseTile(tileToBuild);
+	const UINT wBaseTile = bConvertFakeElement(tileToBuild);
+	INFO("Make sure this tile has an actual layer we can use for checking");
+	REQUIRE(bIsTileWithLayer(wBaseTile));
 	REQUIRE(game->pRoom->IsTileInRectOfType(10, 10, 10, 10, wBaseTile) == canBuild);
 }
 
@@ -29,7 +31,9 @@ static void CanBuildOnTile(const UINT tileToBuild, const UINT underTile, const b
 	CCurrentGame* game = Runner::StartGame(5, 10, N);
 	Runner::ExecuteCommand(CMD_WAIT, 1);
 
-	const UINT wBaseTile = getBaseTile(tileToBuild);
+	const UINT wBaseTile = bConvertFakeElement(tileToBuild);
+	INFO("Make sure this tile has an actual layer we can use for checking");
+	REQUIRE(bIsTileWithLayer(wBaseTile));
 	REQUIRE(game->pRoom->IsTileInRectOfType(10, 10, 10, 10, wBaseTile) == canBuild);
 }
 


### PR DESCRIPTION
Kieran has reported there are some issues in the Mac build caused by depending on the TILE_ARRAY array which in some places can be access with negative indices which causes issues there (but seems to be happily consumed by other platforms). This commit adds a dedicated function for handling that and the rest of the commit log is my notes about each change.

Here are the tags I use:
 - [NO CHECKS] Using TILE_LAYER without any checks
 - [FAKE CHECK] Using TILE_LAYER with values returned from `bConvertFakeElement()`; this protects from most fake elements but not things like "monster" tiles or T_REMOVE_OVERHEAD_IMAGE or invalid values (eg. through _MyScript vars) so still not protected from invalid memory access at all
 - [VALID TILE CHECK] Calls `IsValidTileNo()` before accessing TILE_LAYER which guarantees no out of bounds array access.
 - [MY SCRIPT INJECTION] If there was a way for this function/place to be reached with a command with argument set through _MyScript which means it can contain ANY uint value
 - [SAFE ACCESS] Only called with known safe arguments

Changes:
 - `CDbRooms::LogRoomsWithItem` - [NO CHECKS]; unused function
 - `CDbRooms::DoesSquareContainTile` - [VALID TILE CHECK] [MY SCRIPT INJECTION]
 - `CDbRooms::IsTileInRectOfType` - [NO CHECKS] [SAFE ACCESS]
 - `CDbRooms::FloodPlot` - [NO CHECKS] [SAFE ACCESS]
 - `CDbRooms::RemoveTiles` - [NO CHECKS]; unused function
 - `CDbRooms::ToggleTiles` - [NO CHECKS] [SAFE ACCESS]
 - `CDbRooms::plot` - [NO CHECKS]; used in so many places I didn't want to go down the rabbit hole of checking if _MyScript injection was possible
 - `CDbRooms::RemoveTiles` - [NO CHECKS]; unused function
 - `CEditRoomScreen::PlotObjects` - [NO CHECKS]; can't think how the editor could abuse this
 - `CEditRoomScreen::EraseObjects` - [NO CHECKS]; can't think how the editor could abuse this
 - `CEditRoomScreen::ObjectMenuForTile` - [NO CHECKS]; can't think how the editor could abuse this
 - `CEditRoomScreen::RemoveObjectAt` - [NO CHECKS]; can't think how the editor could abuse this
 - `CEditRoomWidget::IsSafePlacement` - [NO CHECKS]; can't think how the editor could abuse this
 - `CBriars::plotted` - [NO CHECKS]; Called from `CDbRooms::plot()` so might be MyScript injectable
 - `BuildUtil::BuildTilesAt` - [FAKE CHECK] [MY SCRIPT INJECTION]
 - `BuildUtil::CanBuildAt` - [FAKE CHECK] [MY SCRIPT INJECTION]
 - `BuildUtil::BuildNormalTile` - [FAKE CHECK] [MY SCRIPT INJECTION]; fake check is inherited from callers
 - `CMonster::IsObjectAdjacent` - [NO CHECKS] [SAFE ACCESS]

Reference: https://forum.caravelgames.com/viewtopic.php?TopicID=46804

@kieranmillar 