### PR TITLE
ISSUE: Ending the hold via a cutscene with puzzle mode enabled causes the game to crash

### DIFF
--- a/DROD/GameScreen.cpp
+++ b/DROD/GameScreen.cpp
@@ -5089,6 +5089,9 @@ SCREENTYPE CGameScreen::ProcessCueEventsAfterRoomDraw(
 
 			//Show hold stats over a blank room widget.
 			this->pRoomWidget->UnloadCurrentGame();
+			// Make sure permanent effects, like puzzle mode's Grid, are also removed,
+			// otherwise they may access a deleted room and segfault
+			this->pRoomWidget->ClearEffects(false);
 			this->pRoomWidget->AddLastLayerEffect(new CTextEffect(
 					this->pRoomWidget, GetGameStats(true).c_str(), F_Stats, 10000, 0, false, true));
 			HandleEventsForHoldExit();

--- a/DROD/GridEffect.cpp
+++ b/DROD/GridEffect.cpp
@@ -96,6 +96,8 @@ void CGridEffect::Draw(SDL_Surface& destSurface)
 	this->pOwnerWidget->GetRect(OwnerRect);
 
 	const CDbRoom* pRoom = this->pRoomWidget->GetRoom();
+	ASSERT(pRoom);
+
 	const CDbRoom &room = *pRoom;
 	UINT yPixel = OwnerRect.y;
 	for (UINT wY=0; wY<room.wRoomRows; ++wY, yPixel += CBitmapManager::CY_TILE) {


### PR DESCRIPTION
DIAGNOSIS: This was caused by the room being unloaded but the effects not being force-cleared, which allowed the puzzle mode's GridEffect to remain, ask for the room which does not exist and segfault

SOLUTION: All effects are force cleared when ending the hold via non-stairs

Forum topic: https://forum.caravelgames.com/viewtopic.php?TopicID=47425