### PR TITLE
Fix issues with room weather/darkness variables.

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -4692,6 +4692,8 @@ SCREENTYPE CGameScreen::ProcessCueEventsBeforeRoomDraw(
 
 	//Update room weather as needed.
 	this->pRoomWidget->SyncWeather(CueEvents);
+	// If fade occurred we don't want moves to be repeated or queued during this time
+	ClearEventBuffer();
 
 	//
 	//Begin section where room load can occur.  If room load occurs then

--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -1923,7 +1923,6 @@ void CRoomWidget::SyncWeather(CCueEvents& CueEvents)
 			this->wDark = roomWeather.wLight;
 			ASSERT(this->wDark < LIGHT_LEVELS);
 			g_pTheDBM->fLightLevel = fRoomLightLevel[this->wDark];
-			ClearEffects();
 			UpdateFromCurrentGame();
 			ResetForPaint();
 			Paint();
@@ -6619,7 +6618,7 @@ void CRoomWidget::DrawPlatformsAndTLayer(
 		}
 	}
 
-	this->pOLayerEffects->DrawEffects();
+	this->pOLayerEffects->DrawEffects(pDestSurface);
 
 	CBitmapManager::fLightLevel = fOldLightLevel;
 


### PR DESCRIPTION
**ISSUE:** When the crossfade effect, when darkness is changed, finishes the last move is immediately repeated.
**DIAGNOSIS:** The repeated processing is called from between event handler because time keeps accumulating and when the effect finishes it's ready to repeat the press.
**SOLUTION:** Call `ClearEventBuffer()` like we do in a few other places during transitions.

**ISSUE:** Image Overlays are drawn over the UI during darkness-change-crossfade.
**DIAGNOSIS:** Effect drawing call does not pass the destination surface meaning the effects are drawn on the screen with 0 offset (offset is 0,0 when rendering the room for transition effect) instead into the surface.
**SOLUTION:** Pass the destination surface up the chain of renders.

**ISSUE:** When skipping darkness-change-crossfade is enabled darkness changes immediately remove all effects.
**DIAGNOSIS:** that code was explicitly called, I think because it was copied from another place where it made sense.
**SOLUTION:** Removed the code killing effects during crossfade.

Reference:https://forum.caravelgames.com/viewtopic.php?TopicID=47384