### PR TITLE
RPG: Add command to show initial room state

### DIFF
--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8534,7 +8534,7 @@ void CGameScreen::ShowStatsForMonster(CMonster *pMonster)
 }
 
 //*****************************************************************************
-UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents) //room to display
+UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents, bool& initialState) //room to display
 //Temporarily display another room in place of the current room.
 //
 //Returns: roomID of a different room to display, or 0 for none
@@ -8582,6 +8582,9 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents) //room to disp
 				case SDL_MOUSEBUTTONDOWN:
 				{
 					bShow = HandlePreviewClick(event.button, originalRoomID, newShowRoomID);
+					if (!bShow) {
+						initialState = false;
+					}
 				}
 				break;
 
@@ -8604,6 +8607,15 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents) //room to disp
 							break;
 						default: nCommand = GetCommandForInputKey(BuildInputKey(event.key)); break;
 					}
+
+					//Don't allow panning while showing initial room state.
+					if (initialState && !(nCommand == -1 || nCommand == CMD_BATTLE_KEY)) {
+						initialState = false;
+						bShow = false;
+						newShowRoomID = this->pTempRoomWidget->pRoom->dwRoomID;
+						break;
+					}
+
 					switch (nCommand)
 					{
 						case CMD_BATTLE_KEY:
@@ -8624,6 +8636,19 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents) //room to disp
 						case CMD_E:
 							DisplayAdjacentTempRoom(E);
 							break;
+						case CMD_EXTRA_SHOW_INITIAL_ROOM:
+						{
+							//Trying to show initial state for non-visited rooms causes problems, so don't do it
+							//(Since it has been visited, it would look the same anyway)
+							UINT roomID = this->pTempRoomWidget->pRoom->dwRoomID;
+							ExploredRoom* expRoom = this->pTempRoomWidget->pCurrentGame->getExploredRoom(roomID);
+							if (expRoom && expRoom->HasDetail()) {
+								initialState = true;
+								newShowRoomID = this->pTempRoomWidget->pRoom->dwRoomID;
+								bShow = false;
+							}
+						}
+						break;
 						case -1: // modifier key
 							break;
 						default:
@@ -8789,7 +8814,7 @@ void CGameScreen::ShowRoomCoords(CDbRoom *pRoom)
 }
 
 //*****************************************************************************
-void CGameScreen::ShowRoomTemporarily(UINT roomID)
+void CGameScreen::ShowRoomTemporarily(UINT roomID, bool initialState)
 //Temporarily show the indicated room instead of the current room.
 {
 	if (!roomID)
@@ -8804,7 +8829,7 @@ Loop:
 	//list with the start of turn version. This is not really what we want, so we
 	//update the starting list to be the current list.
 	pTempGame->SetMonsterListAtRoomStart();
-	if (!pTempGame->PrepTempGameForRoomDisplay(roomID)) {
+	if (!pTempGame->PrepTempGameForRoomDisplay(roomID, initialState)) {
 		delete pTempGame;
 		return;
 	}
@@ -8813,7 +8838,7 @@ Loop:
 	this->bNoMoveByCurrentMouseClick = true;
 
 	CCueEvents CueEvents;
-	const UINT showNewRoomID = ShowRoom(pTempGame->pRoom, CueEvents);
+	const UINT showNewRoomID = ShowRoom(pTempGame->pRoom, CueEvents, initialState);
 	delete pTempGame;
 
 	this->bShowingTempRoom = false;

--- a/drodrpg/DROD/GameScreen.cpp
+++ b/drodrpg/DROD/GameScreen.cpp
@@ -8543,6 +8543,7 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents, bool& initialS
 
 	UINT newShowRoomID = 0;
 	const UINT originalRoomID = pRoom->dwRoomID;
+	bool bRefresh = true; //Set to false when showing/unshowing initial room state to avoid flicker
 
 	this->pTempRoomWidget->HidePlayer();
 	VERIFY(this->pTempRoomWidget->LoadFromRoom(pRoom));
@@ -8612,6 +8613,7 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents, bool& initialS
 					if (initialState && !(nCommand == -1 || nCommand == CMD_BATTLE_KEY)) {
 						initialState = false;
 						bShow = false;
+						bRefresh = false;
 						newShowRoomID = this->pTempRoomWidget->pRoom->dwRoomID;
 						break;
 					}
@@ -8646,6 +8648,7 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents, bool& initialS
 								initialState = true;
 								newShowRoomID = this->pTempRoomWidget->pRoom->dwRoomID;
 								bShow = false;
+								bRefresh = false;
 							}
 						}
 						break;
