### PR TITLE
macOS: decouple the save-folder name from the resource .dat name

### DIFF
--- a/BackEndLib/Files.cpp
+++ b/BackEndLib/Files.cpp
@@ -84,6 +84,7 @@ WSTRING CFiles::wszDatPath;
 WSTRING CFiles::wszResPath;
 WSTRING CFiles::wCompanyName;
 WSTRING CFiles::wGameName;
+WSTRING CFiles::wGameConfName;
 WSTRING CFiles::wGameVer;
 WSTRING CFiles::wUniqueResFile;
 UINT CFiles::dwRefCount = 0;
@@ -173,7 +174,8 @@ CFiles::CFiles(
 	const WCHAR *wszSetGameVer,   //(in) game major version -- for finding resource files or paths
 	const bool bIsDemo,           //(in) whether we should be looking for files for a demo version or not [default=false]
 	const bool confirm_resource_file,
-	const bool bIsRunningTests)   //(in) set to true by test runner to ensure it uses its own dat files
+	const bool bIsRunningTests,   //(in) set to true by test runner to ensure it uses its own dat files
+	const WCHAR *wszSetGameConfName) //(in) save folder name; NULL uses wszSetGameName
 {
 	ASSERT(this->dwRefCount == 0);
 
@@ -181,7 +183,7 @@ CFiles::CFiles(
 	ASSERT(wszSetGameName != NULL);
 	ASSERT(wszSetGameVer != NULL);
 
-	InitClass(wszSetAppPath, wszSetGameName, wszSetGameVer, bIsDemo, confirm_resource_file, bIsRunningTests);
+	InitClass(wszSetAppPath, wszSetGameName, wszSetGameVer, bIsDemo, confirm_resource_file, bIsRunningTests, wszSetGameConfName);
 
 	++this->dwRefCount;
 }
@@ -411,7 +413,7 @@ const WSTRING CFiles::GetGameConfPathForName(const WCHAR *pwszGameName) {
 }
 
 const WSTRING CFiles::GetGameConfPath() {
-	return GetGameConfPathForName(CFiles::wGameName.c_str());
+	return GetGameConfPathForName(CFiles::wGameConfName.c_str());
 }
 
 #if defined(__APPLE__) && defined(STEAMBUILD) && !defined(STEAMBUILD_TSS_APP)
@@ -1070,7 +1072,8 @@ void CFiles::InitClass(
 	const WCHAR *wszSetGameVer,      //(in)
 	const bool bIsDemo,              //(in)
 	const bool confirm_resource_file,
-	const bool bIsRunningTests)
+	const bool bIsRunningTests,
+	const WCHAR *wszSetGameConfName) //(in) config subfolder name; NULL uses wszSetGameName
 {
 	ASSERT(wszSetAppPath);
 	ASSERT(wszSetGameName);
@@ -1088,6 +1091,8 @@ void CFiles::InitClass(
 	//Get game name and version.
 	ASSERT(CFiles::wGameName.empty());
 	CFiles::wGameName = wszSetGameName;
+	ASSERT(CFiles::wGameConfName.empty());
+	CFiles::wGameConfName = wszSetGameConfName ? wszSetGameConfName : wszSetGameName;
 	ASSERT(this->wGameVer.empty());
 	CFiles::wGameVer = wszSetGameVer;
 
@@ -1362,6 +1367,7 @@ void CFiles::DeinitClass()
 	CFiles::wszResPath.resize(0);
 
 	CFiles::wGameName.resize(0);
+	CFiles::wGameConfName.resize(0);
 	CFiles::wGameVer.resize(0);
 }
 

--- a/BackEndLib/Files.h
+++ b/BackEndLib/Files.h
@@ -89,7 +89,8 @@ public:
 	CFiles(const WCHAR *wszSetAppPath,
 				const WCHAR *wszSetGameName, const WCHAR *wszSetGameVer,
 				const bool bIsDemo = false, const bool confirm_resource_file = true,
-				const bool bIsRunningTests = false);
+				const bool bIsRunningTests = false,
+				const WCHAR *wszSetGameConfName = NULL);
 	CFiles(); //may call this one after the class has been inited
 	~CFiles();
 
