### PR TITLE
macOS: lower deployment floor to macOS 11 (Big Sur)

### DIFF
--- a/Master/Darwin/Config
+++ b/Master/Darwin/Config
@@ -25,7 +25,7 @@ endif
 
 # Deployment target. The third-party dependencies are built from source for this
 # same target (see build_deps.sh), so the .app genuinely runs on macOS >= this.
-MACOSX_VERSION_MIN = 15.0
+MACOSX_VERSION_MIN = 11.0
 
 # Flags always applied. Architecture, deployment target and the C++ standard go
 # here (not in CXXFLAGS) so they survive the make recursion. -std=c++11 makes

--- a/Master/Darwin/Info.plist.template
+++ b/Master/Darwin/Info.plist.template
@@ -20,5 +20,7 @@
 	<string>%VERSION%</string>
 	<key>CSResourceFileMapped</key>
 	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>%MIN_OS%</string>
 </dict>
 </plist>

--- a/Master/Darwin/build_deps.sh
+++ b/Master/Darwin/build_deps.sh
@@ -18,7 +18,7 @@ REPO_DIR="$(cd "$DARWIN_DIR/../.." && pwd)"
 METAKIT_DIR="$REPO_DIR/metakit"
 PREFIX="$DARWIN_DIR/deps"
 SRC="$PREFIX/src"
-DEPLOY="${MACOSX_DEPLOYMENT_TARGET:-15.0}"
+DEPLOY="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 ARCHS="x86_64;arm64"
 JOBS="$(sysctl -n hw.ncpu)"
 
@@ -236,7 +236,11 @@ dep_metakit() {
 		( cd "$bd" && CC=clang CXX=clang++ \
 			CFLAGS="-arch $a -mmacosx-version-min=$DEPLOY" \
 			CXXFLAGS="-arch $a -std=c++11 -mmacosx-version-min=$DEPLOY -fno-rtti" \
-			../unix/configure $host ac_cv_sizeof_long=8 && make -j"$JOBS" libmk4.a && ranlib libmk4.a )
+			../unix/configure $host ac_cv_sizeof_long=8 \
+			&& make -j"$JOBS" AR=ar RANLIB=ranlib libmk4.a )
+			# metakit's Makefile references $(RANLIB) but never defines it (and make
+			# has no built-in default), so its "$(RANLIB) $@" archive step runs a bare
+			# "libmk4.a" and fails -- pass AR/RANLIB explicitly to index the archive.
 	done
 	mkdir -p "$PREFIX/lib"
 	lipo -create "$METAKIT_DIR/build-uni-x86_64/libmk4.a" "$METAKIT_DIR/build-uni-arm64/libmk4.a" \

--- a/Master/Darwin/build_macos.sh
+++ b/Master/Darwin/build_macos.sh
@@ -68,7 +68,7 @@ METAKIT_DIR="$REPO_DIR/metakit"
 APP_NAME=""          # resolved from the Steam variant (or "DROD TSS") unless --name given
 NAME_SET=0
 APP_VERSION="5.2.1"
-DEPLOY="15.0"
+DEPLOY="11.0"
 BUILD_TYPE="custom"
 OUTPUT_DIR="$DARWIN_DIR/custom/bin"
 ASSETS_DIR=""
@@ -286,7 +286,7 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Frameworks" "$RES_DATA"
 
 # 4a. Executable, Info.plist, icon
 cp "$BUILT_BIN" "$APP/Contents/MacOS/drod"
-sed "s/%EXECUTABLE_NAME%/drod/; s/%VERSION%/$APP_VERSION/" \
+sed "s/%EXECUTABLE_NAME%/drod/; s/%VERSION%/$APP_VERSION/; s/%MIN_OS%/$DEPLOY/" \
 	"$DARWIN_DIR/Info.plist.template" > "$APP/Contents/Info.plist"
 # Icon: the app's own .icns, falling back to TSS's if a new game's art isn't in
 # place yet (so a data-only test build still completes).
@@ -369,9 +369,13 @@ dylibbundler -of -b \
 # 6. Ad-hoc code sign (must be last; arm64 binaries must be signed to run)
 ###############################################################################
 log "Ad-hoc code signing..."
+# Sign inside-out (nested code first, bundle last), not with --deep: --deep leaves
+# an invalid seal over libsteam_api.dylib, which Valve ships hardened-runtime with
+# a designated requirement. Verify with --strict to catch a bad seal.
 codesign --force -s - "$APP/Contents/Frameworks/"*.dylib
-codesign --force --deep -s - "$APP"
-codesign --verify --deep "$APP" && log "Code signature OK"
+codesign --force -s - "$APP/Contents/MacOS/drod"
+codesign --force -s - "$APP"
+codesign --verify --deep --strict "$APP" && log "Code signature OK"
 
 # 6a. Sanity: no build-machine paths leaked into the bundle
 if otool -L "$APP/Contents/MacOS/drod" "$APP/Contents/Frameworks/"*.dylib \


### PR DESCRIPTION
The build targeted macOS 15, which needlessly excluded every Intel Mac and anyone not on the latest OS. macOS 11 is the first Apple Silicon release and the current Steam client minimum, so it's a sensible floor that widens hardware reach for the universal (x86_64 + arm64) build.

- Drop MACOSX_VERSION_MIN and the build scripts' DEPLOY default from 15.0 to 11.0; all third-party deps are rebuilt from source for the 11.0 target.
- Declare LSMinimumSystemVersion in Info.plist (substituted from DEPLOY) so the floor is enforced with a clear message, not just the Mach-O minos.
- Fix metakit's clean build, exposed by rebuilding deps from scratch: its Makefile invokes $(RANLIB) but never defines it, and make has no built-in default (unlike AR), so the archive step ran a bare "libmk4.a" and failed. Pass AR=ar RANLIB=ranlib to metakit's make.
- Sign the app inside-out (not --deep) so the ad-hoc seal is valid, fixing local Steam builds that Gatekeeper otherwise rejected as "damaged".