### PR TITLE
RPG: Add predefined variables to control player color

### DIFF
--- a/drodrpg/DROD/CharacterDialogWidget.cpp
+++ b/drodrpg/DROD/CharacterDialogWidget.cpp
@@ -5437,6 +5437,9 @@ void CCharacterDialogWidget::PopulateVarList()
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_X, g_pTheDB->GetMessageText(MID_VarX));
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_Y, g_pTheDB->GetMessageText(MID_VarY));
 	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_O, g_pTheDB->GetMessageText(MID_VarO));
+	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_COLOR, g_pTheDB->GetMessageText(MID_VarColor));
+	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_HUE, g_pTheDB->GetMessageText(MID_VarHue));
+	this->pVarListBox->AddItem(ScriptVars::P_PLAYER_SATURATION, g_pTheDB->GetMessageText(MID_VarSaturation));
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_X, g_pTheDB->GetMessageText(MID_VarRoomX));
 	this->pVarListBox->AddItem(ScriptVars::P_ROOM_Y, g_pTheDB->GetMessageText(MID_VarRoomY));
 	this->pVarListBox->AddItem(ScriptVars::P_RETURN_X, g_pTheDB->GetMessageText(MID_VarReturnX));

--- a/drodrpg/DROD/RoomWidget.cpp
+++ b/drodrpg/DROD/RoomWidget.cpp
@@ -7915,7 +7915,8 @@ void CRoomWidget::DrawPlayer(
 	{
 		TileImageBlitParams blit(swordsman.wX, swordsman.wY, wSManTI, wXOffset, wYOffset, true, fRaised);
 		blit.nOpacity = nOpacity;
-		//blit.nAddColor = nAddColor;
+		blit.nAddColor = swordsman.getColor();
+		blit.hsv = swordsman.getHSV();
 		DrawTileImage(blit, pDestSurface);
 	}
 

--- a/drodrpg/DRODLib/Character.cpp
+++ b/drodrpg/DRODLib/Character.cpp
@@ -853,6 +853,19 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 		}
 		break;
 
+		case (UINT)ScriptVars::P_PLAYER_HUE:
+		{
+			CCurrentGame* pGame = const_cast<CCurrentGame*>(this->pCurrentGame);
+			pGame->pPlayer->SetHue(val);
+		}
+		break;
+		case (UINT)ScriptVars::P_PLAYER_SATURATION:
+		{
+			CCurrentGame* pGame = const_cast<CCurrentGame*>(this->pCurrentGame);
+			pGame->pPlayer->SetSaturation(val);
+		}
+		break;
+
 		case (UINT)ScriptVars::P_MONSTER_NAME:
 		case (UINT)ScriptVars::P_MONSTER_CUSTOM_WEAKNESS:
 		case (UINT)ScriptVars::P_MONSTER_CUSTOM_DESCRIPTION:
@@ -955,6 +968,7 @@ bool CCharacter::setPredefinedVarInt(const UINT varIndex, const UINT val, CCueEv
 					case (UINT)ScriptVars::P_GEL_SWAP:
 					case (UINT)ScriptVars::P_RETURN_X:
 					case (UINT)ScriptVars::P_RETURN_Y:
+					case (UINT)ScriptVars::P_PLAYER_COLOR:
 						//display nothing
 					break;
 

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -7297,6 +7297,8 @@ void CCurrentGame::UnpackData(CDbPackedVars& stats)
 	this->pPlayer->bAccessoryOff = stats.GetVar(accessoryOffStr, this->pPlayer->bAccessoryOff);
 	this->pPlayer->bCommandOff = stats.GetVar(commandOffStr, this->pPlayer->bCommandOff);
 
+	this->pPlayer->SetColorsFromStats();
+
 	//Unpack music.
 	this->music.clear();
 	this->music.musicEnum = stats.GetVar(musicEnumStr, this->music.musicEnum);

--- a/drodrpg/DRODLib/PlayerStats.cpp
+++ b/drodrpg/DRODLib/PlayerStats.cpp
@@ -50,7 +50,8 @@ const char ScriptVars::predefinedVarTexts[PredefinedVarCount][16] =
 	"", "",
 	"_MudSwap", "_TarSwap", "_GelSwap",
 	"", "",
-	"_ReturnX", "_ReturnY"
+	"_ReturnX", "_ReturnY",
+	"_Color", "_Hue", "_Saturation"
 };
 
 //Message texts corresponding to the above short var texts.
