### PR TITLE
Add more detailed assert option

### DIFF
--- a/BackEndLib/Assert.cpp
+++ b/BackEndLib/Assert.cpp
@@ -98,6 +98,30 @@ void AssertErr(const char *pszFile, int nLine, const char *pszDesc)
 }
 
 //**************************************************************************************
+void AssertDetailedErr(const char* pszFile, int nLine, const char* pszDesc, const char* pszInfo)
+{
+	if (!bLogErrors)
+	{
+		return;
+	}
+
+	assert(pszDesc);
+	assert(pszInfo);
+	char szDescription[500];
+	sprintf(szDescription, pszDesc, pszInfo);
+	AssertErr(pszFile, nLine, szDescription);
+}
+
+//**************************************************************************************
+void AssertDetailedErr(const char* pszFile, int nLine, const char* pszDesc, const unsigned int wInfo)
+{
+	assert(pszDesc);
+	char szDescription[500];
+	sprintf(szDescription, pszDesc, wInfo);
+	AssertErr(pszFile, nLine, szDescription);
+}
+
+//**************************************************************************************
 void DebugPrint(const char *pszMessage)
 //Send message to debug output.
 {

--- a/BackEndLib/Assert.h
+++ b/BackEndLib/Assert.h
@@ -81,13 +81,16 @@ using std::string;
 # if defined(WIN32) && !defined(__GNUC__)
 #   define ASSERT(exp)          _ASSERT_VOID_CAST( (exp) ? void() : AssertErr(__FILENAME__,__LINE__,#exp) )
 #   define ASSERTP(exp, desc)   _ASSERT_VOID_CAST( (exp) ? void() : AssertErr(__FILENAME__,__LINE__,(desc)) )
+#   define ASSERT_DETAIL(exp, desc, info)   _ASSERT_VOID_CAST( (exp) ? void() : AssertDetailedErr(__FILENAME__,__LINE__,(desc), (info)) )
 # else
 #   define ASSERT(exp)          do { if (!(exp)) { AssertErr(__FILENAME__,__LINE__,#exp); MY_BREAKPOINT(); }} while (0)
 #   define ASSERTP(exp, desc)   do { if (!(exp)) { AssertErr(__FILENAME__,__LINE__,(desc)); MY_BREAKPOINT(); }} while (0)
+#   define ASSERT_DETAIL(exp, desc, info)   do { if (!(exp)) { AssertDetailedErr(__FILENAME__,__LINE__,(desc), (info)); MY_BREAKPOINT(); }} while (0)
 # endif
 #else
 #   define ASSERT(exp)
 #   define ASSERTP(exp,desc)
+#   define ASSERT_DETAIL(exp, desc, info)
 #endif
 
 //Log context is applied to error logging to show a history of what happened before an error.
@@ -148,6 +151,8 @@ using std::string;
 //Debug-mode.
 #ifdef _DEBUG
 	 void AssertErr(const char *pszFile, int nLine, const char *pszDesc);
+	 void AssertDetailedErr(const char *pszFile, int nLine, const char *pszDesc, const char* pszInfo);
+	 void AssertDetailedErr(const char *pszFile, int nLine, const char *pszDesc, const unsigned int wInfo);
 	 void LogErr(const char *pszMessage);
 	 void DebugPrint(const char *pszMessage);
 

--- a/DRODLib/DbPackedVars.cpp
+++ b/DRODLib/DbPackedVars.cpp
@@ -142,7 +142,7 @@ int CDbPackedVars::GetVar(const char *pszVarName, int nNotFoundValue) const
 #if (GAME_BYTEORDER == GAME_BYTEORDER_BIG)
 		LittleToBig(&nRet);
 #endif
-		ASSERT(GetVarValueSize(pszVarName)==sizeof(int));
+		ASSERT_DETAIL(GetVarValueSize(pszVarName)==sizeof(int), "Var %s was not int size", pszVarName);
 		return nRet;
 	}
 	return nNotFoundValue;
@@ -157,7 +157,7 @@ UINT CDbPackedVars::GetVar(const char *pszVarName, UINT wNotFoundValue) const
 #if (GAME_BYTEORDER == GAME_BYTEORDER_BIG)
 		LittleToBig(&wRet);
 #endif
-		ASSERT(GetVarValueSize(pszVarName)==sizeof(UINT));
+		ASSERT_DETAIL(GetVarValueSize(pszVarName)==sizeof(UINT), "Var %s was not UINT size", pszVarName);
 		return wRet;
 	}
 	return wNotFoundValue;
