### PR TITLE
RPG: Allow scorepoints on the turn player wins game

### DIFF
--- a/drodrpg/DRODLib/CueEvents.cpp
+++ b/drodrpg/DRODLib/CueEvents.cpp
@@ -49,6 +49,15 @@ const CUEEVENT_ID CIDA_PlayerDied[6] = {
 	CID_MonsterKilledPlayer, CID_ExplosionKilledPlayer, CID_BriarKilledPlayer,
 	CID_CriticalNPCDied, CID_PlayerFellIntoPit, CID_PlayerDrownedInWater}; //CID_NPCBeethroDied
 
+//Did something happen that will prevent a scorepoint from being valid?
+//Leaving a room in anyway other than winning the game, or making an illegal move that
+//has to be rewound.
+const CUEEVENT_ID CIDA_ScoreCheckpointBlocked[12] = {
+	CID_ExitRoomPending, CID_ExitRoom, CID_ExitLevelPending, CID_ExitToWorldMapPending,
+	CID_MonsterKilledPlayer, CID_ExplosionKilledPlayer, CID_BriarKilledPlayer,
+	CID_CriticalNPCDied, CID_PlayerFellIntoPit, CID_PlayerDrownedInWater,
+	CID_InvalidAttackMove, CID_StalledCombat};
+
 //Did a monster die?
 const CUEEVENT_ID CIDA_MonsterDied[2] = {
 	CID_SnakeDiedFromTruncation, CID_MonsterDiedFromStab}; //, CID_MonsterBurned};

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -754,6 +754,9 @@ extern const CUEEVENT_ID CIDA_PlayerLeftRoom[11];
 //project-wide changes to code.
 extern const CUEEVENT_ID CIDA_PlayerDied[6];
 
+//Did something happen that will prevent a scorepoint from being valid?
+extern const CUEEVENT_ID CIDA_ScoreCheckpointBlocked[12];
+
 //Did a monster die?
 extern const CUEEVENT_ID CIDA_MonsterDied[2];
 

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -3322,7 +3322,7 @@ void CCurrentGame::ProcessCommand(
 	//Create any pending scorepoint saves and local highscore entries.
 	//Due to how validation works, it's not valid to make a scorepoint when leaving a room
 	if (CueEvents.HasOccurred(CID_ScoreCheckpoint) && !this->Commands.IsFrozen() &&
-		!CueEvents.HasAnyOccurred(IDCOUNT(CIDA_PlayerLeftRoom), CIDA_PlayerLeftRoom)) {
+		!CueEvents.HasAnyOccurred(IDCOUNT(CIDA_ScoreCheckpointBlocked), CIDA_ScoreCheckpointBlocked)) {
 		for (const CAttachableObject* pObj = CueEvents.GetFirstPrivateData(CID_ScoreCheckpoint);
 			pObj != NULL; pObj = CueEvents.GetNextPrivateData())
 		{


### PR DESCRIPTION
The Fix to prevent scorepoints being registered in situations where they can't be validated overlooked that there's one instance that counts as leaving a room that can still be valid for a scorepoint - when the player wins.

I've made a new event set of everything that would make a scorepoint invalid. While this is mostly overlaps with room leaving events minus winning, I've also added in the two events that are sent when an illegal move is rewound. This isn't required with the current way things are wired, but it helps state intent.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47397