@@ -87,7 +88,8 @@ const UINT ScriptVars::predefinedVarMIDs[PredefinedVarCount] = {
 	MID_VarTotalAtk, MID_VarTotalDef,
 	MID_VarMudSwap, MID_VarTarSwap, MID_VarGelSwap,
 	MID_VarMonsterHue, MID_VarMonsterSaturation,
-	MID_VarReturnX, MID_VarReturnY
+	MID_VarReturnX, MID_VarReturnY,
+	MID_VarColor, MID_VarHue, MID_VarSaturation
 };
 
 string ScriptVars::midTexts[PredefinedVarCount]; //inited on first call
@@ -546,6 +548,10 @@ UINT PlayerStats::getVar(const Predefined var) const
 		case ScriptVars::P_RETURN_X: return this->scriptReturnX;
 		case ScriptVars::P_RETURN_Y: return this->scriptReturnY;
 
+		case ScriptVars::P_PLAYER_COLOR: return this->color;
+		case ScriptVars::P_PLAYER_HUE: return this->hue;
+		case ScriptVars::P_PLAYER_SATURATION: return this->saturation;
+
 		case P_NoVar:
 		default: return 0;
 	}
@@ -616,6 +622,8 @@ void PlayerStats::setVar(const Predefined var, const UINT val)
 		case P_RETURN_X: this->scriptReturnX = int(val); break;
 		case P_RETURN_Y: this->scriptReturnY = int(val); break;
 
+		case P_PLAYER_COLOR: this->color = val; break;
+
 		case P_NoVar:
 		default: break;
 	}
@@ -681,6 +689,9 @@ bool PlayerStats::IsGlobalStatIndex(UINT i)
 		case P_PRIOR_O:
 		case P_RETURN_X: //globally accessible script return vars
 		case P_RETURN_Y:
+		case P_PLAYER_COLOR: //player coloring variables
+		case P_PLAYER_HUE:
+		case P_PLAYER_SATURATION:
 			return true;
 		default: return false;
 	}
@@ -765,6 +776,10 @@ void PlayerStats::Pack(CDbPackedVars& stats) const
 
 			case 106: val = this->scriptReturnX; break;
 			case 107: val = this->scriptReturnY; break;
+
+			case 108: val = this->color; break;
+			case 109: val = this->hue; break;
+			case 110: val = this->saturation; break;
 
 			default:
 				ASSERT(!"Not a global var index");
@@ -858,6 +873,10 @@ void PlayerStats::Unpack(CDbPackedVars& stats)
 
 			case 106: this->scriptReturnX = val; break;
 			case 107: this->scriptReturnY = val; break;
+
+			case 108: this->color = val; break;
+			case 109: this->hue = val; break;
+			case 110: this->saturation = val; break;
 
 			default: ASSERT(!"Bad var"); break;
 		}

--- a/drodrpg/DRODLib/PlayerStats.h
+++ b/drodrpg/DRODLib/PlayerStats.h
@@ -163,7 +163,10 @@ namespace ScriptVars
 		P_MONSTER_SATURATION = -106,
 		P_RETURN_X = -107,
 		P_RETURN_Y = -108,
-		FirstPredefinedVar = P_RETURN_Y, //set this to the last var in the enumeration
+		P_PLAYER_COLOR = -109,
+		P_PLAYER_HUE = -110,
+		P_PLAYER_SATURATION = -111,
+		FirstPredefinedVar = P_PLAYER_SATURATION, //set this to the last var in the enumeration
 		PredefinedVarCount = -int(FirstPredefinedVar)
 	};
 
@@ -278,6 +281,7 @@ public:
 		mudSpawnID = tarSpawnID = gelSpawnID = queenSpawnID = mudSwapID = tarSwapID = gelSwapID = UINT(-1); //negative indicates default
 		scoreHP = scoreATK = scoreDEF = scoreYellowKeys = scoreGreenKeys = scoreBlueKeys = scoreSkeletonKeys = scoreGOLD = scoreXP = scoreShovels = 0;
 		scriptReturnX = scriptReturnY = 0;
+		color = hue = saturation = 0;
 	}
 
 	UINT getVar(const WSTRING& wstr) const
@@ -313,6 +317,8 @@ public:
 	int scoreHP, scoreATK, scoreDEF, scoreYellowKeys, scoreGreenKeys, scoreBlueKeys, scoreSkeletonKeys, scoreGOLD, scoreXP, scoreShovels;
 
 	int scriptReturnX, scriptReturnY;
+
+	UINT color, hue, saturation;
 };
 
 //More stats used for various tally operations.

--- a/drodrpg/DRODLib/Swordsman.cpp
+++ b/drodrpg/DRODLib/Swordsman.cpp
@@ -164,6 +164,12 @@ UINT CSwordsman::GetIdentity() const
 }
 
 //*****************************************************************************