@@ -168,7 +168,7 @@ char CDbPackedVars::GetVar(const char *pszVarName, char cNotFoundValue) const
 	const char *pcRet = (char *) GetVar(pszVarName, (void *)NULL);
 	if (pcRet)
 	{
-		ASSERT(GetVarValueSize(pszVarName)==sizeof(char));
+		ASSERT_DETAIL(GetVarValueSize(pszVarName)==sizeof(char), "Var %s was not char size", pszVarName);
 		return *pcRet;
 	}
 	return cNotFoundValue;
@@ -179,7 +179,7 @@ const char * CDbPackedVars::GetVar(const char *pszVarName, const char *pszNotFou
 	const char *pszRet = (char *) GetVar(pszVarName, (void *)NULL);
 	if (pszRet)
 	{
-		ASSERT(GetVarValueSize(pszVarName)==strlen(pszRet)+1);
+		ASSERT_DETAIL(GetVarValueSize(pszVarName)==strlen(pszRet)+1, "Var %s was did not have expected size", pszVarName);
 		return pszRet;
 	}
 	return pszNotFoundValue;
@@ -204,7 +204,7 @@ const WCHAR * CDbPackedVars::GetVar(const char *pszVarName, const WCHAR *pwczNot
 #else
 		tempBuffer = reinterpret_cast<USHORT*>(const_cast<WCHAR*>(pwczRet));
 #endif
-		ASSERT(GetVarValueSize(pszVarName)==(len+1)*sizeof(WCHAR));
+		ASSERT_DETAIL(GetVarValueSize(pszVarName)==(len+1)*sizeof(WCHAR), "Var %s was not WCHAR size", pszVarName);
 		return reinterpret_cast<const WCHAR*>(tempBuffer);
 	}
 	return pwczNotFoundValue;
@@ -215,7 +215,7 @@ BYTE CDbPackedVars::GetVar(const char *pszVarName, BYTE ucNotFoundValue) const
 	const BYTE *pucRet = (BYTE*) GetVar(pszVarName, (void *)NULL);
 	if (pucRet)
 	{
-		ASSERT(GetVarValueSize(pszVarName)==sizeof(BYTE));
+		ASSERT_DETAIL(GetVarValueSize(pszVarName)==sizeof(BYTE), "Var %s was not BYTE size", pszVarName);
 		return *pucRet;
 	}
 	return ucNotFoundValue;
@@ -230,7 +230,7 @@ bool CDbPackedVars::GetVar(const char *pszVarName, bool bNotFoundValue) const
 			return *pucRet != 0;
 
 		//Handle old data size (UINT).
-		ASSERT(GetVarValueSize(pszVarName)==sizeof(UINT));
+		ASSERT_DETAIL(GetVarValueSize(pszVarName)==sizeof(UINT), "Var %s was not UINT size", pszVarName);
 		UINT wRet(*((UINT*)pucRet)); //recast what's being pointed at to 4-byte value
 #if (GAME_BYTEORDER == GAME_BYTEORDER_BIG)
 		LittleToBig(&wRet);
@@ -249,7 +249,7 @@ int64_t CDbPackedVars::GetVar(const char* pszVarName, int64_t notFoundValue) con
 #if (GAME_BYTEORDER == GAME_BYTEORDER_BIG)
 		LittleToBig(&wRet);
 #endif
-		ASSERT(GetVarValueSize(pszVarName) == sizeof(int64_t));
+		ASSERT_DETAIL(GetVarValueSize(pszVarName) == sizeof(int64_t), "Var %s was not int64_t size", pszVarName);
 		return wRet;
 	}
 	return notFoundValue;

--- a/DRODLib/GameConstants.cpp
+++ b/DRODLib/GameConstants.cpp
@@ -52,7 +52,7 @@ const UINT NEXT_VERSION_NUMBER = 600;
 const WCHAR wszVersionReleaseNumber[] = WS("5.2.0.") WS(STRFY_EXPAND(DROD_VERSION_REVISION));
 #else
 const WCHAR wszVersionReleaseNumber[] = {
-	We('5'),We('.'),We('2'),We('.'),We('1'),We('.'),We('1'),We('1'),We('4'),We('9'),We(0)   // 5.2.1.*
+	We('5'),We('.'),We('2'),We('.'),We('1'),We('.'),We('1'),We('1'),We('5'),We('3'),We(0)   // 5.2.1.*
 };
 #endif
 


### PR DESCRIPTION
Adds a new kind of assert, `ASSERT_DETAIL`. This allows an extra piece of information (currently a raw string or unsigned int) to be spliced into an assert message for more detailed reporting.

As a live example, I've changed several asserts in `DbPackedVars` to use this new assert type.