@@ -8676,18 +8679,22 @@ UINT CGameScreen::ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents, bool& initialS
 		RequestPaint();
 	}
 
-	this->pTempRoomWidget->Hide();
+	if (bRefresh) {
+		this->pTempRoomWidget->Hide();
+	}
 	this->pTempRoomWidget->pCurrentGame = NULL;
 
 	if (this->bShowingBigMap)
 		this->pBigMapWidget->Show();
 
 	//Reload graphics for current room.
-	this->pRoomWidget->Show();
-	this->pRoomWidget->LoadRoomImages();
-	this->pRoomWidget->UpdateFromCurrentGame();
-	UpdateSign();
-	Paint();
+	if (bRefresh) {
+		this->pRoomWidget->Show();
+		this->pRoomWidget->LoadRoomImages();
+		this->pRoomWidget->UpdateFromCurrentGame();
+		UpdateSign();
+		Paint();
+	}
 
 	//Show a new room?
 	return newShowRoomID;

--- a/drodrpg/DROD/GameScreen.h
+++ b/drodrpg/DROD/GameScreen.h
@@ -193,9 +193,9 @@ private:
 //	void           ShowLockIcon(const bool bShow=true);
 	void           UpdatePlayerFace();
 	void           ResolvePlayerFace(SPEAKER& pSpeaker, HoldCharacter** playerHoldCharacter);
-	UINT           ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents);
+	UINT           ShowRoom(CDbRoom *pRoom, CCueEvents& CueEvents, bool& initialState);
 	void           ShowRoomCoords(CDbRoom *pRoom);
-	void           ShowRoomTemporarily(UINT roomID);
+	void           ShowRoomTemporarily(UINT roomID, bool initialState = false);
 	void           ShowScoreDialog(const WSTRING pTitle, const PlayerStats& st);
 	void           ShowSpeechLog();
 	void           SwirlEffect();