+UINT CSwordsman::getColor() const
+{
+	return st.color;
+}
+
+//*****************************************************************************
 int CSwordsman::getGoldMultiplier() const
 //Returns: gold multiplier
 {
@@ -512,6 +518,25 @@ void CSwordsman::SetOrientation(
 	this->wO = this->wPrevO = wO;
 
 //	SetSwordCoords();
+}
+
+//*****************************************************************************
+void CSwordsman::SetColorsFromStats()
+{
+	this->hue = this->st.hue;
+	this->saturation = this->st.saturation;
+}
+
+//*****************************************************************************
+void CSwordsman::SetHue(const UINT hue) {
+	CMonster::SetHue(hue);
+	this->st.hue = this->hue;
+}
+
+//*****************************************************************************
+void CSwordsman::SetSaturation(const UINT saturation) {
+	CMonster::SetSaturation(saturation);
+	this->st.saturation = this->saturation;
 }
 
 //*****************************************************************************

--- a/drodrpg/DRODLib/Swordsman.h
+++ b/drodrpg/DRODLib/Swordsman.h
@@ -63,6 +63,7 @@ public:
 	UINT Damage(CCueEvents& CueEvents, int damageVal, CUEEVENT_ID deathCID);
 	void DecHealth(CCueEvents& CueEvents, const UINT delta, CUEEVENT_ID deathCID);
 	void EndHaste() {this->bHasted = false;}
+	virtual UINT getColor() const;
 	int  getGoldMultiplier() const;
 	int  getXPMultiplier() const;
 	virtual bool IsFlying() const;
@@ -75,6 +76,9 @@ public:
 	void RotateClockwise();
 	void RotateCounterClockwise();
 	void SetOrientation(const UINT wO);
+	void SetColorsFromStats();
+	virtual void SetHue(const UINT hue);
+	virtual void SetSaturation(const UINT saturation);
 	static UINT GetSwordMovement(const int nCommand, const UINT wO);
 
 	//Sword position

--- a/drodrpg/Data/Help/1/script.html
+++ b/drodrpg/Data/Help/1/script.html
@@ -847,6 +847,12 @@ The variable names are case-insensitive.
   </tr><tr>
     <td>_O</td><td>player's orientation (direction faced)</td><td></td><td>0,8</td>
   </tr><tr>
+    <td>_Color</td><td>Player's RGB modifier (<a href="#mycolor">*</a>)</td><td>505050</td><td>000000,999999</td>
+  </tr><tr>
+    <td>_Hue</td><td>Player's base color modifier (<a href="#myhue">*</a>)</td><td>0</td><td>0,6000</td>
+  </tr><tr>
+    <td>_Saturation</td><td>Player's color strength modifier (<a href="#mysaturation">*</a>)</td><td>0</td><td>0,1000</td>
+  </tr><tr>
     <td>_RoomX</td><td>current room's X coordinate in level(<a href="#roompositionvars">*</a>)</td><td></td><td></td>
   </tr><tr>
     <td>_RoomY</td><td>current room's Y coordinate in level(<a href="#roompositionvars">*</a>)</td><td></td><td></td>
@@ -914,6 +920,7 @@ The variable names are case-insensitive.
     the NPC's image. Lower values make the colors less intense, while higher values
     make them more intense.
 </p>
+<p><b>_Color</b>, <b>_Hue</b> and <b>_Saturation</b> work identically to the three previous variables, but alter the appearance of the player.</p>
 <p><a name="mysword"><b>*_MySword</b></a> - set this to change what kind of
   sword the NPC wields.  This affects the NPC's appearance only, and does
   not alter the NPC's ATK rating.

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1930,6 +1930,9 @@ enum MID_CONSTANT {
   MID_VarMonsterSaturation = 2078,
   MID_VarReturnX = 2107,
   MID_VarReturnY = 2173,
+  MID_VarColor = 2183,
+  MID_VarHue = 2184,
+  MID_VarSaturation = 2185,
 
   //Messages from Steam.uni:
   MID_SteamAPIInitError = 1743,

--- a/drodrpg/Texts/Stats.uni
+++ b/drodrpg/Texts/Stats.uni
@@ -409,3 +409,15 @@ _ReturnX
 [MID_VarReturnY]
 [eng]
 _ReturnY
+
+[MID_VarColor]
+[eng]
+_Color
+
+[MID_VarHue]
+[eng]
+_Hue
+
+[MID_VarSaturation]
+[eng]
+_Saturation


### PR DESCRIPTION
The player can now be recoloured. I've routed some things through the existing `CMonster` functions for colour so that the various calculations for hue/saturation aren't duplicated.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=28782