### PR TITLE
Fix segfault with image overlay when restarting a room.

### DIFF
--- a/DROD/RoomWidget.cpp
+++ b/DROD/RoomWidget.cpp
@@ -2448,8 +2448,6 @@ void CRoomWidget::DisplayPersistingImageOverlays(CCueEvents& CueEvents)
 		const int clearsLayer = pImageOverlay->clearsImageOverlays();
 		if (clearsLayer != ImageOverlayCommand::NO_LAYERS) {
 			RemoveLayerEffects(EIMAGEOVERLAY, clearsLayer);
-			CueEvents.Remove(cid, pObj);
-			pObj = CueEvents.GetFirstPrivateData(cid);
 			bClearedEffect = true;
 		}
 
@@ -2459,8 +2457,11 @@ void CRoomWidget::DisplayPersistingImageOverlays(CCueEvents& CueEvents)
 			bClearedEffect = true;
 		}
 
-		if (bClearedEffect)
+		if (bClearedEffect) {
+			CueEvents.Remove(cid, pObj);
+			pObj = CueEvents.GetFirstPrivateData(cid);
 			continue;
+		}
 
 		pObj = CueEvents.GetNextPrivateData();
 	}


### PR DESCRIPTION
**ISSUE:** When you have an image overlay command that cancels a layer AND another on the same layer that has `Loop -1`, restarting the room can cause a segfault.

**DIAGNOSIS:** The exact issue was in `DisplayPersistingImageOverlays`; if there were two private datas and the first image overlay cleared the second one we ended up with no private data. But then `pObj = CueEvents.GetFirstPrivateData(cid);` would set `pObj` to null causing a segfault due to playing with deleted/undefiend memory.

**SOLUTION:** Moved the proceeding to the next private data to the end of effect removing code.

REFERENCE: https://forum.caravelgames.com/viewtopic.php?TopicID=47386