### PR TITLE
RPG: Add Skeleton guard feature

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -680,6 +680,12 @@ void CGameScreen::RedrawStats(
 		pLabel->RequestPaint();
 	}
 
+	if (this->pCurrentGame->bSkeletonKeyGuard) {
+		CLabelWidget* pLabel = DYN_CAST(CLabelWidget*, CWidget*, GetWidget(TAG_SKEY));
+		g_pTheDBM->BlitTileImagePart(TI_SMALL_CROSSES, pLabel->GetX() - 2, pLabel->GetY() - 18,
+			0, 0, 22, 22, pDestSurface);
+	}
+
 	//Draw tile image.
 	for (i=0; i<numMenuPics; ++i)
 	{
@@ -2747,6 +2753,7 @@ void CGameScreen::OnKeyDown(
 			this->pCurrentGame->bSkeletonKeyGuard = !this->pCurrentGame->bSkeletonKeyGuard;
 			g_pTheSound->PlaySoundEffect(this->pCurrentGame->bSkeletonKeyGuard ?
 				SEID_WISP : SEID_CHECKPOINT);
+			Paint();
 		break;
 
 		//Skip cutscene/clear playing speech.

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -2743,6 +2743,12 @@ void CGameScreen::OnKeyDown(
 			ToggleBigMap();
 		break;
 
+		case CMD_EXTRA_SKELETON_KEY_GUARD:
+			this->pCurrentGame->bSkeletonKeyGuard = !this->pCurrentGame->bSkeletonKeyGuard;
+			g_pTheSound->PlaySoundEffect(this->pCurrentGame->bSkeletonKeyGuard ?
+				SEID_WISP : SEID_CHECKPOINT);
+		break;
+
 		//Skip cutscene/clear playing speech.
 		case CMD_EXTRA_SKIP_SPEECH:
 			if (this->pCurrentGame && this->pCurrentGame->InCombat()) {
@@ -5639,7 +5645,8 @@ SCREENTYPE CGameScreen::ProcessCommand(
 			}
 
 			if (this->sCueEvents.HasOccurred(CID_InvalidAttackMove) ||
-				this->sCueEvents.HasOccurred(CID_StalledCombat))
+				this->sCueEvents.HasOccurred(CID_StalledCombat) ||
+				this->sCueEvents.HasOccurred(CID_SkeletonKeyBlocked))
 			{
 				//This move was just undone.
 				//Speech pointers need to be relinked and room state refreshed.
@@ -6956,6 +6963,11 @@ SCREENTYPE CGameScreen::ProcessCueEventsAfterRoomDraw(
 		this->pRoomWidget->AddInfoSubtitle(&coord, g_pTheDB->GetMessageText(MID_CantHarmDangerousEnemy), 2000);
 		PlayHitObstacleSound(player.wAppearance, CueEvents);
 		ShowStatsForMonsterAt(pCoord->wX, pCoord->wY);
+	} else if (CueEvents.HasOccurred(CID_SkeletonKeyBlocked)) {
+		CSwordsman* player = this->pCurrentGame->pPlayer;
+		this->pRoomWidget->DisplaySubtitle(g_pTheDB->GetMessageText(MID_SkeletonGuardBlock),
+			player->wX, player->wY, true);
+		g_pTheSound->PlaySoundEffect(SEID_WISP);
 	}
 
 	if (CueEvents.HasOccurred(CID_BumpedLockedDoor))

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -2750,10 +2750,7 @@ void CGameScreen::OnKeyDown(
 		break;
 
 		case CMD_EXTRA_SKELETON_KEY_GUARD:
-			this->pCurrentGame->bSkeletonKeyGuard = !this->pCurrentGame->bSkeletonKeyGuard;
-			g_pTheSound->PlaySoundEffect(this->pCurrentGame->bSkeletonKeyGuard ?
-				SEID_WISP : SEID_CHECKPOINT);
-			Paint();
+			ToggleSkeletonKeyGuard();
 		break;
 
 		//Skip cutscene/clear playing speech.
@@ -3123,6 +3120,8 @@ void CGameScreen::OnMouseUp(
 					ClickOnEquipment(CMD_USE_ARMOR, Button.button == SDL_BUTTON_RIGHT);
 				else if (IsInRect(Button.x, Button.y, X_PIC[6], Y_PIC[6], X_PIC[6] + g_pTheDBM->CX_TILE, Y_PIC[6] + g_pTheDBM->CY_TILE))
 					ClickOnEquipment(CMD_USE_ACCESSORY, Button.button == SDL_BUTTON_RIGHT);
+				else if (IsInRect(Button.x, Button.y, 16, 352, 16 + 112, 400))
+					ToggleSkeletonKeyGuard();
 			}
 
 			//Texts describing stat labels on sidebar.
@@ -9047,6 +9046,16 @@ void CGameScreen::ToggleBigMap()
 		RedrawStats(this->pCurrentGame ? this->pCurrentGame->pCombat : NULL, false);
 
 	UpdateRect();
+}
+
+//*****************************************************************************
+void CGameScreen::ToggleSkeletonKeyGuard()
+{
+	ASSERT(this->pCurrentGame);
+	this->pCurrentGame->bSkeletonKeyGuard = !this->pCurrentGame->bSkeletonKeyGuard;
+	g_pTheSound->PlaySoundEffect(this->pCurrentGame->bSkeletonKeyGuard ?
+		SEID_WISP : SEID_CHECKPOINT);
+	Paint();
 }
 
 //*****************************************************************************

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -161,6 +161,10 @@ const UINT CX_SIDEBAR = 268; //width of active sidebar widget area
 const UINT CX_SPACE = 12;
 const UINT CY_SPACE = 12;
 
+//Position of cross graphic when skeleton key guard is active
+const UINT CX_SKEY_CROSS = 99;
+const UINT CY_SKEY_CROSS = 343;
+
 //UINT wMood = SONG_PUZZLE;
 int nDangerLevel = 0;	//for setting room mood
 
@@ -682,8 +686,7 @@ void CGameScreen::RedrawStats(
 
 	if (this->pCurrentGame->bSkeletonKeyGuard) {
 		CLabelWidget* pLabel = DYN_CAST(CLabelWidget*, CWidget*, GetWidget(TAG_SKEY));
-		g_pTheDBM->BlitTileImagePart(TI_SMALL_CROSSES, pLabel->GetX() - 2, pLabel->GetY() - 18,
-			0, 0, 22, 22, pDestSurface);
+		g_pTheDBM->BlitTileImage(TI_SMALL_CROSS, CX_SKEY_CROSS, CY_SKEY_CROSS, pDestSurface);
 	}
 
 	//Draw tile image.

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -203,6 +203,7 @@ private:
 	void           StopAmbientSounds();
 	void           TakeStepTowardQuickExit();
 	void           ToggleBigMap();
+	void           ToggleSkeletonKeyGuard();
 	void           UndoMove();
 	void           UpdateEffectsFreeze();
 	void           UpdateScroll();

--- a/drodrpg/DROD/SettingsScreen.cpp
+++ b/drodrpg/DROD/SettingsScreen.cpp
@@ -853,7 +853,7 @@ void CSettingsScreen::SetupKeymap1Tab(CTabbedMenuWidget* pTabbedMenu)
 			NO_COMMAND,
 		},
 		{
-			DCMD_Battle, DCMD_ShowScore, DCMD_ShowMap,
+			DCMD_Battle, DCMD_ShowScore, DCMD_ShowMap, DCMD_SkeletonKeyGuard,
 			NO_COMMAND
 		},
 		{

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2578,8 +2578,10 @@
 #define TI_WORLDMAP_LOCK 2378
 #define TI_WORLDMAP_IN_PROGRESS 2379
 #define TI_WORLDMAP_CLEAR 2380
+//*****************************************************************************
+#define TI_SMALL_CROSSES 2381
 
-static const UINT TI_COUNT = 2381;
+static const UINT TI_COUNT = 2382;
 
 static inline bool bIsBriarTI(const UINT ti)
 {

--- a/drodrpg/DROD/TileImageConstants.h
+++ b/drodrpg/DROD/TileImageConstants.h
@@ -2579,7 +2579,7 @@
 #define TI_WORLDMAP_IN_PROGRESS 2379
 #define TI_WORLDMAP_CLEAR 2380
 //*****************************************************************************
-#define TI_SMALL_CROSSES 2381
+#define TI_SMALL_CROSS 2381
 
 static const UINT TI_COUNT = 2382;
 

--- a/drodrpg/DRODLib/CueEvents.h
+++ b/drodrpg/DRODLib/CueEvents.h
@@ -732,6 +732,12 @@ enum CUEEVENT_ID
 	//Private data: CDbMessageText *pAutosaveName (one)
 	CID_MakeAutosave,
 
+	//The player tried to open a door with a skeleton key, but has locked spending
+	//of skeleton keys
+	//
+	//Private data: none
+	CID_SkeletonKeyBlocked,
+
 	//End of enumeration typedef.
 	CUEEVENT_COUNT
 };

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -786,6 +786,7 @@ void CCurrentGame::Clear(
 	this->persistingImageOverlays.clear();
 	this->imageOverlayNextID = 0;
 
+	this->bSkeletonKeyGuard = false;
 /*
 	this->bRoomExitLocked = false;
 
@@ -3301,6 +3302,11 @@ void CCurrentGame::ProcessCommand(
 			UndoCommand(CueEvents); //can't undo when move sequence is frozen (avoid infinite recursion)
 		CueEvents.Clear(); //don't show events from previous turn again
 		CueEvents.Add(CID_StalledCombat, &coord); //add an event to let the front-end know what happened
+	} else if (CueEvents.HasOccurred(CID_SkeletonKeyBlocked)) {
+		if (!this->Commands.IsFrozen())
+			UndoCommand(CueEvents); //can't undo when move sequence is frozen (avoid infinite recursion)
+		CueEvents.Clear(); //don't show events from previous turn again
+		CueEvents.Add(CID_SkeletonKeyBlocked); //readd the event for front-end
 	}
 
 	//Now everything else is done, make any autosaves that have been queued
@@ -5404,8 +5410,13 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				--ps.yellowKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, YellowKey), true);
 			} else if (ps.skeletonKeys) {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
+					--ps.skeletonKeys;
+					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				}
 			}
 			else
 				return false;
@@ -5416,8 +5427,13 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				--ps.greenKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, GreenKey), true);
 			} else if (ps.skeletonKeys) {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
+					--ps.skeletonKeys;
+					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				}
 			}
 			else
 				return false;
@@ -5428,8 +5444,13 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				--ps.blueKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, BlueKey), true);
 			} else if (ps.skeletonKeys) {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
+					--ps.skeletonKeys;
+					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				}
 			}
 			else
 				return false;
@@ -5442,8 +5463,13 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				incintValueWithBounds(ps.GOLD, -cost); //gold may go negative
 				CueEvents.Add(CID_EntityAffected, new CCombatEffect(this->pPlayer, CET_GOLD, -cost), true);
 			} else if (ps.skeletonKeys) {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
+					--ps.skeletonKeys;
+					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
+				}
 			}
 			else
 				return false;
@@ -5487,8 +5513,13 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 			}
 			else if (ps.skeletonKeys)
 			{
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
 				--ps.skeletonKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
+				}
 			}
 			else
 				return false;
@@ -5501,8 +5532,13 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 			}
 			else if (ps.skeletonKeys)
 			{
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
 				--ps.skeletonKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
+				}
 			}
 			else
 				return false;
@@ -5515,8 +5551,13 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 			}
 			else if (ps.skeletonKeys)
 			{
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
 				--ps.skeletonKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
+				}
 			}
 			else
 				return false;
@@ -5530,8 +5571,13 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 				incintValueWithBounds(ps.GOLD, -cost); //gold may go negative
 				CueEvents.Add(CID_EntityAffected, new CCombatEffect(this->pPlayer, CET_GOLD, -cost), true);
 			} else if (ps.skeletonKeys) {
+				if (this->bSkeletonKeyGuard) {
+					CueEvents.Add(CID_SkeletonKeyBlocked);
+					return false;
+				} else {
 				--ps.skeletonKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
+				}
 			}
 			else
 				return false;

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -5410,12 +5410,8 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				--ps.yellowKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, YellowKey), true);
 			} else if (ps.skeletonKeys) {
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY, ps)) {
 					return false;
-				} else {
-					--ps.skeletonKeys;
-					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
 				}
 			}
 			else
@@ -5427,12 +5423,8 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				--ps.greenKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, GreenKey), true);
 			} else if (ps.skeletonKeys) {
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY, ps)) {
 					return false;
-				} else {
-					--ps.skeletonKeys;
-					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
 				}
 			}
 			else
@@ -5444,12 +5436,8 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				--ps.blueKeys;
 				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, BlueKey), true);
 			} else if (ps.skeletonKeys) {
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY, ps)) {
 					return false;
-				} else {
-					--ps.skeletonKeys;
-					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
 				}
 			}
 			else
@@ -5463,12 +5451,8 @@ bool CCurrentGame::KnockOnDoor(CCueEvents& CueEvents, const UINT wX, const UINT 
 				incintValueWithBounds(ps.GOLD, -cost); //gold may go negative
 				CueEvents.Add(CID_EntityAffected, new CCombatEffect(this->pPlayer, CET_GOLD, -cost), true);
 			} else if (ps.skeletonKeys) {
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY, ps)) {
 					return false;
-				} else {
-					--ps.skeletonKeys;
-					CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
 				}
 			}
 			else
@@ -5513,12 +5497,8 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 			}
 			else if (ps.skeletonKeys)
 			{
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY - (wY > 0 ? 1 : -1), ps)) {
 					return false;
-				} else {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
 				}
 			}
 			else
@@ -5532,12 +5512,8 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 			}
 			else if (ps.skeletonKeys)
 			{
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY - (wY > 0 ? 1 : -1), ps)) {
 					return false;
-				} else {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
 				}
 			}
 			else
@@ -5551,12 +5527,8 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 			}
 			else if (ps.skeletonKeys)
 			{
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY - (wY > 0 ? 1 : -1), ps)) {
 					return false;
-				} else {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
 				}
 			}
 			else
@@ -5571,12 +5543,8 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 				incintValueWithBounds(ps.GOLD, -cost); //gold may go negative
 				CueEvents.Add(CID_EntityAffected, new CCombatEffect(this->pPlayer, CET_GOLD, -cost), true);
 			} else if (ps.skeletonKeys) {
-				if (this->bSkeletonKeyGuard) {
-					CueEvents.Add(CID_SkeletonKeyBlocked);
+				if (!SpendSkeletonKey(CueEvents, wX, wY - (wY > 0 ? 1 : -1), ps)) {
 					return false;
-				} else {
-				--ps.skeletonKeys;
-				CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY - (wY > 0 ? 1 : -1), SkeletonKey), true);
 				}
 			}
 			else
@@ -5593,6 +5561,27 @@ bool CCurrentGame::LockDoor(CCueEvents& CueEvents, const UINT wX, const UINT wY)
 
 	CueEvents.Add(CID_DoorLocked, NULL, false);
 	this->pRoom->CloseDoor(this->pPlayer->wX, this->pPlayer->wY, CueEvents);
+	return true;
+}
+
+
+//*****************************************************************************
+//Decrement's players skeleton key count (and generates use effect), but only
+//if skeleton key guard is not enabled. Should only be called if player has a
+//nonzero number of skeleton keys.
+//Returns: True if key was spent, false if spending was blocked.
+bool CCurrentGame::SpendSkeletonKey(
+	CCueEvents& CueEvents,
+	const UINT wX, const UINT wY, PlayerStats& playerStats)
+{
+	ASSERT(playerStats.skeletonKeys > 0);
+	if (this->bSkeletonKeyGuard) {
+		CueEvents.Add(CID_SkeletonKeyBlocked);
+		return false;
+	}
+
+	--playerStats.skeletonKeys;
+	CueEvents.Add(CID_ItemUsed, new CMoveCoord(wX, wY, SkeletonKey), true);
 	return true;
 }
 

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -440,6 +440,7 @@ public:
 	vector<CMoveCoordEx> ambientSounds;  //ambient sounds playing now
 	vector<SpeechLog> roomSpeech; //speech played up to this moment in the current room
 //	bool     bRoomExitLocked; //safety to prevent player from exiting room when set
+	bool bSkeletonKeyGuard; //safety to prevent player spending skeleton keys
 //	PlayerStats playerStatsAtRoomStart;
 
 	//Front-end effects.

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -522,6 +522,7 @@ private:
 	bool     SetRoomAtCoords(const UINT dwRoomX, const UINT dwRoomY);
 	void     SetRoomStartToPlayer();
 //	void     SwitchToCloneAt(const UINT wX, const UINT wY);
+	bool     SpendSkeletonKey(CCueEvents& CueEvents, const UINT wX, const UINT wY, PlayerStats& playerStats);
 	bool     TunnelMove(const int dx, const int dy);
 	void     UpdatePrevPlatformCoords();
 //	UINT     WriteCurrentRoomDemo(DEMO_REC_INFO &dri, const bool bHidden=false,

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -861,6 +861,9 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_LogicalWaitNOR: strText = "Wait for None:"; break;
 		case MID_IfNot: strText = "If Not ..."; break;
 		case MID_IfElseIfNot: strText = "Else If Not"; break;
+		case MID_VarColor: strText = "_Color"; break;
+		case MID_VarHue: strText = "_Hue"; break;
+		case MID_VarSaturation: strText = "_Saturation"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -864,6 +864,8 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarColor: strText = "_Color"; break;
 		case MID_VarHue: strText = "_Hue"; break;
 		case MID_VarSaturation: strText = "_Saturation"; break;
+		case MID_Command_ToggleSkeletonGuard: strText = "Skeleton Key Guard"; break;
+		case MID_SkeletonGuardBlock: strText = "Skeleton key guard prevents spending skeleton key"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/GameConstants.cpp
+++ b/drodrpg/DRODLib/GameConstants.cpp
@@ -93,6 +93,7 @@ namespace InputCommands
 		keyDefinitions[DCMD_QuickSave] = new KeyDefinition(CMD_EXTRA_QUICK_SAVE, "Key_QuickSave", MID_QuickSave, SDLK_F5);
 		keyDefinitions[DCMD_QuickLoad] = new KeyDefinition(CMD_EXTRA_QUICK_LOAD, "Key_QuickLoad", MID_QuickLoad, SDLK_F9);
 		keyDefinitions[DCMD_ShowMap] = new KeyDefinition(CMD_EXTRA_SHOW_MAP, "Key_ShowMap", MID_Command_ShowMap, SDLK_m);
+		keyDefinitions[DCMD_SkeletonKeyGuard] = new KeyDefinition(CMD_EXTRA_SKELETON_KEY_GUARD, "Key_ToggleSkeletonGuard", MID_Command_ToggleSkeletonGuard, BuildInputKey(0, true, false, false));
 
 		keyDefinitions[DCMD_SkipSpeech] = new KeyDefinition(CMD_EXTRA_SKIP_SPEECH, "Key_SkipSpeech", MID_SkipSpeech, SDLK_SPACE);
 		keyDefinitions[DCMD_OpenChat] = new KeyDefinition(CMD_EXTRA_OPEN_CHAT, "Key_OpenChat", MID_Command_OpenChat, SDLK_RETURN);

--- a/drodrpg/DRODLib/GameConstants.h
+++ b/drodrpg/DRODLib/GameConstants.h
@@ -128,6 +128,7 @@ extern const WCHAR wszVersionReleaseNumber[];
 #define CMD_EXTRA_SCRIPT_ADD_COMMAND (COMMAND_COUNT+44)
 #define CMD_EXTRA_SCRIPT_CHAR_OPTIONS (COMMAND_COUNT+45)
 #define CMD_EXTRA_SHOW_MAP (COMMAND_COUNT+46)
+#define CMD_EXTRA_SKELETON_KEY_GUARD (COMMAND_COUNT+47)
 
 //Sword orientation.
 static const UINT NW = 0;
@@ -205,6 +206,7 @@ namespace InputCommands
 		DCMD_QuickSave,
 		DCMD_QuickLoad,
 		DCMD_ShowMap,
+		DCMD_SkeletonKeyGuard,
 
 		//Dialogs and screens
 		DCMD_SkipSpeech,
@@ -282,7 +284,7 @@ static inline bool bIsGameScreenCommand(const int command)
 {
 	return bIsGameCommand(command) ||
 		(command >= CMD_ADVANCE_CUTSCENE && command <= CMD_EXTRA_RELOAD_STYLE) ||
-		command == CMD_EXTRA_SHOW_MAP;
+		command == CMD_EXTRA_SHOW_MAP || command == CMD_EXTRA_SKELETON_KEY_GUARD;
 }
 
 static inline bool bIsEditorCommand(const int command)

--- a/drodrpg/Data/Help/1/keyboard.html
+++ b/drodrpg/Data/Help/1/keyboard.html
@@ -61,6 +61,9 @@
     <tr>
 	  <td colspan="3">Press <u>Shift-Tab</u> to activate special weapon and <u>Ctrl-Tab</u> to activate special armor.</td>
     </tr>
+    <tr>
+      <td colspan="3"><b>Shift</b> - Toggle <a href="#skeletonguard">skeleton key guard.</a></td>
+    </tr>
   </tbody>
 </table>
 </p>
@@ -139,6 +142,10 @@ this game session's CaravelNet chat history.</td>
 to run from wherever you are in the room to the closest exit in the indicated
 direction.  This will only work if you have exited the current room in that
 direction before, and if nothing is blocking your path.</p>
+<p><a name="skeletonguard"><b>Skeleton key guard</b></a> - <a href="elements.html#skeletonkey">Skeleton keys</a>
+are valuable. Enabling skeleton key guard will block moves that would spend
+a skeleton key to lock or unlock a door. In addition to the keyboard command,
+the guard can be toggled by clicking on the key area of the side bar.</p>
 <p><a name="info"><b>Right-click</b></a> a room tile to display its
 coordinates and the names of game elements on this tile.  It will also show
 contextual information.  For instance, right-clicking <b>door openers</b> will

--- a/drodrpg/Texts/GameScreen.uni
+++ b/drodrpg/Texts/GameScreen.uni
@@ -393,3 +393,7 @@ Multiplies resources gained from health potions, gems and shovels.
 [MID_FlyingAbility]
 [eng]
 Airborne
+
+[MID_SkeletonGuardBlock]
+[eng]
+Skeleton key guard prevents spending skeleton key

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -688,6 +688,7 @@ enum MID_CONSTANT {
   MID_ShovelTooltip = 2158,
   MID_LevelMultiplierTooltip = 2159,
   MID_FlyingAbility = 2164,
+  MID_SkeletonGuardBlock = 2187,
 
   //Messages from General.uni:
   MID_SDLInitFailed = 464,
@@ -1351,6 +1352,7 @@ enum MID_CONSTANT {
   MID_Command_Script_AddCommand = 2161,
   MID_Command_Script_CharacterOptions = 2162,
   MID_Command_ShowMap = 2163,
+  MID_Command_ToggleSkeletonGuard = 2186,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/drodrpg/Texts/SettingsScreen.uni
+++ b/drodrpg/Texts/SettingsScreen.uni
@@ -665,3 +665,7 @@ Show Character Options
 [MID_Command_ShowMap]
 [eng]
 Open Map
+
+[MID_Command_ToggleSkeletonGuard]
+[eng]
+Skeleton Key Guard


### PR DESCRIPTION
Similar to room lock in TSS, the skeleton key guard is a toggleable meta-state that blocks moves that would spend a skeleton key to open or close a door.

When active, a cross symbol is drawn over the skeleton key icon on the sidebar:
<img width="272" height="216" alt="image" src="https://github.com/user-attachments/assets/22543474-a7a9-48ac-8e0e-e200d2145e2b" />

I will make a PR in the RPG data repo to add the new tile image required for this feature.