@@ -178,6 +179,9 @@ public:
 #endif
 
 	static WSTRING wCompanyName, wGameName, wGameVer, wUniqueResFile;
+	//Save-folder name; defaults to wGameName but can differ, so a build can use its
+	//own folder without changing the .dat/.ini/log names wGameName also determines.
+	static WSTRING wGameConfName;
 	static vector<string> datFiles, playerDataSubDirs;
 
 	static bool bad_data_path_file;
@@ -206,7 +210,8 @@ private:
 #endif
 	void                 InitClass(const WCHAR *pszSetAppPath,
 			const WCHAR *wszSetGameName, const WCHAR *wszSetGameVer, const bool bIsDemo,
-			const bool confirm_resource_file, const bool bIsRunningTests);
+			const bool confirm_resource_file, const bool bIsRunningTests,
+			const WCHAR *wszSetGameConfName = NULL);
 	static bool          InitINI();
 	static void          SetupHomePath();
 	static void          SetupHomePathSubDirs();

--- a/DROD/Main.cpp
+++ b/DROD/Main.cpp
@@ -291,15 +291,17 @@ int main(int argc, char *argv[])
 #endif
 
 	const WCHAR* gameName = wszDROD;
+	const WCHAR* gameConfName = NULL; //save folder; NULL means same as gameName
 #ifdef STEAMBUILD_TSS_APP
 	const WCHAR wszDRODTSS[] = { We('d'),We('r'),We('o'),We('d'),We('-'),We('t'),We('s'),We('s'),We(0) };
 	gameName = wszDRODTSS;
 #elif defined(__APPLE__) && defined(STEAMBUILD)
-	//The macOS Steam GatEB build uses a dedicated folder so it doesn't collide
-	//with the non-Steam TSS standalone build (both otherwise use "drod-5_0").
+	//Keep gameName "drod" (so it still loads drod5_0.dat) but give the macOS Steam
+	//GatEB build its own save folder, so it doesn't collide with the non-Steam TSS
+	//standalone build (both otherwise use "drod-5_0").
 	const WCHAR wszDRODGatEBSteam[] = { We('d'),We('r'),We('o'),We('d'),We('-'),
 		We('g'),We('a'),We('t'),We('e'),We('b'),We('-'),We('s'),We('t'),We('e'),We('a'),We('m'),We(0) };
-	gameName = wszDRODGatEBSteam;
+	gameConfName = wszDRODGatEBSteam;
 #elif defined(KDD_STANDALONE)
 	const WCHAR wszDRODKDD[] = { We('d'),We('r'),We('o'),We('d'),We('-'),We('k'),We('d'),We('d'),We(0) };
 	gameName = wszDRODKDD;
@@ -313,7 +315,7 @@ int main(int argc, char *argv[])
 	const WCHAR wszDRODGatEB[] = { We('d'),We('r'),We('o'),We('d'),We('-'),We('g'),We('a'),We('t'),We('e'),We('b'),We(0) };
 	gameName = wszDRODGatEB;
 #endif
-	m_pFiles = new CFiles(wstrPath.c_str(), gameName, wszDROD_VER, bIsDemo);
+	m_pFiles = new CFiles(wstrPath.c_str(), gameName, wszDROD_VER, bIsDemo, true, false, gameConfName);
 	if (CFiles::bad_data_path_file) {
 		DisplayInitErrorMessage(MID_DataPathDotTextFileIsInvalid);
 	}


### PR DESCRIPTION
gameName drives both the save folder and CDbBase::BaseResourceFilename(), so giving the Steam GatEB build a dedicated folder made the DB look for "drod-gateb-steam5_0.dat" instead of the bundled "drod5_0.dat" and fail to start (MID_DatMissing). Add CFiles::wGameConfName (defaults to wGameName, used only by GetGameConfPath) so a build can choose its save folder without changing the .dat/.ini/log names.