--- a/drodrpg/DROD/SettingsScreen.cpp
+++ b/drodrpg/DROD/SettingsScreen.cpp
@@ -854,6 +854,7 @@ void CSettingsScreen::SetupKeymap1Tab(CTabbedMenuWidget* pTabbedMenu)
 		},
 		{
 			DCMD_Battle, DCMD_ShowScore, DCMD_ShowMap, DCMD_SkeletonKeyGuard,
+			DCMD_ShowInitialRoom,
 			NO_COMMAND
 		},
 		{

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -8723,7 +8723,7 @@ bool CCurrentGame::PrepTempGameForRoomDisplay(const UINT roomID, bool initialSta
 //*****************************************************************************
 void CCurrentGame::RestartRoomForPreview(bool bLoadExploration)
 //Restarts the current room.
-//Only call this on a temporary object, as part setting up tempory room view
+//Only call this on a temporary object, as part setting up temporary room view
 {
 	//Move the player back to the beginning of the room.
 	//We need to set up player stats before monsters are loaded, as the stats include

--- a/drodrpg/DRODLib/CurrentGame.cpp
+++ b/drodrpg/DRODLib/CurrentGame.cpp
@@ -8681,7 +8681,7 @@ UINT CCurrentGame::WriteScoreCheckpointSave(const ScoreCheckpointData& scoreData
 //***************************************************************************************
 //Only call this on a temporary object, prior to temporary room preview in the front-end.
 //Returns: whether prep operation succeeded
-bool CCurrentGame::PrepTempGameForRoomDisplay(const UINT roomID)
+bool CCurrentGame::PrepTempGameForRoomDisplay(const UINT roomID, bool initialState)
 {
 	this->bRoomDisplayOnly = true;
 
@@ -8702,7 +8702,7 @@ bool CCurrentGame::PrepTempGameForRoomDisplay(const UINT roomID)
 	const bool bPlayerHasted = this->pPlayer->bHasted;
 	const bool bPlayerInvisible = this->pPlayer->bInvisible;
 	CCueEvents Ignored;
-	RestartRoom(Ignored);
+	RestartRoomForPreview(!initialState);
 	this->pPlayer->bHasted = bPlayerHasted;
 	this->pPlayer->bInvisible = bPlayerInvisible;
 
@@ -8718,6 +8718,30 @@ bool CCurrentGame::PrepTempGameForRoomDisplay(const UINT roomID)
 	this->pRoom->SetSwordsSheathed();
 
 	return true;
+}
+
+//*****************************************************************************
+void CCurrentGame::RestartRoomForPreview(bool bLoadExploration)
+//Restarts the current room.
+//Only call this on a temporary object, as part setting up tempory room view
+{
+	//Move the player back to the beginning of the room.
+	//We need to set up player stats before monsters are loaded, as the stats include
+	//the monster HP multiplier value
+	SetPlayerToRoomStart();
+
+	//Return room to the state it had on entry.
+	ASSERT(this->pRoom);
+	this->pRoom->Reload();
+	CDbSavedGame::ReloadMonsterList();
+	if (bLoadExploration) {
+		RetrieveExploredRoomData(*this->pRoom);
+	}
+
+	//Do post-load processing
+	CCueEvents Ignored;
+	SetMembersAfterRoomLoad(Ignored);
+	ProcessCommand_EndOfTurnEventHandling(Ignored);
 }
 
 //***************************************************************************************

--- a/drodrpg/DRODLib/CurrentGame.h
+++ b/drodrpg/DRODLib/CurrentGame.h
@@ -355,6 +355,7 @@ public:
 	void     QuickSave();
 	void     RemoveClearedImageOverlays(const int clearLayers);
 	void     RestartRoom(CCueEvents &CueEvents);
+	void     RestartRoomForPreview(bool bLoadExploration);
 	void     SaveGame(const SAVETYPE eSaveType, const WSTRING& name);
 	void     SaveToContinue();
 	void     SaveToEndHold();
@@ -397,7 +398,7 @@ public:
 	UINT     WriteLocalHighScore(const ScoreCheckpointData& scoreData);
 	UINT     WriteScoreCheckpointSave(const ScoreCheckpointData& scoreData);
 
-	bool     PrepTempGameForRoomDisplay(const UINT roomID);
+	bool     PrepTempGameForRoomDisplay(const UINT roomID, bool initialState);
 
 	//World map.
 	void     SetWorldMapIcon(UINT worldMapID, UINT xPos, UINT yPos, UINT entranceID, ExitType exitType,

--- a/drodrpg/DRODLib/DbBase.cpp
+++ b/drodrpg/DRODLib/DbBase.cpp
@@ -866,6 +866,7 @@ const WCHAR* CDbBase::GetMessageText(
 		case MID_VarSaturation: strText = "_Saturation"; break;
 		case MID_Command_ToggleSkeletonGuard: strText = "Skeleton Key Guard"; break;
 		case MID_SkeletonGuardBlock: strText = "Skeleton key guard prevents spending skeleton key"; break;
+		case MID_Command_ShowInitialRoom: strText = "Show Initial Room"; break;
 		default: break;
 	}
 	if (!strText.empty() && (Language::GetLanguage() == Language::English))

--- a/drodrpg/DRODLib/GameConstants.cpp
+++ b/drodrpg/DRODLib/GameConstants.cpp
@@ -94,6 +94,7 @@ namespace InputCommands
 		keyDefinitions[DCMD_QuickLoad] = new KeyDefinition(CMD_EXTRA_QUICK_LOAD, "Key_QuickLoad", MID_QuickLoad, SDLK_F9);
 		keyDefinitions[DCMD_ShowMap] = new KeyDefinition(CMD_EXTRA_SHOW_MAP, "Key_ShowMap", MID_Command_ShowMap, SDLK_m);
 		keyDefinitions[DCMD_SkeletonKeyGuard] = new KeyDefinition(CMD_EXTRA_SKELETON_KEY_GUARD, "Key_ToggleSkeletonGuard", MID_Command_ToggleSkeletonGuard, BuildInputKey(0, true, false, false));
+		keyDefinitions[DCMD_ShowInitialRoom] = new KeyDefinition(CMD_EXTRA_SHOW_INITIAL_ROOM, "Key_ShowInitialRoom", MID_Command_ShowInitialRoom, BuildInputKey(SDLK_i, false, false, true));
 
 		keyDefinitions[DCMD_SkipSpeech] = new KeyDefinition(CMD_EXTRA_SKIP_SPEECH, "Key_SkipSpeech", MID_SkipSpeech, SDLK_SPACE);
 		keyDefinitions[DCMD_OpenChat] = new KeyDefinition(CMD_EXTRA_OPEN_CHAT, "Key_OpenChat", MID_Command_OpenChat, SDLK_RETURN);

--- a/drodrpg/DRODLib/GameConstants.h
+++ b/drodrpg/DRODLib/GameConstants.h
@@ -129,6 +129,7 @@ extern const WCHAR wszVersionReleaseNumber[];
 #define CMD_EXTRA_SCRIPT_CHAR_OPTIONS (COMMAND_COUNT+45)
 #define CMD_EXTRA_SHOW_MAP (COMMAND_COUNT+46)
 #define CMD_EXTRA_SKELETON_KEY_GUARD (COMMAND_COUNT+47)
+#define CMD_EXTRA_SHOW_INITIAL_ROOM (COMMAND_COUNT+48)
 
 //Sword orientation.
 static const UINT NW = 0;
@@ -207,6 +208,7 @@ namespace InputCommands
 		DCMD_QuickLoad,
 		DCMD_ShowMap,
 		DCMD_SkeletonKeyGuard,
+		DCMD_ShowInitialRoom,
 
 		//Dialogs and screens
 		DCMD_SkipSpeech,
@@ -284,7 +286,8 @@ static inline bool bIsGameScreenCommand(const int command)
 {
 	return bIsGameCommand(command) ||
 		(command >= CMD_ADVANCE_CUTSCENE && command <= CMD_EXTRA_RELOAD_STYLE) ||
-		command == CMD_EXTRA_SHOW_MAP || command == CMD_EXTRA_SKELETON_KEY_GUARD;
+		command == CMD_EXTRA_SHOW_MAP || command == CMD_EXTRA_SKELETON_KEY_GUARD ||
+		command == CMD_EXTRA_SHOW_INITIAL_ROOM;
 }
 
 static inline bool bIsEditorCommand(const int command)

--- a/drodrpg/Data/Help/1/keyboard.html
+++ b/drodrpg/Data/Help/1/keyboard.html
@@ -158,7 +158,8 @@ This can be helpful if the tooltip is blocking an area of interest in the room.<
 map of all the explored rooms in the level.  Clicking a room will temporarily
 display the current state of that room. While remotely viewing a room, you can use
 the battle key to view the stats of monstetrs in that room, and scroll to adjacent rooms
-by moving North, South, East or West.
+by moving North, South, East or West. You can also press <b>Ctrl-I</b> to view the initial
+state of a room.
 Press any other key or click off the map to return to play.</p>
 <p><a name="markingrooms"><b>Mark rooms on the minimap</b></a> by right clicking
 them.  You may shade rooms with any of three colors to help you remember

--- a/drodrpg/Texts/MIDs.h
+++ b/drodrpg/Texts/MIDs.h
@@ -1353,6 +1353,7 @@ enum MID_CONSTANT {
   MID_Command_Script_CharacterOptions = 2162,
   MID_Command_ShowMap = 2163,
   MID_Command_ToggleSkeletonGuard = 2186,
+  MID_Command_ShowInitialRoom = 2188,
 
   //Messages from Speech.uni:
   MID_CustomizeCharacter = 964,

--- a/drodrpg/Texts/SettingsScreen.uni
+++ b/drodrpg/Texts/SettingsScreen.uni
@@ -669,3 +669,7 @@ Open Map
 [MID_Command_ToggleSkeletonGuard]
 [eng]
 Skeleton Key Guard
+
+[MID_Command_ShowInitialRoom]
+[eng]
+Show Initial Room


### PR DESCRIPTION
Rewires some things in the temporary room display code to allowing viewing the initial state of a room while previewing. It does theoretically work from the active gameplay room, however what happened in practice was that the game would get stuck in the preview state until you made the program inactive. I'll consider a follow-up PR to get that all in order.

Thread: https://forum.caravelgames.com/viewtopic.php?TopicID=47158